### PR TITLE
fix: freeimage plugin caused crash

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,6 +14,6 @@ Homepage: http://www.deepin.org
 Package: deepin-image-viewer
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, libqt5sql5-sqlite, qt5-image-formats-plugins
-Recommends: libqt5libqgtk2
+Recommends: libqt5libqgtk2, kimageformat-plugins
 Description: Image Viewer for Deepin Desktop Environment
  Deepin Image Viewer is Deepin Desktop Environment Image Viewer.

--- a/qimage-plugins/qimage-plugins.pro
+++ b/qimage-plugins/qimage-plugins.pro
@@ -1,4 +1,4 @@
 TEMPLATE = subdirs
 SUBDIRS = \
-        freeimage \
+#        freeimage \
         libraw


### PR DESCRIPTION
drop freeimage plugin and recommend plugins provides by kimageformats
as suggested in https://github.com/linuxdeepin/deepin-image-viewer/issues/2