### PR TITLE
fix: the image content navigation widget not visible

### DIFF
--- a/viewer/module/view/navigationwidget.h
+++ b/viewer/module/view/navigationwidget.h
@@ -48,7 +48,7 @@ private:
     qreal m_imageScale = 1.0;
     QImage m_img;
     QPixmap m_pix;
-    QRect m_r;          // Image visible rect
+    QRectF m_r;          // Image visible rect
     QRect m_mainRect;
     QRect m_originRect;
 

--- a/viewer/module/view/scen/imageview.cpp
+++ b/viewer/module/view/scen/imageview.cpp
@@ -31,6 +31,7 @@
 #include <qmath.h>
 #include <QScrollBar>
 #include <QGestureEvent>
+#include <QSvgRenderer>
 
 #include "graphicsitem.h"
 #include "utils/baseutils.h"
@@ -287,9 +288,9 @@ const QImage ImageView::image()
         //FIXME: access to m_pixmapItem will crash
         return m_pixmapItem->pixmap().toImage();
     } else if (m_svgItem) {    // svg
-        QImage image(viewport()->size(), QImage::Format_ARGB32_Premultiplied);
+        QImage image(m_svgItem->renderer()->defaultSize(), QImage::Format_ARGB32_Premultiplied);
         QPainter imagePainter(&image);
-        QGraphicsView::render(&imagePainter);
+        m_svgItem->renderer()->render(&imagePainter);
         imagePainter.end();
         return image;
     } else {
@@ -385,7 +386,10 @@ QRect ImageView::visibleImageRect() const
 
 bool ImageView::isWholeImageVisible() const
 {
-    return visibleImageRect().size() == sceneRect().size();
+    const QRect &r = visibleImageRect();
+    const QRectF &sr = sceneRect();
+
+    return r.width() >= sr.width() && r.height() >= sr.height();
 }
 
 bool ImageView::isFitImage() const


### PR DESCRIPTION
when the image content coordinates are 0,0
https://github.com/linuxdeepin/internal-discussion/issues/1680