### PR TITLE
feat: Initial packit setup

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,17 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+specfile_path: rpm/deepin-image-viewer.spec
+
+# add or remove files that should be synced
+synced_files:
+    - rpm/deepin-image-viewer.spec
+    - .packit.yaml
+
+upstream_package_name: deepin-image-viewer
+# downstream (Fedora) RPM package name
+downstream_package_name: deepin-image-viewer
+
+actions:
+  fix-spec-file: |
+    bash -c "sed -i -r \"s/Version:(\s*)\S*/Version:\1${PACKIT_PROJECT_VERSION}/\" rpm/deepin-image-viewer.spec"

--- a/rpm/deepin-image-viewer-appdata.xml
+++ b/rpm/deepin-image-viewer-appdata.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2017 mosquito -->
+<component type="desktop">
+  <id>deepin-image-viewer.desktop</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>Deepin Image Viewer</name>
+  <name xml:lang="zh_CN">深度看图</name>
+  <name xml:lang="zh_TW">深度看图</name>
+  <summary>Deepin Image Viewer is Deepin Desktop Environment image viewer</summary>
+  <summary xml:lang="zh_CN">深度看图是一个免费开源的跨平台看图软件</summary>
+  <summary xml:lang="zh_TW">深度看图是一个免费开源的跨平台看图软件</summary>
+  <description>
+    <p>
+      Deepin Image Viewer is a free and open source cross-platform image viewer.
+    </p>
+    <p xml:lang="zh_CN">
+      深度看图是一个免费开源的跨平台看图软件。
+    </p>
+  </description>
+  <url type="homepage">https://github.com/linuxdeepin/deepin-image-viewer/</url>
+  <url type="bugtracker">https://github.com/linuxdeepin/deepin-image-viewer/issues/</url>
+  <releases>
+    <release version="1.3.8" date="2019-01-25"></release>
+    <release version="1.3.7" date="2019-01-03"></release>
+    <release version="1.3.6" date="2018-12-11"></release>
+    <release version="1.3.5" date="2018-12-06"></release>
+    <release version="1.3.4" date="2018-12-06"></release>
+    <release version="1.3.3" date="2018-11-30"></release>
+    <release version="1.3.2" date="2018-11-23"></release>
+    <release version="1.3.1" date="2018-11-08"></release>
+    <release version="1.3.0" date="2018-10-24"></release>
+    <release version="1.2.23" date="2018-07-20"></release>
+    <release version="1.2.22" date="2018-05-24"></release>
+    <release version="1.2.21" date="2018-05-15"></release>
+    <release version="1.2.20" date="2018-05-14"></release>
+    <release version="1.2.19" date="2018-04-11"></release>
+    <release version="1.2.18" date="2018-03-22"></release>
+    <release version="1.2.17" date="2018-03-15"></release>
+    <release version="1.2.16" date="2017-10-26"></release>
+    <release version="1.2.15" date="2017-08-18"></release>
+  </releases>
+  <project_license>GPL-3.0</project_license>
+  <developer_name>Linux Deepin</developer_name>
+  <screenshots>
+    <screenshot type="default">https://www.deepin.org/wp-content/uploads/2016/12/deepin-imageviewer-1.png</screenshot>
+    <screenshot type="default">https://www.deepin.org/wp-content/uploads/2016/12/deepin-imageviewer-2.png</screenshot>
+    <screenshot type="default">https://www.deepin.org/wp-content/uploads/2016/12/deepin-imageviewer-3.png</screenshot>
+  </screenshots>
+</component>

--- a/rpm/deepin-image-viewer.spec
+++ b/rpm/deepin-image-viewer.spec
@@ -1,0 +1,72 @@
+Name:           deepin-image-viewer
+Version:        5.6.3.47
+Release:        1%{?dist}
+Summary:        Deepin Image Viewer
+License:        GPLv3
+URL:            https://github.com/linuxdeepin/deepin-image-viewer
+Source0:        %{url}/archive/%{version}/%{name}-%{version}.tar.gz
+Source1:        %{name}-appdata.xml
+
+BuildRequires:  gcc-c++
+BuildRequires:  freeimage-devel
+BuildRequires:  qt5-linguist
+BuildRequires:  pkgconfig(Qt5Core)
+BuildRequires:  pkgconfig(Qt5Concurrent)
+BuildRequires:  pkgconfig(Qt5DBus)
+BuildRequires:  pkgconfig(Qt5Gui)
+BuildRequires:  pkgconfig(Qt5OpenGL)
+BuildRequires:  pkgconfig(Qt5PrintSupport)
+BuildRequires:  pkgconfig(Qt5Sql)
+BuildRequires:  pkgconfig(Qt5Svg)
+BuildRequires:  pkgconfig(Qt5X11Extras)
+BuildRequires:  pkgconfig(Qt5Multimedia)
+BuildRequires:  pkgconfig(dtkwidget) >= 2.0.6
+BuildRequires:  pkgconfig(gio-unix-2.0)
+BuildRequires:  pkgconfig(libraw)
+BuildRequires:  pkgconfig(libexif)
+BuildRequires:  pkgconfig(libstartup-notification-1.0)
+BuildRequires:  pkgconfig(xcb-util)
+BuildRequires:  pkgconfig(xext)
+BuildRequires:  pkgconfig(gio-qt)
+BuildRequires:  udisks2-qt5-devel
+BuildRequires:  qt5-qtbase-private-devel
+%{?_qt5:Requires: %{_qt5}%{?_isa} = %{_qt5_version}}
+BuildRequires:  desktop-file-utils
+BuildRequires:  libappstream-glib
+Requires:       hicolor-icon-theme
+
+%description
+%{summary}.
+
+%prep
+%autosetup -p1
+# Fedora freeimage 3.19.0-0.1.svn1859 does not support FAXG3
+sed -i '/FIF_FAXG3/d' viewer/utils/unionimage.cpp
+
+%build
+# help find (and prefer) qt5 utilities, e.g. qmake, lrelease
+export PATH=%{_qt5_bindir}:$PATH
+%qmake_qt5 PREFIX=%{_prefix}
+%make_build
+
+%install
+%make_install INSTALL_ROOT=%{buildroot}
+install -Dm644 %SOURCE1 %{buildroot}%{_metainfodir}/%{name}.appdata.xml
+
+%check
+desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop ||:
+appstream-util validate-relax --nonet %{buildroot}%{_metainfodir}/*.appdata.xml
+
+%files
+%doc README.md
+%license LICENSE
+%{_bindir}/%{name}
+%{_qt5_plugindir}/imageformats/*.so
+%{_datadir}/dbus-1/services/*.service
+%{_datadir}/%{name}/
+%{_datadir}/dman/%{name}/
+%{_metainfodir}/%{name}.appdata.xml
+%{_datadir}/applications/%{name}.desktop
+%{_datadir}/icons/hicolor/scalable/apps/%{name}.svg
+
+%changelog


### PR DESCRIPTION
This commit contains the specfile for building the official package for Fedora
with a Packit setup.

Ultimately, a unified specfile is targeted for Fedora and any other rpm-based
distributions, e.g. openEuler.

And Packit(https://packit.dev/) is a tool for maintaining specfile within
upstream source. It requires a simple config file(.packit.yaml).

Log:
Signed-off-by: Robin Lee <cheeselee@fedoraproject.org>