### PR TITLE
chore: including headers from libimageviewer

### DIFF
--- a/src/src/mainwindow/mainwindow.cpp
+++ b/src/src/mainwindow/mainwindow.cpp
@@ -38,8 +38,8 @@
 #include <DFileDialog>
 
 #include "module/view/homepagewidget.h"
-#include "../libimageviewer/imageviewer.h"
-#include "../libimageviewer/imageengine.h"
+#include <libimageviewer/imageviewer.h>
+#include <libimageviewer/imageengine.h>
 #include "application.h"
 
 // 最小宽高

--- a/src/src/module/view/homepagewidget.cpp
+++ b/src/src/module/view/homepagewidget.cpp
@@ -1,8 +1,8 @@
-#include "../libimageviewer/image-viewer_global.h"
+#include <libimageviewer/image-viewer_global.h>
 #include "homepagewidget.h"
 
 #include "accessibility/ac-desktop-define.h"
-#include "../libimageviewer/imageviewer.h"
+#include <libimageviewer/imageviewer.h>
 
 #include <QMimeDatabase>
 #include <QFileInfo>


### PR DESCRIPTION
避免使用相对路径引用 libimageviewer 的头文件

Resolve: https://github.com/linuxdeepin/developer-center/issues/2237