### PR TITLE
fix: 删除构建的多余参数以适配新版cmake

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -10,5 +10,5 @@ override_dh_auto_configure:
 	dh_auto_configure -- \
 	  -DCMAKE_BUILD_TYPE=Release \
 	  -DCMAKE_INSTALL_PREFIX=/usr \
-      -DAPP_VERSION=$(DEB_VERSION_UPSTREAM) -DVERSION=$(DEB_VERSION_UPSTREAM) LIB_INSTALL_DIR=/usr/lib/$(DEB_HOST_MULTIARCH) DH_AUTO_ARGS = --parallel --buildsystem=cmake
+      -DAPP_VERSION=$(DEB_VERSION_UPSTREAM) -DVERSION=$(DEB_VERSION_UPSTREAM) LIB_INSTALL_DIR=/usr/lib/$(DEB_HOST_MULTIARCH)
 


### PR DESCRIPTION
删除构建的多余参数以适配新版cmake

Log: 删除构建的多余参数以适配新版cmake