### PR TITLE
fix: 修复连续使用DBus启动看图无法正常启动的问题

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,7 +56,7 @@ set(PROJECT_INCLUDE
     ${PROJECT_SOURCE_DIR}/src/module
     )
 
-set(QtModule Core Gui Widgets LinguistTools )
+set(QtModule Core Gui Widgets LinguistTools DBus)
 
 #先查找到这些qt相关的模块以供链接使用
 find_package(Qt5 REQUIRED ${QtModule})

--- a/src/src/main.cpp
+++ b/src/src/main.cpp
@@ -9,6 +9,10 @@
 //#include <DApplication>
 //#undef protected
 
+#include "mainwindow/mainwindow.h"
+#include "application.h"
+#include "eventlogutils.h"
+
 #include <DWidgetUtil>
 #include <DMainWindow>
 #include <DLog>
@@ -18,17 +22,12 @@
 #include <QTranslator>
 #include <QDebug>
 #include <QDesktopWidget>
+#include <QtDBus/QDBusConnection>
 
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
-
-#include "mainwindow/mainwindow.h"
-#include "application.h"
-#include "eventlogutils.h"
-
-//using namespace Dtk::Core;
 
 // 最小宽高
 #define MAINWIDGET_MINIMUN_HEIGHT 300
@@ -212,5 +211,10 @@ int main(int argc, char *argv[])
     }
 //    Dtk::Core::DVtableHook::overrideVfptrFun(qApp, &DApplication::handleQuitAction, w, &MainWindow::quitApp);
     QObject::connect(dApp, &Application::sigQuit, w, &MainWindow::quitApp, Qt::DirectConnection);
+
+    // 临时修改，注册DBus服务以正常启动进程，后续添加相关的DBus接口
+    QDBusConnection dbus = QDBusConnection::sessionBus();
+    dbus.registerService("com.deepin.ImageViewer");
+
     return a.exec();
 }


### PR DESCRIPTION
Description: 看图DBus服务未注册，导致DBus send未正常获取应答，添加注册看图服务，后续添加看图DBus接口。

Log: 修复连续使用DBus启动看图无法正常启动的问题
Influence: DBus调用