### PR TITLE
fix: 看图切换图片后，xwininfo读取路径有时没有变化

### DIFF
--- a/src/src/mainwindow/mainwindow.cpp
+++ b/src/src/mainwindow/mainwindow.cpp
@@ -239,8 +239,8 @@ void MainWindow::initSize()
 void MainWindow::setWindowTitleInfo()
 {
     if (m_imageViewer) {
-        qDebug() << __FUNCTION__ << "--" << m_imageViewer->getCurrentPath();
-        if (m_imageViewer->getCurrentPath() != "") {
+        if (m_imageViewer->getCurrentPath() != "" && m_mainwidow->windowTitle() != m_imageViewer->getCurrentPath()) {
+            qDebug() << __FUNCTION__ << "--" << m_imageViewer->getCurrentPath();
             m_mainwidow->setWindowTitle(m_imageViewer->getCurrentPath());
         }
     }
@@ -311,7 +311,7 @@ void MainWindow::initUI()
 
     m_saveSettingTimer->setSingleShot(true);
 
-    connect(ImageEngine::instance(), &ImageEngine::sigOneImgReady, this, &MainWindow::setWindowTitleInfo);
+    connect(ImageEngine::instance(), &ImageEngine::sigUpdateCollectBtn, this, &MainWindow::setWindowTitleInfo);
 }
 
 void MainWindow::slotOpenImg()


### PR DESCRIPTION
Description: 切换gif图片，sigOneImgReady没有发送到外部，导致外部没有设置windowtitle。更换信号为 sigUpdateCollectBtn

Log: 看图切换图片后，xwininfo读取路径有时没有变化

Bug: https://pms.uniontech.com/bug-view-177025.html