### PR TITLE
fix: 修复打开图片后焦点丢失，快捷键失效问题

### DIFF
--- a/src/src/mainwindow/mainwindow.cpp
+++ b/src/src/mainwindow/mainwindow.cpp
@@ -341,6 +341,12 @@ void MainWindow::slotOpenImg()
         }
     }
 
+    // 设置图片后重新更新焦点
+    if (m_mainwidow) {
+        QApplication::setActiveWindow(m_mainwidow);
+    } else {
+        QApplication::setActiveWindow(this);
+    }
 }
 
 bool MainWindow::slotDrogImg(const QStringList &paths)


### PR DESCRIPTION
弹窗设置图片后，窗口切换，焦点可能丢失，导致不响应快捷键。
修改为弹窗设置后强制更新窗口焦点。

Log: 修复打开图片后焦点丢失，快捷键失效问题
Bug: https://pms.uniontech.com/bug-view-185519.html
Influence: 设置图片后的焦点切换