### PR TITLE
chore: 去掉DBus服务玲珑命令相关配置

### DIFF
--- a/src/com.deepin.imageViewer.service
+++ b/src/com.deepin.imageViewer.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.imageViewer
-Exec=/usr/bin/ll-cli run org.deepin.image.viewer --exec deepin-image-viewer
+Exec=/usr/bin/deepin-image-viewer deepin-image-viewer


### PR DESCRIPTION
  为保证在其他上游正常构建，恢复为deepin-image-viewer来启动看图，在下一笔提交中使用patch补丁设置玲珑环境下用玲珑命令启动看图

Log: 去掉DBus服务玲珑命令相关配置