### PR TITLE
fix: 修复看图应用图标在帮助手册显示为撕裂图的问题

### DIFF
--- a/src/assets/deepin-image-viewer/image-viewer/en_US/d_image-viewer.md
+++ b/src/assets/deepin-image-viewer/image-viewer/en_US/d_image-viewer.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
-
-SPDX-License-Identifier: GPL-3.0-or-later
--->
-
 # Image Viewer|deepin-image-viewer|
 
 ## Overview

--- a/src/assets/deepin-image-viewer/image-viewer/en_US/image-viewer.md
+++ b/src/assets/deepin-image-viewer/image-viewer/en_US/image-viewer.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
-
-SPDX-License-Identifier: GPL-3.0-or-later
--->
-
 # Image Viewer|deepin-image-viewer|
 
 ## Overview

--- a/src/assets/deepin-image-viewer/image-viewer/zh_CN/d_image-viewer.md
+++ b/src/assets/deepin-image-viewer/image-viewer/zh_CN/d_image-viewer.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
-
-SPDX-License-Identifier: GPL-3.0-or-later
--->
-
 # 看图|deepin-image-viewer|
 
 ## 概述

--- a/src/assets/deepin-image-viewer/image-viewer/zh_CN/image-viewer.md
+++ b/src/assets/deepin-image-viewer/image-viewer/zh_CN/image-viewer.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
-
-SPDX-License-Identifier: GPL-3.0-or-later
--->
-
 # 看图|deepin-image-viewer|
 
 ## 概述

--- a/src/assets/deepin-image-viewer/image-viewer/zh_HK/d_image-viewer.md
+++ b/src/assets/deepin-image-viewer/image-viewer/zh_HK/d_image-viewer.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
-
-SPDX-License-Identifier: GPL-3.0-or-later
--->
-
 # 看圖|deepin-image-viewer|
 
 ## 概述

--- a/src/assets/deepin-image-viewer/image-viewer/zh_HK/image-viewer.md
+++ b/src/assets/deepin-image-viewer/image-viewer/zh_HK/image-viewer.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
-
-SPDX-License-Identifier: GPL-3.0-or-later
--->
-
 # 看圖|deepin-image-viewer|
 
 ## 概述

--- a/src/assets/deepin-image-viewer/image-viewer/zh_TW/d_image-viewer.md
+++ b/src/assets/deepin-image-viewer/image-viewer/zh_TW/d_image-viewer.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
-
-SPDX-License-Identifier: GPL-3.0-or-later
--->
-
 # 看圖|deepin-image-viewer|
 
 ## 概述

--- a/src/assets/deepin-image-viewer/image-viewer/zh_TW/image-viewer.md
+++ b/src/assets/deepin-image-viewer/image-viewer/zh_TW/image-viewer.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
-
-SPDX-License-Identifier: GPL-3.0-or-later
--->
-
 # 看圖|deepin-image-viewer|
 
 ## 概述


### PR DESCRIPTION
   删除md文件中多余的开源合规注释，以便帮助手册能正确解析md文件找到应用图标名称和位置

Log: 修复看图应用图标在帮助手册显示为撕裂图的问题

Bug: https://pms.uniontech.com/bug-view-183623.html