### PR TITLE
fix: AboutDialog's titlebar tearing shadow

### DIFF
--- a/src/qml/ViewTopTitle.qml
+++ b/src/qml/ViewTopTitle.qml
@@ -100,10 +100,8 @@ Rectangle {
             }
             AboutAction {
                 aboutDialog: AboutDialog {
-                    maximumWidth: 360
-                    maximumHeight: 362
-                    minimumWidth: 360
-                    minimumHeight: 362
+                    width: 360
+                    height: 362
                     productName: qsTr("Image Viewer")
                     productIcon: "deepin-image-viewer"
                     version: qsTr("Version") + ": %1".arg(Qt.application.version)


### PR DESCRIPTION
  It is a bug for `dtkdeclarative`, but we can avoid it.

Issue: https://github.com/linuxdeepin/developer-center/issues/4222