### PR TITLE
chore: Update version to 6.0.2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-image-viewer (6.0.2) unstable; urgency=medium
+
+  * fix: AboutDialog's titlebar tearing shadow (#140)(Issue: 4222)
+
+ -- Deepin Packages Builder <packages@deepin.org>  Thu, 11 May 2023 13:29:44 +0800
+
 deepin-image-viewer (6.0.1) unstable; urgency=medium
 
   * Update version to 6.0.1


### PR DESCRIPTION
Update version to 6.0.2
相关PR：
* https://github.com/linuxdeepin/deepin-image-viewer/pull/140

Log: Update version to 6.0.2