### PR TITLE
chore: 添加安装依赖libxraw

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,14 +12,16 @@ Homepage: http://www.deepin.org
 
 Package: deepin-image-viewer
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libqt5sql5-sqlite, qt5-image-formats-plugins, libimageeditor (>= 1.0.22)
+Depends: ${shlibs:Depends}, ${misc:Depends}, libqt5sql5-sqlite, qt5-image-formats-plugins, libimageeditor (>= 1.0.22), libxraw (>= 5.9.11)
 Recommends: libqt5libqgtk2, kimageformat-plugins ,deepin-ocr,uos-reporter, deepin-event-log 
+Conflicts: deepin-image-viewer (<= 5.9.11-1)
 Description: Image Viewer is an image viewing tool with fashion interface and smooth performance.
  Deepin Image Viewer is an image viewing tool with fashion interface and smooth performance.
 
 Package: libxraw
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
+Replaces: deepin-image-viewer (<= 5.9.11-1)
 Multi-Arch: same
 Description: Image Viewer is an image viewing tool with fashion interface and smooth performance.
  Deepin Image Viewer is an image viewing tool with fashion interface and smooth performance.


### PR DESCRIPTION
看图拆分 libxraw 后，补充安装依赖 libxraw，
以规避自旧版本升级看图时，无法正常安装及处理RAW格式图片,
看图 5.9.11 后版本不兼容，使用 Conficts 强制重新安装,
libxraw 使用 Replaces 安装 5.9.11 之前的包内容(libxraw.so库)

Log: 添加安装依赖libxraw
Bug: https://pms.uniontech.com/bug-view-199143.html
Influence: 安装依赖libxraw