### PR TITLE
chore: Update version to 5.9.12

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-image-viewer (5.9.12) unstable; urgency=medium
+
+  * fix: 拆分 libxraw 插件和应用(Bug: 199143)(Influence: libxraw 插件)
+  * chore: 添加安装依赖libxraw(Bug: 199143)(Influence: 安装依赖libxraw)
+
+ -- Deepin Packages Builder <packages@deepin.org>  Wed, 24 May 2023 13:15:23 +0800
+
 deepin-image-viewer (5.9.11) unstable; urgency=medium
 
   * Update version to distinguish pro/community.


### PR DESCRIPTION
Update version to 5.9.12
主要拆分看图 libxraw 插件为两个包
相关PR:
* https://github.com/linuxdeepin/deepin-image-viewer/pull/142
* https://github.com/linuxdeepin/deepin-image-viewer/pull/145

Log: Update version to 5.9.12