### PR TITLE
chore: Update version to 5.9.13

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-image-viewer (5.9.13) unstable; urgency=medium
+
+  * fix: Adapt compact mode.(Bug: 199309)(Influence: TitleBar CompactMode)
+  * fix: Adapt comapct mode with click image.(Bug: 199309)(Influence: ComapctMode)
+
+ -- Deepin Packages Builder <packages@deepin.org>  Wed, 31 May 2023 13:32:29 +0800
+
 deepin-image-viewer (5.9.12) unstable; urgency=medium
 
   * fix: 拆分 libxraw 插件和应用(Bug: 199143)(Influence: libxraw 插件)


### PR DESCRIPTION
Update version to 5.9.13
适配紧凑模式
相关PR：
* https://github.com/linuxdeepin/deepin-image-viewer/pull/147
* https://github.com/linuxdeepin/deepin-image-viewer/pull/147

Log: Update version to 5.9.13