### PR TITLE
fix: 修复高分屏图标显示过大的问题

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,6 +38,7 @@ int main(int argc, char *argv[])
     app->loadTranslator();
     app->setApplicationLicense("GPLV3");
     app->setApplicationVersion(VERSION);
+    app->setAttribute(Qt::AA_UseHighDpiPixmaps);
     app->setOrganizationName("deepin");
     app->setApplicationName("deepin-image-viewer");
     app->setApplicationDisplayName(QObject::tr("Image Viewer"));


### PR DESCRIPTION
   看图应用使用Qt::AA_UseHighDpiPixmaps属性

Log: 修复高分屏图标显示过大的问题
Issue: linuxdeepin/developer-center#4884