### PR TITLE
fix: .ts翻译文件中name“InfomationDialog”与qml文件InformationDialog.qml文件名不对应导致的图片信息窗口未能按相应语言显示的问题

### DIFF
--- a/src/translations/deepin-image-viewer.ts
+++ b/src/translations/deepin-image-viewer.ts
@@ -108,7 +108,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation>Basic info</translation>

--- a/src/translations/deepin-image-viewer_am_ET.ts
+++ b/src/translations/deepin-image-viewer_am_ET.ts
@@ -108,7 +108,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation type="unfinished"></translation>

--- a/src/translations/deepin-image-viewer_ar.ts
+++ b/src/translations/deepin-image-viewer_ar.ts
@@ -108,7 +108,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation type="unfinished"></translation>

--- a/src/translations/deepin-image-viewer_ast.ts
+++ b/src/translations/deepin-image-viewer_ast.ts
@@ -108,7 +108,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation type="unfinished"></translation>

--- a/src/translations/deepin-image-viewer_az.ts
+++ b/src/translations/deepin-image-viewer_az.ts
@@ -106,7 +106,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation>Əsas məlumatlar</translation>

--- a/src/translations/deepin-image-viewer_bg.ts
+++ b/src/translations/deepin-image-viewer_bg.ts
@@ -108,7 +108,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation type="unfinished"></translation>

--- a/src/translations/deepin-image-viewer_bo.ts
+++ b/src/translations/deepin-image-viewer_bo.ts
@@ -106,7 +106,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation>གཞི་རྩའི་ཆ་འཕྲིན། </translation>

--- a/src/translations/deepin-image-viewer_ca.ts
+++ b/src/translations/deepin-image-viewer_ca.ts
@@ -106,7 +106,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation>Informació bàsica</translation>

--- a/src/translations/deepin-image-viewer_cs.ts
+++ b/src/translations/deepin-image-viewer_cs.ts
@@ -106,7 +106,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation>Základní údaje</translation>

--- a/src/translations/deepin-image-viewer_da.ts
+++ b/src/translations/deepin-image-viewer_da.ts
@@ -108,7 +108,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation type="unfinished"></translation>

--- a/src/translations/deepin-image-viewer_de.ts
+++ b/src/translations/deepin-image-viewer_de.ts
@@ -106,7 +106,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation>Basisinformationen</translation>

--- a/src/translations/deepin-image-viewer_el.ts
+++ b/src/translations/deepin-image-viewer_el.ts
@@ -108,7 +108,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation type="unfinished"></translation>

--- a/src/translations/deepin-image-viewer_es.ts
+++ b/src/translations/deepin-image-viewer_es.ts
@@ -106,7 +106,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation>Información básica</translation>

--- a/src/translations/deepin-image-viewer_et.ts
+++ b/src/translations/deepin-image-viewer_et.ts
@@ -108,7 +108,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation type="unfinished"></translation>

--- a/src/translations/deepin-image-viewer_fa.ts
+++ b/src/translations/deepin-image-viewer_fa.ts
@@ -108,7 +108,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation type="unfinished"></translation>

--- a/src/translations/deepin-image-viewer_fi.ts
+++ b/src/translations/deepin-image-viewer_fi.ts
@@ -106,7 +106,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation>Perustiedot</translation>

--- a/src/translations/deepin-image-viewer_fr.ts
+++ b/src/translations/deepin-image-viewer_fr.ts
@@ -106,7 +106,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation>Info de base</translation>

--- a/src/translations/deepin-image-viewer_gl_ES.ts
+++ b/src/translations/deepin-image-viewer_gl_ES.ts
@@ -108,7 +108,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation type="unfinished"></translation>

--- a/src/translations/deepin-image-viewer_he.ts
+++ b/src/translations/deepin-image-viewer_he.ts
@@ -108,7 +108,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation type="unfinished"></translation>

--- a/src/translations/deepin-image-viewer_hr.ts
+++ b/src/translations/deepin-image-viewer_hr.ts
@@ -106,7 +106,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation>Osnovne informacije</translation>

--- a/src/translations/deepin-image-viewer_hu.ts
+++ b/src/translations/deepin-image-viewer_hu.ts
@@ -106,7 +106,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation>Alapvető információk</translation>

--- a/src/translations/deepin-image-viewer_id.ts
+++ b/src/translations/deepin-image-viewer_id.ts
@@ -106,7 +106,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation>Info dasar</translation>

--- a/src/translations/deepin-image-viewer_it.ts
+++ b/src/translations/deepin-image-viewer_it.ts
@@ -106,7 +106,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation>Info base</translation>

--- a/src/translations/deepin-image-viewer_ko.ts
+++ b/src/translations/deepin-image-viewer_ko.ts
@@ -108,7 +108,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation type="unfinished"></translation>

--- a/src/translations/deepin-image-viewer_lt.ts
+++ b/src/translations/deepin-image-viewer_lt.ts
@@ -108,7 +108,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation type="unfinished"></translation>

--- a/src/translations/deepin-image-viewer_ms.ts
+++ b/src/translations/deepin-image-viewer_ms.ts
@@ -106,7 +106,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation>Maklumat asas</translation>

--- a/src/translations/deepin-image-viewer_ne.ts
+++ b/src/translations/deepin-image-viewer_ne.ts
@@ -108,7 +108,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation type="unfinished"></translation>

--- a/src/translations/deepin-image-viewer_nl.ts
+++ b/src/translations/deepin-image-viewer_nl.ts
@@ -106,7 +106,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation>Bestandsinformatie</translation>

--- a/src/translations/deepin-image-viewer_pl.ts
+++ b/src/translations/deepin-image-viewer_pl.ts
@@ -106,7 +106,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation>Informacje podstawowe</translation>

--- a/src/translations/deepin-image-viewer_pt.ts
+++ b/src/translations/deepin-image-viewer_pt.ts
@@ -106,7 +106,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation>Informação básica</translation>

--- a/src/translations/deepin-image-viewer_pt_BR.ts
+++ b/src/translations/deepin-image-viewer_pt_BR.ts
@@ -106,7 +106,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation>Informação básica</translation>

--- a/src/translations/deepin-image-viewer_ru.ts
+++ b/src/translations/deepin-image-viewer_ru.ts
@@ -106,7 +106,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation>Основная информация</translation>

--- a/src/translations/deepin-image-viewer_sk.ts
+++ b/src/translations/deepin-image-viewer_sk.ts
@@ -108,7 +108,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation type="unfinished"></translation>

--- a/src/translations/deepin-image-viewer_sl.ts
+++ b/src/translations/deepin-image-viewer_sl.ts
@@ -106,7 +106,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation>Osnovni podatki</translation>

--- a/src/translations/deepin-image-viewer_sq.ts
+++ b/src/translations/deepin-image-viewer_sq.ts
@@ -106,7 +106,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation>Të dhëna elementare</translation>

--- a/src/translations/deepin-image-viewer_sr.ts
+++ b/src/translations/deepin-image-viewer_sr.ts
@@ -106,7 +106,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation>Основни подаци</translation>

--- a/src/translations/deepin-image-viewer_sv.ts
+++ b/src/translations/deepin-image-viewer_sv.ts
@@ -108,7 +108,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation type="unfinished"></translation>

--- a/src/translations/deepin-image-viewer_tr.ts
+++ b/src/translations/deepin-image-viewer_tr.ts
@@ -106,7 +106,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation>Temel bilgi</translation>

--- a/src/translations/deepin-image-viewer_ug.ts
+++ b/src/translations/deepin-image-viewer_ug.ts
@@ -106,7 +106,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation>ئاساسى ئۇچۇر</translation>

--- a/src/translations/deepin-image-viewer_uk.ts
+++ b/src/translations/deepin-image-viewer_uk.ts
@@ -106,7 +106,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation>Основна інформація</translation>

--- a/src/translations/deepin-image-viewer_zh_CN.ts
+++ b/src/translations/deepin-image-viewer_zh_CN.ts
@@ -106,7 +106,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation>基本信息</translation>

--- a/src/translations/deepin-image-viewer_zh_HK.ts
+++ b/src/translations/deepin-image-viewer_zh_HK.ts
@@ -106,7 +106,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation>基本訊息</translation>

--- a/src/translations/deepin-image-viewer_zh_TW.ts
+++ b/src/translations/deepin-image-viewer_zh_TW.ts
@@ -106,7 +106,7 @@
     </message>
 </context>
 <context>
-    <name>InfomationDialog</name>
+    <name>InformationDialog</name>
     <message>
         <source>Basic info</source>
         <translation>基本訊息</translation>


### PR DESCRIPTION
fix: .ts翻译文件中name“InfomationDialog”与qml文件InformationDialog.qml文件名不对应导致的图片信息窗口未能按相应语言显示的问题 
修改了所有.ts翻译文件的name “InfomationDialog”, 改为“InformationDialog”