### PR TITLE
Revert "chore: 添加安装依赖libxraw"

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,8 +12,8 @@ Homepage: http://www.deepin.org
 
 Package: deepin-image-viewer
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libqt5sql5-sqlite, qt5-image-formats-plugins, libimageeditor (>= 1.0.22), libxraw (>= 5.9.11)
+Depends: ${shlibs:Depends}, ${misc:Depends}, libqt5sql5-sqlite, qt5-image-formats-plugins, libimageeditor (>= 1.0.22)
 Recommends: libqt5libqgtk2, kimageformat-plugins ,deepin-ocr,uos-reporter, deepin-event-log 
-Conflicts: deepin-image-viewer (<= 5.9.11-1)
 Description: Image Viewer is an image viewing tool with fashion interface and smooth performance.
  Deepin Image Viewer is an image viewing tool with fashion interface and smooth performance.
+ 

--- a/debian/control
+++ b/debian/control
@@ -14,6 +14,9 @@ Package: deepin-image-viewer
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, libqt5sql5-sqlite, qt5-image-formats-plugins, libimageeditor (>= 1.0.22)
 Recommends: libqt5libqgtk2, kimageformat-plugins ,deepin-ocr,uos-reporter, deepin-event-log 
+Conflicts: libxraw (<< 5.9.14)
+Replaces: libxraw (<< 5.9.14)
+Provides: libxraw (= 5.9.13)
 Description: Image Viewer is an image viewing tool with fashion interface and smooth performance.
  Deepin Image Viewer is an image viewing tool with fashion interface and smooth performance.
  


### PR DESCRIPTION
回退应分级管控引入的安装依赖关系
image-viewer 中途拆分 libxraw 软件包，为兼容升级处理，
对低于 5.9.14 版本的软件包进行替换处理。

Log: 兼容旧版本拆分的 libxraw 软件包.
Influence: Debian/Control