### PR TITLE
fix: build failed with libraw after version 0.21.0

### DIFF
--- a/qimage-plugins/libraw/rawiohandler.cpp
+++ b/qimage-plugins/libraw/rawiohandler.cpp
@@ -63,7 +63,14 @@ bool RawIOHandlerPrivate::load(QIODevice *device)
 
     stream = new Datastream(device);
     raw = new LibRaw;
+
+    // libraw 在 0.21.0 版本调整了 use_rawspeed 参数配置结构
+#if LIBRAW_VERSION < LIBRAW_MAKE_VERSION(0, 21, 0)
     raw->imgdata.params.use_rawspeed = 1;
+#else
+    raw->imgdata.rawparams.use_rawspeed = 1;
+#endif
+
     if (raw->open_datastream(stream) != LIBRAW_SUCCESS) {
         delete raw;
         raw = nullptr;


### PR DESCRIPTION
libraw 库在0.21.0版本变更了`libraw_data_t`结构,
移动`use_rawspeed`至`libraw_raw_unpack_params_t`,
添加版本分支以兼容 0.21.0 或更低版本.

Log: 修复 0.21.0 及更高版本的 libraw 编译问题
Influence: RAW