### PR TITLE
fix: The right-click menu disappears after slideshow.

### DIFF
--- a/src/qml/ImageViewer.qml
+++ b/src/qml/ImageViewer.qml
@@ -609,6 +609,11 @@ Item {
                 }
             }
         }
+
+        // 菜单销毁后也需要发送信号，否则可能未正常送达
+        Component.onDestruction: {
+            GStatus.showRightMenu = false
+        }
     }
 
     // 图片信息窗口


### PR DESCRIPTION
右键菜单在调用换灯片播放后，当前图片展示组件将被销毁，
但未复位 showRightMenu 属性，二次创建时菜单无法正常展示。
添加菜单销毁复位 showRightMenu 属性。

Log: 修复幻灯片播放后，右键菜单丢失
Bug: https://pms.uniontech.com/bug-view-208417.html
Influence: RightClickMenu