### PR TITLE
chore: Fix bug and Bump version to 5.9.15

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-image-viewer (5.9.15) unstable; urgency=medium
+
+  * fix: build failed with libraw after version 0.21.0(Influence: RAW)
+
+ -- Deepin Packages Builder <packages@deepin.org>  Thu, 21 Sep 2023 15:54:07 +0800
+
 deepin-image-viewer (5.9.14) unstable; urgency=medium
 
   * Revert "fix: Split libxraw plugin and app(Bug: 199143)"

--- a/qimage-plugins/libraw/rawiohandler.cpp
+++ b/qimage-plugins/libraw/rawiohandler.cpp
@@ -63,7 +63,14 @@ bool RawIOHandlerPrivate::load(QIODevice *device)
 
     stream = new Datastream(device);
     raw = new LibRaw;
+
+    // libraw 在 0.21.0 版本调整了 use_rawspeed 参数配置结构
+#if LIBRAW_VERSION < LIBRAW_MAKE_VERSION(0, 21, 0)
     raw->imgdata.params.use_rawspeed = 1;
+#else
+    raw->imgdata.rawparams.use_rawspeed = 1;
+#endif
+
     if (raw->open_datastream(stream) != LIBRAW_SUCCESS) {
         delete raw;
         raw = nullptr;


### PR DESCRIPTION
Fix build failed with libraw after version 0.21.0
Bump version to 5.9.15
PR:
* https://github.com/linuxdeepin/deepin-image-viewer/pull/158

Log: Bump version to 5.9.15
