### PR TITLE
fix: Add implicitly included header files

### DIFF
--- a/src/src/main.cpp
+++ b/src/src/main.cpp
@@ -26,6 +26,9 @@
 #include <QDesktopWidget>
 #include <QScreen>
 #include <QtDBus/QDBusConnection>
+#include <QDir>
+#include <QFileInfo>
+#include <QProcessEnvironment>
 
 #include <sys/types.h>
 #include <sys/stat.h>


### PR DESCRIPTION
These header files are no longer implicitly included in Qt 5.15, add them.

Log: Add implicitly included header files