### PR TITLE
chore: Bump version to 5.9.18

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-image-viewer (5.9.18) unstable; urgency=medium
+
+  * feat: Change default shortcuts popup position(Task: 332273)(Influence: Shortcuts)
+
+ -- renbin <renbin@uniontech.com>  Wed, 27 Mar 2024 16:02:10 +0800
+
 deepin-image-viewer (5.9.17) unstable; urgency=medium
 
   * fix: Not layout center on OpenImage widget.(Bug: 156713)


### PR DESCRIPTION
Bump version to 5.9.18
PR:
* https://github.com/linuxdeepin/deepin-image-viewer/pull/164

Log: Bump version to 5.9.18