### PR TITLE
fix: Improve image load policy

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 ~ 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 ~ 2024 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -68,6 +68,9 @@ int main(int argc, char *argv[])
     CursorTool cursorTool;
     engine.rootContext()->setContextProperty("cursorTool", &cursorTool);
 
+    // 解析命令行参数
+    QString cliParam = fileControl.parseCommandlineGetPath();
+
     // 后端缩略图加载，由 QMLEngine 管理生命周期
     // 部分平台支持线程数较低时，使用同步加载
     ProviderCache *providerCache = nullptr;
@@ -81,6 +84,10 @@ int main(int argc, char *argv[])
         engine.addImageProvider(QLatin1String("ImageLoad"), asyncImageProvider);
 
         providerCache = static_cast<ProviderCache *>(asyncImageProvider);
+
+        if (!cliParam.isEmpty()) {
+            asyncImageProvider->preloadImage(cliParam);
+        }
     }
 
     ThumbnailProvider *multiImageLoad = new ThumbnailProvider;
@@ -110,7 +117,6 @@ int main(int argc, char *argv[])
     engine.addImageProvider(QLatin1String("liveTextAnalyzer"), liveTextAnalyzer);
 
     // 判断命令行数据，在 QML 前优先加载
-    QString cliParam = fileControl.parseCommandlineGetPath();
     if (!cliParam.isEmpty()) {
         QStringList filePaths = fileControl.getDirImagePath(cliParam);
         if (!filePaths.isEmpty()) {

--- a/src/qml/ImageViewer.qml
+++ b/src/qml/ImageViewer.qml
@@ -299,7 +299,7 @@ Item {
         y: window.isFullScreen ? 0 : GStatus.titleHeight
         height: window.isFullScreen ? parent.height : (parent.height - (GStatus.titleHeight * 2))
         width: parent.width
-        cacheBuffer: 200
+        cacheBuffer: 100
         interactive: !GStatus.fullScreenAnimating && GStatus.viewInteractive
         preferredHighlightBegin: 0
         preferredHighlightEnd: 0
@@ -343,6 +343,7 @@ Item {
                 }
             }
 
+            // TODO: 这部分组件也应移动到 Component 中，再抽象一层组件，不提前创建
             IV.ImageInfo {
                 id: imageInfo
 
@@ -380,7 +381,10 @@ Item {
                     }
                 }
 
-                source: swipeViewItemLoader.source
+                // WARNING: 由于 Delegate 组件宽度关联的 view.width ，ListView 会计算 Delegate 大小
+                // Loader 在构造时直接设置图片链接会导致数据提前加载，破坏了延迟加载策略
+                // 调整机制，不在激活状态的图片信息置为空，在需要加载时设置图片链接
+                source: swipeViewItemLoader.active ? swipeViewItemLoader.source : ""
 
                 onDelegateSourceChanged: {
                     if (swipeViewItemLoader.active && delegateSource) {
@@ -439,7 +443,8 @@ Item {
                 } else if (view.currentItem.item) {
                     return view.currentItem.item.status === Image.Loading
                 }
-                return false
+                // 非确定状态都为加载，以避免启动时的白屏过长
+                return true
             }
         }
 

--- a/src/qml/ThumbnailListView.qml
+++ b/src/qml/ThumbnailListView.qml
@@ -209,7 +209,7 @@ Item {
         spacing: 4
         focus: true
         orientation: Qt.Horizontal
-        cacheBuffer: 200
+        cacheBuffer: 60
 
         model: GControl.globalModel
         delegate: Loader {

--- a/src/src/imagedata/imageinfo.h
+++ b/src/src/imagedata/imageinfo.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2024 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -64,7 +64,7 @@ public:
 
 protected:
     void setStatus(Status status);
-    void updateData(const QSharedPointer<ImageInfoData> &newData);
+    bool updateData(const QSharedPointer<ImageInfoData> &newData);
     void refreshDataFromCache(bool reload = false);
     Q_SLOT void onLoadFinished(const QString &path, int frameIndex = 0);
     Q_SLOT void onSizeChanged(const QString &path, int frameIndex = 0);

--- a/src/src/imagedata/imageprovider.cpp
+++ b/src/src/imagedata/imageprovider.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2024 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -206,6 +206,14 @@ void ProviderCache::clearCache()
 }
 
 /**
+   @brief 预载图片数据并缓存
+ */
+void ProviderCache::preloadImage(const QString &)
+{
+    // Nothing
+}
+
+/**
    @class AsyncImageProvider
    @brief 异步图像加载器，提供主要图像的并行加载，主要用于展示图像的加载，会缓存最近的图像信息。
         缩略图通过 ThumbnailProvider 加载
@@ -227,8 +235,18 @@ AsyncImageProvider::~AsyncImageProvider() {}
 QQuickImageResponse *AsyncImageProvider::requestImageResponse(const QString &id, const QSize &requestedSize)
 {
     AsyncImageResponse *response = new AsyncImageResponse(this, id, requestedSize);
-    QThreadPool::globalInstance()->start(response, QThread::IdlePriority);
+    QThreadPool::globalInstance()->start(response, QThread::HighPriority);
     return response;
+}
+
+/**
+   @brief 预加载图片 \a filePath 数据并缓存，用于首次打开应用
+ */
+void AsyncImageProvider::preloadImage(const QString &filePath)
+{
+    AsyncImageResponse *response = new AsyncImageResponse(this, filePath, QSize());
+    response->setAutoDelete(true);
+    QThreadPool::globalInstance()->start(response, QThread::TimeCriticalPriority);
 }
 
 /**

--- a/src/src/imagedata/imageprovider.h
+++ b/src/src/imagedata/imageprovider.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2024 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -16,11 +16,13 @@ class ProviderCache
 {
 public:
     ProviderCache();
-    ~ProviderCache();
+    virtual ~ProviderCache();
 
     void rotateImageCached(int angle, const QString &imagePath, int frameIndex = 0);
     void removeImageCache(const QString &imagePath);
     void clearCache();
+
+    virtual void preloadImage(const QString &filePath);
 
 protected:
     QMutex mutex;
@@ -39,6 +41,7 @@ public:
     ~AsyncImageProvider() override;
 
     virtual QQuickImageResponse *requestImageResponse(const QString &id, const QSize &requestedSize) override;
+    void preloadImage(const QString &filePath) override;
 
 private:
     friend class AsyncImageResponse;


### PR DESCRIPTION
优化图像加载策略,旧版代码 Delegate 依赖外部ListView
的组件大小,导致ListView计算时会遍历元素导致加载关联
图片的缩略图.
调整加载策略,避免启动后无关的加载,将首张图片加载优先
级提前.

Log: 修复部分启动问题