### PR TITLE
fix: style for not-existent images and information dialog

### DIFF
--- a/src/qml/FullImageView.qml
+++ b/src/qml/FullImageView.qml
@@ -1,5 +1,7 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2024 UnionTech Software Technology Co., Ltd.
+//
 // SPDX-License-Identifier: GPL-3.0-or-later
+
 import QtQuick 2.11
 import QtQuick.Controls 2.4
 import QtQuick.Window 2.11
@@ -46,7 +48,12 @@ Item {
             // 显示图像的组件高度(组件高度不会随着缩放变更，是组件在布局内的高度)
             var imageCompoHeight = imageViewer.targetImage.height;
             imageScaleNeedShow = Boolean(imagePaintedHeight <= imageCompoHeight);
+
+            // 设置标题栏的状态，是否图片已缩放到标题栏部分
+            titleRect.imageScaledToTitle = !imageScaleNeedShow;
         }
+
+        // 判断标题栏和底栏的计算
         if (window.isFullScreen) {
             // 全屏时特殊处理
             if (mouseY > bottomHotspotHeight) {
@@ -62,7 +69,7 @@ Item {
                 // 窗口大小大于最小大小，光标不在热区内
                 needShowTopBottom = false;
             } else if (imageScaleNeedShow) {
-                // 缩放范围高度未超过显示范围高度限制时时，不会隐藏工具/标题栏，根据高度而非宽度计算
+                // 缩放范围高度未超过显示范围高度限制时，不会隐藏工具/标题栏，根据高度而非宽度计算
                 needShowTopBottom = true;
             } else if (cursorInWidnow && ((mouseY > bottomHotspotHeight && mouseY <= Window.height) || (0 < mouseY && mouseY < IV.GStatus.titleHeight))) {
                 // 当缩放范围超过工具/标题栏且光标在工具/标题栏范围，显示工具/标题栏

--- a/src/qml/ImageDelegate/NonexistImageDelegate.qml
+++ b/src/qml/ImageDelegate/NonexistImageDelegate.qml
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import QtQuick 2.11
+import org.deepin.dtk 1.0
+import org.deepin.dtk.style 1.0 as DS
 import org.deepin.image.viewer 1.0 as IV
 
 BaseImageDelegate {
@@ -10,37 +12,41 @@ BaseImageDelegate {
 
     status: notExistImage.status
 
+    Component.onCompleted: {
+        if (delegate.targetImageInfo.hasCachedThumbnail) {
+            notExistImage.source = "image://ThumbnailLoad/" + delegate.source;
+        } else {
+            notExistImage.source = "qrc:/res/icon_import_photo.svg";
+        }
+    }
+
     Image {
         id: notExistImage
 
         anchors.centerIn: parent
         fillMode: Image.PreserveAspectFit
-        width: 100
         height: 100
-        smooth: true
         mipmap: true
+        smooth: true
+        width: 100
     }
 
-    Text {
+    Label {
         // 提示图片未找到信息
         id: notExistLabel
 
-        anchors {
-            top: notExistImage.bottom
-            topMargin: 20
-            horizontalCenter: notExistImage.horizontalCenter
-        }
+        // 不同的前景色
+        color: DS.Style.control.selectColor(undefined, Qt.rgba(0, 0, 0, 0.6), Qt.rgba(1, 1, 1, 0.6))
+        font: DTK.fontManager.t9
+        horizontalAlignment: Text.AlignHCenter
         text: qsTr("Image file not found")
         textFormat: Text.PlainText
-        horizontalAlignment: Text.AlignHCenter
         verticalAlignment: Text.AlignVCenter
-    }
 
-    Component.onCompleted: {
-        if (delegate.targetImageInfo.hasCachedThumbnail) {
-            notExistImage.source = "image://ThumbnailLoad/" + delegate.source
-        } else {
-            notExistImage.source = "qrc:/res/icon_import_photo.svg"
+        anchors {
+            horizontalCenter: notExistImage.horizontalCenter
+            top: notExistImage.bottom
+            topMargin: 20
         }
     }
 }

--- a/src/qml/ImageViewer.qml
+++ b/src/qml/ImageViewer.qml
@@ -11,6 +11,7 @@ import org.deepin.dtk 1.0
 import org.deepin.image.viewer 1.0 as IV
 import "./ImageDelegate"
 import "./LiveText"
+import "./InformationDialog"
 
 Item {
     id: imageViewer
@@ -614,6 +615,9 @@ Item {
                 if (IV.GStatus.showRightMenu) {
                     rightMenu.popup(IV.CursorTool.currentCursorPos());
                     rightMenu.focus = true;
+
+                    // 关闭详细信息弹窗
+                    IV.GStatus.showImageInfo = false;
                 }
             }
 
@@ -631,8 +635,10 @@ Item {
 
         active: IV.GStatus.showImageInfo
         asynchronous: true
+
         // 图片属性信息窗口
-        source: "qrc:/qml/InformationDialog/InformationDialog.qml"
+        sourceComponent: InformationDialog {
+        }
     }
 
     //导航窗口

--- a/src/qml/ImageViewer.qml
+++ b/src/qml/ImageViewer.qml
@@ -581,9 +581,10 @@ Item {
         }
 
         DciIcon {
-            Layout.alignment: Qt.AlignHCenter | Qt.AlignBottom
+            anchors.centerIn: parent
             height: 45
             name: "icon_recognition_highlight"
+            palette: DTK.makeIconPalette(parent.palette)
             width: 45
         }
     }

--- a/src/qml/InformationDialog/InformationDialog.qml
+++ b/src/qml/InformationDialog/InformationDialog.qml
@@ -9,41 +9,68 @@ import org.deepin.dtk 1.0
 import org.deepin.image.viewer 1.0 as IV
 
 DialogWindow {
-    property int leftX: 20
-    property int topY: 70
+    id: dialog
+
     property string fileName: IV.FileControl.slotGetFileNameSuffix(filePath)
     property url filePath: IV.GControl.currentSource
+    property int leftX: 20
+    property int propFullWidth: 260
+    property int propLeftWidth: 66
+    property int propMidWidth: 106
+    property int propRightWidth: 86
+    property int topY: 70
 
     flags: Qt.Dialog | Qt.WindowCloseButtonHint | Qt.MSWindowsFixedSizeDialogHint | Qt.WindowStaysOnTopHint
-    visible: false
-    width: 280
-    x: window.x + window.width - width - leftX
-    y: window.y + topY
-    minimumWidth: 280
     maximumWidth: 280
-    minimumHeight: contentHeight.height + 60
-    maximumHeight: contentHeight.height + 60
+    minimumWidth: 280
+    visible: true
+    width: 280
+
     header: DialogTitleBar {
         property string title: fileName
 
         enableInWindowBlendBlur: true
+
         content: Loader {
             sourceComponent: Label {
                 anchors.centerIn: parent
+                elide: Text.ElideMiddle
+                font: DTK.fontManager.t6
                 horizontalAlignment: Text.AlignHCenter
-                verticalAlignment: Text.AlignVCenter
-                font: DTK.fontManager.t8
                 text: title
                 textFormat: Text.PlainText
-                elide: Text.ElideMiddle
+                verticalAlignment: Text.AlignVCenter
             }
         }
+    }
+    Behavior on height {
+        NumberAnimation {
+            duration: 200
+            easing.type: Easing.InOutQuad
+        }
+    }
+
+    Component.onCompleted: {
+        x = window.x + window.width - width - leftX;
+        y = window.y + topY;
+    }
+
+    // 窗口关闭时复位组件状态
+    onClosing: {
+        fileNameProp.reset();
+        IV.GStatus.showImageInfo = false;
+    }
+
+    // 图片变更时复位组件状态(切换时关闭重命名框)
+    onFileNameChanged: {
+        fileNameProp.reset();
     }
 
     ColumnLayout {
         id: contentHeight
 
         width: 260
+
         anchors {
             horizontalCenter: parent.horizontalCenter
             margins: 10
@@ -57,14 +84,13 @@ DialogWindow {
 
                 PropertyActionItemDelegate {
                     id: fileNameProp
+
                     Layout.fillWidth: true
-                    title: qsTr("File name")
+                    corners: RoundRectangle.TopCorner
                     description: fileName
                     iconName: "action_edit"
-                    onClicked: {
-
-                    }
-                    corners: RoundRectangle.TopCorner
+                    implicitWidth: propFullWidth
+                    title: qsTr("File name")
                 }
 
                 RowLayout {
@@ -72,21 +98,24 @@ DialogWindow {
                     spacing: 1
 
                     PropertyItemDelegate {
-                        title: qsTr("Size")
-                        description: IV.FileControl.slotGetInfo("FileSize", filePath)
+                        contrlImplicitWidth: propLeftWidth
                         corners: RoundRectangle.BottomLeftCorner
+                        description: IV.FileControl.slotGetInfo("FileSize", filePath)
+                        title: qsTr("Size")
                     }
 
                     PropertyItemDelegate {
-                        title: qsTr("Dimensions")
-                        description: imageInfo.width + "x" + imageInfo.height
                         Layout.fillWidth: true
+                        contrlImplicitWidth: propMidWidth
+                        description: imageInfo.width + "x" + imageInfo.height
+                        title: qsTr("Dimensions")
                     }
 
                     PropertyItemDelegate {
-                        title: qsTr("Type")
-                        description: IV.FileControl.slotFileSuffix(filePath, false)
+                        contrlImplicitWidth: propRightWidth
                         corners: RoundRectangle.BottomRightCorner
+                        description: IV.FileControl.slotFileSuffix(filePath, false)
+                        title: qsTr("Type")
                     }
                 }
             }
@@ -96,147 +125,142 @@ DialogWindow {
 
                 PropertyActionItemDelegate {
                     Layout.fillWidth: true
-                    title: qsTr("Date captured")
-                    description: IV.FileControl.slotGetInfo("DateTimeOriginal", filePath)
                     corners: RoundRectangle.TopCorner
+                    description: IV.FileControl.slotGetInfo("DateTimeOriginal", filePath)
+                    title: qsTr("Date captured")
                 }
 
                 PropertyActionItemDelegate {
                     Layout.fillWidth: true
-                    title: qsTr("Date modified")
-                    description: IV.FileControl.slotGetInfo("DateTimeDigitized", filePath)
                     corners: RoundRectangle.BottomCorner
+                    description: IV.FileControl.slotGetInfo("DateTimeDigitized", filePath)
+                    title: qsTr("Date modified")
                 }
             }
         }
+
         PropertyItem {
+            id: detailInfoItem
+
+            // 详细信息默认不显示，会影响自动布局效果，因此目前设置为固定布局
+            showProperty: false
             title: qsTr("Details")
 
             GridLayout {
+                Layout.fillWidth: true
                 columnSpacing: 1
+                columns: 3
                 rowSpacing: 1
                 rows: 4
-                columns: 3
-                Layout.fillWidth: true
 
                 PropertyItemDelegate {
-                    contrlImplicitWidth: 66
-                    title: qsTr("Aperture")
-                    description: IV.FileControl.slotGetInfo("ApertureValue", filePath)
+                    contrlImplicitWidth: propLeftWidth
                     corners: RoundRectangle.TopLeftCorner
+                    description: IV.FileControl.slotGetInfo("ApertureValue", filePath)
+                    title: qsTr("Aperture")
                 }
 
                 PropertyItemDelegate {
-                    contrlImplicitWidth: 106
-                    title: qsTr("Exposure program")
+                    Layout.fillWidth: true
+                    Layout.minimumWidth: propMidWidth
+                    contrlImplicitWidth: propMidWidth
                     description: IV.FileControl.slotGetInfo("ExposureProgram", filePath)
-                    Layout.fillWidth: true
+                    title: qsTr("Exposure program")
                 }
 
                 PropertyItemDelegate {
-                    contrlImplicitWidth: 86
-                    title: qsTr("Focal length")
-                    description: IV.FileControl.slotGetInfo("FocalLength", filePath)
+                    contrlImplicitWidth: propRightWidth
                     corners: RoundRectangle.TopRightCorner
+                    description: IV.FileControl.slotGetInfo("FocalLength", filePath)
+                    title: qsTr("Focal length")
                 }
 
                 PropertyItemDelegate {
-                    contrlImplicitWidth: 66
-                    title: qsTr("ISO")
+                    contrlImplicitWidth: propLeftWidth
                     description: IV.FileControl.slotGetInfo("ISOSpeedRatings", filePath)
+                    title: qsTr("ISO")
                 }
 
                 PropertyItemDelegate {
-                    contrlImplicitWidth: 106
-                    title: qsTr("Exposure mode")
+                    Layout.fillWidth: true
+                    contrlImplicitWidth: propMidWidth
                     description: IV.FileControl.slotGetInfo("ExposureMode", filePath)
-                    Layout.fillWidth: true
+                    title: qsTr("Exposure mode")
                 }
 
                 PropertyItemDelegate {
-                    contrlImplicitWidth: 86
-                    title: qsTr("Exposure time")
+                    contrlImplicitWidth: propRightWidth
                     description: IV.FileControl.slotGetInfo("ExposureTime", filePath)
+                    title: qsTr("Exposure time")
                 }
 
                 PropertyItemDelegate {
-                    contrlImplicitWidth: 66
-                    title: qsTr("Flash")
+                    contrlImplicitWidth: propLeftWidth
                     description: IV.FileControl.slotGetInfo("Flash", filePath)
+                    title: qsTr("Flash")
                 }
 
                 PropertyItemDelegate {
-                    contrlImplicitWidth: 106
-                    title: qsTr("Flash compensation")
+                    Layout.fillWidth: true
+                    contrlImplicitWidth: propMidWidth
                     description: IV.FileControl.slotGetInfo("FlashExposureComp", filePath)
-                    Layout.fillWidth: true
+                    title: qsTr("Flash compensation")
                 }
 
                 PropertyItemDelegate {
-                    contrlImplicitWidth: 86
-                    title: qsTr("Max aperture")
+                    contrlImplicitWidth: propRightWidth
                     description: IV.FileControl.slotGetInfo("MaxApertureValue", filePath)
+                    title: qsTr("Max aperture")
                 }
 
                 PropertyItemDelegate {
-                    contrlImplicitWidth: 66
-                    title: qsTr("Colorspace")
-                    description: IV.FileControl.slotGetInfo("ColorSpace", filePath)
+                    contrlImplicitWidth: propLeftWidth
                     corners: RoundRectangle.BottomLeftCorner
+                    description: IV.FileControl.slotGetInfo("ColorSpace", filePath)
+                    title: qsTr("Colorspace")
                 }
 
                 PropertyItemDelegate {
-                    contrlImplicitWidth: 106
-                    title: qsTr("Metering mode")
-                    description: IV.FileControl.slotGetInfo("MeteringMode", filePath)
                     Layout.fillWidth: true
+                    contrlImplicitWidth: propMidWidth
+                    description: IV.FileControl.slotGetInfo("MeteringMode", filePath)
+                    title: qsTr("Metering mode")
                 }
 
                 PropertyItemDelegate {
-                    contrlImplicitWidth: 86
-                    title: qsTr("White balance")
-                    description: IV.FileControl.slotGetInfo("WhiteBalance", filePath)
+                    contrlImplicitWidth: propRightWidth
                     corners: RoundRectangle.BottomRightCorner
+                    description: IV.FileControl.slotGetInfo("WhiteBalance", filePath)
+                    title: qsTr("White balance")
                 }
             }
 
-            PropertyItemDelegate {
-                contrlImplicitWidth: 240
-                title: qsTr("Device model")
-                description: IV.FileControl.slotGetInfo("Model", filePath)
-                corners: RoundRectangle.AllCorner
-            }
+            ColumnLayout {
+                spacing: 1
 
-            PropertyItemDelegate {
-                contrlImplicitWidth: 240
-                title: qsTr("Lens model")
-                description: IV.FileControl.slotGetInfo("LensType", filePath)
-                corners: RoundRectangle.AllCorner
-            }
+                PropertyItemDelegate {
+                    contrlImplicitWidth: propFullWidth
+                    corners: RoundRectangle.AllCorner
+                    description: IV.FileControl.slotGetInfo("Model", filePath)
+                    title: qsTr("Device model")
+                }
 
-            // 默认隐藏"详细"菜单，再初始布局完成后隐藏
-            Component.onCompleted: {
-                showProperty = false
+                PropertyItemDelegate {
+                    contrlImplicitWidth: propFullWidth
+                    corners: RoundRectangle.AllCorner
+                    description: IV.FileControl.slotGetInfo("LensType", filePath)
+                    title: qsTr("Lens model")
+                }
             }
         }
-    }
 
-    onVisibleChanged: {
-        if (visible) {
-            setX(window.x + window.width / 2 - width / 2)
-            setY(window.y + window.height / 2 - height / 2)
+        // 隐藏占位组件
+        Item {
+            id: footer
+
+            Layout.preferredHeight: detailInfoItem.showProperty ? 5 : 10
+            width: 10
         }
-    }
-
-    // 窗口关闭时复位组件状态
-    onClosing: {
-        fileNameProp.reset()
-        IV.GStatus.showImageInfo = false
-    }
-
-    // 图片变更时复位组件状态(切换时关闭重命名框)
-    onFileNameChanged: {
-        fileNameProp.reset()
     }
 
     // DialogWindow 无法直接包含 ImageInfo
@@ -247,9 +271,5 @@ DialogWindow {
             frameIndex: IV.GControl.currentFrameIndex
             source: IV.GControl.currentSource
         }
-    }
-
-    Component.onCompleted: {
-        show()
     }
 }

--- a/src/qml/InformationDialog/PropertyItem.qml
+++ b/src/qml/InformationDialog/PropertyItem.qml
@@ -6,30 +6,47 @@ import QtQuick 2.11
 import QtQuick.Layouts 1.11
 import QtQml.Models 2.11
 import org.deepin.dtk 1.0
+import org.deepin.dtk.style 1.0 as DS
 
 ColumnLayout {
-    property string title
+    default property alias content: itemModel.children
     // 提供隐藏菜单接口
     property alias showProperty: info.visible
-    default property alias content: itemModel.children
+    property string title
 
+    spacing: 10
     width: 280
+
     ItemDelegate {
         id: titleBar
 
+        property Palette titleTextColor: Palette {
+            normal: Qt.rgba(0, 0, 0, 1)
+            normalDark: Qt.rgba(1, 1, 1, 1)
+        }
+
         Layout.fillWidth: true
         Layout.preferredHeight: 24
-        text: title
-        icon.name: info.visible ? "arrow_ordinary_up" : "arrow_ordinary_down"
-        display: IconLabel.IconBesideText
-        checkable: false
-        font: DTK.fontManager.t5
+        anchors.bottomMargin: 10
         backgroundVisible: false
+        checkable: false
+        display: IconLabel.IconBesideText
+        font: DTK.fontManager.t5
+        leftPadding: 10
+        palette.windowText: ColorSelector.titleTextColor
+        text: title
+
+        icon {
+            height: 12
+            name: info.visible ? "arrow_ordinary_up" : "arrow_ordinary_down"
+            width: 12
+        }
 
         MouseArea {
             anchors.fill: parent
+
             onClicked: {
-                info.visible = !info.visible
+                info.visible = !info.visible;
             }
         }
     }
@@ -39,15 +56,18 @@ ColumnLayout {
 
         Layout.fillWidth: true
         Layout.preferredHeight: contentHeight
-        spacing: 5
+        interactive: false
+        spacing: 10
+
         model: ObjectModel {
             id: itemModel
+
         }
 
         Component.onCompleted: {
             for (var i = 0; i < count; ++i) {
-                var item = model.get(i)
-                item.width = width
+                var item = model.get(i);
+                item.width = width;
             }
         }
     }

--- a/src/qml/InformationDialog/PropertyItemDelegate.qml
+++ b/src/qml/InformationDialog/PropertyItemDelegate.qml
@@ -6,74 +6,137 @@ import QtQuick 2.11
 import QtQuick.Layouts 1.11
 import QtQuick.Controls 2.4
 import org.deepin.dtk 1.0
+import org.deepin.dtk.style 1.0 as DS
+import "../"
 
 Control {
     id: control
 
-    property string title
-    property string description
-    property int corners: RoundRectangle.NoneCorner
-    property string iconName
-    property int contrlImplicitWidth: 66
-    property int contrlIntimplicitHeight: 40
     property Component action: ActionButton {
-        visible: control.iconName
         Layout.alignment: Qt.AlignRight
-        icon {
-            width: 14
-            height: 14
-            name: control.iconName
-        }
+        visible: control.iconName
 
         onClicked: control.clicked()
+
+        icon {
+            height: 14
+            name: control.iconName
+            width: 14
+        }
     }
+    property int contrlImplicitWidth: 66
+    property int contrlIntimplicitHeight: 40
+    property int corners: RoundRectangle.NoneCorner
+    property string description
+    property int descriptionWidth: control.width - leftPadding - rightPadding
+    property string iconName
+    property Palette infoTextColor: Palette {
+        normal: Qt.rgba(0, 0, 0, 1)
+        normalDark: Qt.rgba(1, 1, 1, 1)
+    }
+    property Palette sectionTextColor: Palette {
+        normal: Qt.rgba(0, 0, 0, 0.6)
+        normalDark: Qt.rgba(1, 1, 1, 0.6)
+    }
+    property string title
 
     signal clicked
 
-    width: 66
-    padding: 5
+    bottomPadding: 4
+    implicitWidth: contrlImplicitWidth
+    leftPadding: 10
+    rightPadding: 10
+    topPadding: 3
+
+    background: RoundRectangle {
+        color: Qt.rgba(0, 0, 0, 0.05)
+        corners: control.corners
+        implicitHeight: contrlIntimplicitHeight
+        implicitWidth: contrlImplicitWidth
+        radius: Style.control.radius
+    }
     contentItem: ColumnLayout {
+        spacing: 0
+
         Label {
-            visible: control.title
+            color: control.ColorSelector.sectionTextColor
+            font: DTK.fontManager.t10
             text: control.title
             textFormat: Text.PlainText
-            font: DTK.fontManager.t10
+            visible: control.title
         }
 
         RowLayout {
-            Item {
-                Label {
-                    id: showlabel
+            id: content
 
-                    width: contrlImplicitWidth
-                    visible: control.description.length > 0
-                    Layout.fillWidth: true
-                    text: control.description
-                    textFormat: Text.PlainText
-                    font: DTK.fontManager.t8
+            Label {
+                id: showlabel
+
+                Layout.fillWidth: true
+                color: control.ColorSelector.infoTextColor
+                font: DTK.fontManager.t8
+                text: textMetics.elidedText
+                textFormat: Text.PlainText
+                visible: control.description
+
+                TextMetrics {
+                    id: textMetics
+
                     elide: Text.ElideMiddle
+                    elideWidth: descriptionWidth
+                    font: showlabel.font
+                    text: control.description
+                }
 
-                    MouseArea {
+                Loader {
+                    active: textMetics.width > descriptionWidth
+                    anchors.fill: parent
+
+                    sourceComponent: MouseArea {
                         anchors.fill: parent
                         hoverEnabled: true
 
-                        AlertToolTip {
-                            id: tip
-
-                            visible: parent.focus
-                            text: control.description
+                        onExited: {
+                            tip.visible = false;
                         }
-
                         onMouseXChanged: {
-                            if (tip.width < control.width + 15) {
-                                tip.visible = false
+                            if (textMetics.width < descriptionWidth) {
+                                tip.visible = false;
                             } else {
-                                tip.visible = true
+                                tip.visible = true;
                             }
                         }
 
-                        onExited: {
-                            tip.visible = false
+                        ToolTip {
+                            id: tip
+
+                            parent: parent
+                            text: control.description
+                            visible: parent.focus
+                            width: control.width - 5
+                            y: showlabel.y + 20
+
+                            background: FloatingPanel {
+                                ColorSelector.family: Palette.CrystalColor
+                                implicitHeight: DS.Style.toolTip.height
+                                implicitWidth: 0
+                                radius: DS.Style.control.radius
+
+                                backgroundColor: Palette {
+                                    normal {
+                                        common: "#f0f0f0"
+                                        crystal: Qt.rgba(0.20, 0.2, 0.2, 0.1)
+                                    }
+                                }
+                            }
+                            contentItem: Text {
+                                color: control.palette.toolTipText
+                                font: DTK.fontManager.t8
+                                horizontalAlignment: Text.AlignLeft
+                                text: control.description
+                                verticalAlignment: Text.AlignVCenter
+                                wrapMode: Text.Wrap
+                            }
                         }
                     }
                 }
@@ -84,13 +147,5 @@ Control {
                 sourceComponent: control.action
             }
         }
-    }
-
-    background: RoundRectangle {
-        implicitWidth: contrlImplicitWidth
-        implicitHeight: contrlIntimplicitHeight
-        color: Qt.rgba(0, 0, 0, 0.05)
-        radius: Style.control.radius
-        corners: control.corners
     }
 }

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2024 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -7,6 +7,7 @@ import QtQuick 2.11
 import QtQuick.Window 2.11
 import QtQuick.Controls 2.4
 import org.deepin.dtk 1.0
+import org.deepin.dtk.style 1.0 as DS
 import org.deepin.image.viewer 1.0 as IV
 
 ApplicationWindow {
@@ -18,6 +19,8 @@ ApplicationWindow {
 
     // 设置 dtk 风格窗口
     DWindow.enabled: true
+    // 调整暗色主题下的窗口背景色
+    color: DS.Style.control.selectColor(palette.window, palette.window, Qt.rgba(24 / 255, 24 / 255, 24 / 255, 1))
     flags: Qt.Window | Qt.WindowMinMaxButtonsHint | Qt.WindowCloseButtonHint | Qt.WindowTitleHint
     height: IV.FileControl.getlastHeight()
     minimumHeight: IV.GStatus.minHeight

--- a/src/src/globalcontrol.h
+++ b/src/src/globalcontrol.h
@@ -29,10 +29,12 @@ public:
     explicit GlobalControl(QObject *parent = nullptr);
     ~GlobalControl() override;
 
+    // 用于全局的图像源数据模型
     void setGlobalModel(ImageSourceModel *model);
     ImageSourceModel *globalModel() const;
     Q_SIGNAL void globalModelChanged();
 
+    // 当前图像设置及(帧)索引变更信号
     void setCurrentSource(const QUrl &source);
     QUrl currentSource() const;
     Q_SIGNAL void currentSourceChanged();
@@ -45,11 +47,13 @@ public:
     int imageCount() const;
     Q_SIGNAL void imageCountChanged();
 
+    // 图像旋转处理
     void setCurrentRotation(int angle);
     int currentRotation();
     Q_SIGNAL void currentRotationChanged();
     Q_SIGNAL void requestRotateCacheImage();
 
+    // 图片切换操作
     bool hasPreviousImage() const;
     Q_SIGNAL void hasPreviousImageChanged();
     bool hasNextImage() const;
@@ -59,6 +63,7 @@ public:
     Q_INVOKABLE bool firstImage();
     Q_INVOKABLE bool lastImage();
 
+    // 图像文件变更操作
     Q_SLOT void setImageFiles(const QStringList &imageFiles, const QString &openFile);
     Q_SLOT void removeImage(const QUrl &removeImage);
     Q_SLOT void renameImage(const QUrl &oldName, const QUrl &newName);
@@ -66,6 +71,7 @@ public:
     Q_SLOT void submitImageChangeImmediately();
     Q_SIGNAL void requestRotateImage(const QString &localPath, int rotation);
 
+    // 判断当前设备是否支持多线程处理
     static bool enableMultiThread();
 
 protected:


### PR DESCRIPTION
[fix: style for not-existent images](https://github.com/linuxdeepin/deepin-image-viewer/commit/949d7377c8ee0f470f5457169cc814e69a203179) 

Fixed style for not-existent images.

Log: Fixed style for not-existent images
Bug: https://pms.uniontech.com/bug-view-213323.html

[fix: information dialog layout](https://github.com/linuxdeepin/deepin-image-viewer/commit/f5226c3aa9a4b0d1286ce695c656b5f1a51201f4) 

* Update information dialog layout;
* Update font size and palette.

Log: Fix information dialog layout
Bug: https://pms.uniontech.com/bug-view-168015.html

[fix: live text button position and palette](https://github.com/linuxdeepin/deepin-image-viewer/pull/173/commits/6528512a519d6122de80df4339b3919d90755e02) 

As titile.

Log: Fixed live text button position and palette
Bug: https://pms.uniontech.com/bug-view-168833.html

[fix: palette of title bar in different states](https://github.com/linuxdeepin/deepin-image-viewer/pull/173/commits/3581bc7f4cbffdad409333531f1b8286da71f0bd) 

* Update the palette of title bar in different states;
* DTK TitleBar now supports double-clicking to switch window mode;
* Remove mousetrackitem, managed by qml component properties.

Log: Update the palette of title bar in different states
Bug: https://pms.uniontech.com/bug-view-167839.html,
     https://pms.uniontech.com/bug-view-167813.html,
     https://pms.uniontech.com/bug-view-167813.html,
     https://pms.uniontech.com/bug-view-167913.html
Influence: TitleBar