### PR TITLE
fix: ui/ocr/reinitialization error

### DIFF
--- a/src/qml/ImageViewer.qml
+++ b/src/qml/ImageViewer.qml
@@ -412,6 +412,12 @@ Item {
             }
         }
 
+        Component.onCompleted: {
+            // 首次进入(退出缩略图后创建)重置当前显示的索引
+            IV.GStatus.viewFlicking = true;
+            currentIndex = IV.GControl.viewModel.currentIndex;
+            IV.GStatus.viewFlicking = false;
+        }
         onCurrentIndexChanged: {
             var curIndex = view.currentIndex;
             var previousIndex = IV.GControl.viewModel.currentIndex;

--- a/src/qml/InformationDialog/PropertyActionItemDelegate.qml
+++ b/src/qml/InformationDialog/PropertyActionItemDelegate.qml
@@ -78,6 +78,8 @@ Control {
 
         ElideLabel {
             Layout.fillWidth: true
+            // 系数微调整以满足默认字号标签均显示的效果
+            Layout.minimumWidth: descriptionWidth + 5
             color: control.ColorSelector.sectionTextColor
             font: DTK.fontManager.t10
             sourceText: control.title

--- a/src/qml/InformationDialog/PropertyItemDelegate.qml
+++ b/src/qml/InformationDialog/PropertyItemDelegate.qml
@@ -28,7 +28,7 @@ Control {
     property int contrlIntimplicitHeight: 40
     property int corners: RoundRectangle.NoneCorner
     property string description
-    property int descriptionWidth: control.width - leftPadding - rightPadding
+    property int descriptionWidth: control.width - control.leftPadding - control.rightPadding
     property string iconName
     property Palette infoTextColor: Palette {
         normal: Qt.rgba(0, 0, 0, 1)
@@ -60,11 +60,12 @@ Control {
 
         ElideLabel {
             Layout.fillWidth: true
+            // 系数微调整以满足默认字号标签均显示的效果
+            Layout.minimumWidth: descriptionWidth + 5
             color: control.ColorSelector.sectionTextColor
             font: DTK.fontManager.t10
             sourceText: control.title
             tipsColor: control.palette.toolTipText
-            width: descriptionWidth
         }
 
         RowLayout {

--- a/src/src/filecontrol.cpp
+++ b/src/src/filecontrol.cpp
@@ -418,7 +418,13 @@ void FileControl::ocrImage(const QString &path, int index)
         QImageReader imageReader(localPath);
         imageReader.jumpToImage(index);
         auto image = imageReader.read();
-        auto tempFileName = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + QDir::separator() + "rec.png";
+        auto tempDir = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+        QDir dir(tempDir);
+        if (!dir.exists()) {
+            dir.mkpath(".");
+        }
+        auto tempFileName = tempDir + QDir::separator() + "rec.png";
+
         image.save(tempFileName);
         m_ocrInterface->openFile(tempFileName);
     }

--- a/src/src/imagedata/pathviewproxymodel.cpp
+++ b/src/src/imagedata/pathviewproxymodel.cpp
@@ -186,14 +186,16 @@ void PathViewProxyModel::resetModel(int sourceIndex, int frameIndex)
 {
     beginResetModel();
 
-    setCurrentIndex(0);
+    // 无需通知
+    currentProxyIdx = 0;
+    jumpFlag = Current;
     indexQueue.clear();
     indexQueue.append(infoFromIndex(sourceIndex, frameIndex));
 
     QList<IndexInfoPtr> prependQueue;
 
     while ((indexQueue.size() + prependQueue.size()) < maxCount) {
-        // 首次进入时，前面的节点不填充，而是追加到尾部
+        // 首次进入时，前面的节点不填充，而是追加到尾部，保证首张图片索引指向 0
         if (prependQueue.isEmpty()) {
             prependQueue.prepend(createPreviousIndexInfo(indexQueue.first()));
         } else {


### PR DESCRIPTION
[fix: ui/ocr/reinit error](https://github.com/linuxdeepin/deepin-image-viewer/pull/182/commits/c57dc6db8820869bd12be3b415651021b650e47d) 

Adjust information dialog label padding;
Init PathView currentIndex when component completed;
Adjust ocr cache folder.

Log: Fix some known errors.
Bug: https://pms.uniontech.com/bug-view-268607.html