### PR TITLE
Fix: error shortcut and pop-up deletion dialog

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,7 @@
 #include "config.h"
 
 #include <DApplication>
+#include <DLog>
 
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
@@ -48,6 +49,15 @@ int main(int argc, char *argv[])
     app.setApplicationDescription(
         QObject::tr("Image Viewer is an image viewing tool with fashion interface and smooth performance."));
     app.setWindowIcon(QIcon::fromTheme("deepin-image-viewer"));
+
+    // LOG
+    DLogManager::registerConsoleAppender();
+    DLogManager::registerFileAppender();
+    qInfo() << QString("%1 start, PID: %2, Version: %3")
+                   .arg(app.applicationName())
+                   .arg(app.applicationPid())
+                   .arg(app.applicationVersion());
+    qDebug() << "LogFile:" << DLogManager::getlogFilePath();
 
     QQmlApplicationEngine engine;
 

--- a/src/qml/MainStack.qml
+++ b/src/qml/MainStack.qml
@@ -121,8 +121,7 @@ Item {
         sourceComponent: FileDialog {
             id: fileDialog
 
-            currentFolder: shortcuts.pictures
-            // selectMultiple: true
+            currentFolder: IV.FileControl.standardPicturesPath()
             fileMode: FileDialog.OpenFiles
             nameFilters: ["Image files (*.jpg *.png *.bmp *.gif *.ico *.jpe " + "*.jps *.jpeg *.jng *.koala *.koa *.lbm " + "*.iff *.mng *.pbm *.pbmraw *.pcd *.pcx " + "*.pgm *.pgmraw *.ppm *.ppmraw *.ras *.tga " + "*.targa *.tiff *.tif *.wbmp *.psd *.cut *.xbm " + "*.xpm *.dds *.fax *.g3 *.sgi *.exr *.pct *.pic " + "*.pict *.webp *.jxr *.mrw *.raf *.mef *.raw *.orf " + "*.djvu *.or2 *.icns *.dng *.svg *.nef *.pef *.pxm *.pnm)"]
             title: qsTr("Select pictures")
@@ -143,7 +142,7 @@ Item {
         sequence: "F1"
 
         onActivated: {
-            D.ApplicationHelper.handleHelpAction();
+            DTK.ApplicationHelper.handleHelpAction();
         }
     }
 

--- a/src/src/filecontrol.cpp
+++ b/src/src/filecontrol.cpp
@@ -115,6 +115,11 @@ FileControl::~FileControl()
     saveSetting();
 }
 
+QString FileControl::standardPicturesPath() const
+{
+    return QStandardPaths::writableLocation(QStandardPaths::PicturesLocation);
+}
+
 QStringList FileControl::getDirImagePath(const QString &path)
 {
     if (path.isEmpty()) {

--- a/src/src/filecontrol.h
+++ b/src/src/filecontrol.h
@@ -27,6 +27,8 @@ public:
     explicit FileControl(QObject *parent = nullptr);
     ~FileControl();
 
+    Q_INVOKABLE QString standardPicturesPath() const;
+
     Q_INVOKABLE void resetImageFiles(const QStringList &filePaths = {});       // 重设当前展示图片列表
     Q_INVOKABLE QStringList getDirImagePath(const QString &path);              // 获得路径下的所有图片路径
     Q_INVOKABLE bool isCurrentWatcherDir(const QUrl &path);                    // 判断是否为当前正在监控的文件路径

--- a/src/src/utils/filetrashhelper.h
+++ b/src/src/utils/filetrashhelper.h
@@ -29,7 +29,7 @@ private:
     bool isExternalDevice(const QString &path);
     bool isGvfsFile(const QUrl &url) const;
 
-    bool moveFileToTrashWithDBus(const QUrl &url);
+    int moveFileToTrashWithDBus(const QUrl &url);
 
 private:
     QScopedPointer<QDBusInterface> m_dfmDeviceManager;


### PR DESCRIPTION
[fix: shortcut and log file](https://github.com/linuxdeepin/deepin-image-viewer/commit/5f6534583ffa340b1663c07aa205431a3188756a) 

* Fix open help shortcut;
* Set default open file folder;
* Add log file.

Log: Fix some issue.
Bug: https://pms.uniontech.com/bug-view-273543.html

[fix: error pop-up deletion dialog](https://github.com/linuxdeepin/deepin-image-viewer/commit/7735a3d815348980d0dcb383fb89ee3f45d68750) 

The timeout is too short, and the file manager
backend cannot complete the image deletion.
This causes an error dialog to pop up.

Log: Fix error pop-up deletion dialog.
Bug: https://pms.uniontech.com/bug-view-273813.html