### PR TITLE
fix: ocr position offset on HiDPI displays

### DIFF
--- a/src/qml/LiveText/LiveBlock.qml
+++ b/src/qml/LiveText/LiveBlock.qml
@@ -73,8 +73,8 @@ Rectangle {
     }
 
     Image {
+        // Note: we need to use default fillMode, to support diff devicePixelRatio (>1.0)
         anchors.fill: parent
-        fillMode: Image.Tile
         source: "image://liveTextAnalyzer/" + Math.random() + "_" + index
     }
 

--- a/src/src/ocr/livetextanalyzer.h
+++ b/src/src/ocr/livetextanalyzer.h
@@ -9,7 +9,7 @@
 #include <QQuickImageProvider>
 
 namespace DeepinOCRPlugin {
-    class DeepinOCRDriver;
+class DeepinOCRDriver;
 }
 
 class LiveTextAnalyzer : public QQuickImageProvider
@@ -36,4 +36,5 @@ protected:
 private:
     DeepinOCRPlugin::DeepinOCRDriver *ocrDriver;
     QImage imageCache;
+    qreal pixelRatio{1.0};  // for diff devicePixelRatio
 };


### PR DESCRIPTION
- Add devicePixelRatio support to fix text box positioning on HiDPI screens
- Remove Image.Tile fillMode for better DPI compatibility
- Scale image dimensions based on device pixel ratio

Log: Fix ocr position offset on HiDPI displays.
Bug: https://pms.uniontech.com/bug-view-275403.html