### PR TITLE
fix: 修复大窗口关闭看图后，改变增加缩放比后，打开看图无法看到看图标题栏问题

### DIFF
--- a/src/src/main.cpp
+++ b/src/src/main.cpp
@@ -285,6 +285,10 @@ int main(int argc, char *argv[])
     //修复窗口会一直在中间变小的问题
     if (checkOnly()) {
         Dtk::Widget::moveToCenter(mainwindow);
+        QPoint pt = mainwindow->geometry().topLeft();
+        if(pt.x() < 0 || pt.y() < 0) {
+            mainwindow->move(0, 0);
+        }
     }
 
     QObject::connect(dApp, &Application::sigQuit, w, &MainWindow::quitApp, Qt::DirectConnection);


### PR DESCRIPTION
修复大窗口关闭看图后，改变增加缩放比后，打开看图无法看到看图标题栏问题

Bug: https://pms.uniontech.com/bug-view-298659.html
Log: 修复大窗口关闭看图后，改变增加缩放比后，打开看图无法看到看图标题栏问题