### PR TITLE
chore: Support linglong building base on Qt6.8 runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ debian/deepin-image-viewer.substvars
 !debian/control
 !debian/compat
 !debian/source/*
+
+#linglong building dir
+linglong
+build

--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -1,0 +1,1061 @@
+# SPDX-FileCopyrightText: 2024 - 2025 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+version: '1'
+
+package:
+  id: org.deepin.image.viewer
+  name: deepin-image-viewer
+  version: 6.0.10.1
+  kind: app
+  description: |
+    view images for deepin os.
+
+command:
+  - deepin-image-viewer
+
+base: org.deepin.base/23.1.0/arm64
+runtime: org.deepin.runtime.dtk/25.2.0/arm64
+
+build: |
+  bash ./install_dep linglong/sources "$PREFIX"
+
+  # add path for searching OpenGL
+  export PATH=$PATH:/runtime/include:/runtime/lib/${TRIPLET}
+
+  VERSION=$(head -1 debian/changelog | awk -F'[()]' '{print $2}')
+  cmake -B build \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+        -DCMAKE_INSTALL_LIBDIR=${PREFIX}/lib/${TRIPLET} \
+        -DVERSION=${VERSION}
+  cmake --build build -j`nproc`
+  cmake --build build --target install >install.log 2>&1
+
+  # 项目生成应用名和动态隐式加载的依赖库，ldd无法找到的其他库
+  LDD_FILES=(
+    deepin-image-viewer
+  )
+
+  # 生成.install 文件
+  bash ./deploy_dep "${LDD_FILES[@]}"
+
+  ID_VALUE=$(awk -F ': ' '/^  id: / {print $2}' linglong.yaml)
+  # deepin-ocr-plugin-manager model 文件添加到 install 文件
+  find "${PREFIX}/share/deepin-ocr-plugin-manager/model/" -type f -o -type d >> "${ID_VALUE}.install"
+
+sources:
+  # linglong:gen_deb_source sources arm64 https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release/ beige main community
+  # linglong:gen_deb_source install libdtk6gui-dev, libdtk6widget-dev, qt6-svg-dev, qt6-tools-dev, qt6-tools-dev-tools, qt6-base-dev, qt6-base-dev-tools, qt6-base-private-dev, qt6-l10n-tools, libraw-dev, libexif-dev, libdeepin-ocr-plugin-manager-dev
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_arm64.deb
+    digest: db24bc67c73659376f0a1eae6d7c536aaa53eb75790e6bf51916a0cb2a630fbd
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/binutils-aarch64-linux-gnu_2.41-6deepin4_arm64.deb
+    digest: 6dea84674ed887668dbcff5aa24049be9d6ab447c5a25efd0319daf262d678fb
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/binutils-common_2.41-6deepin4_arm64.deb
+    digest: cd56d2bf469c714c7a3cd72bc5ce1d33eda15dacb552b561014ec73e44d752f1
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/binutils_2.41-6deepin4_arm64.deb
+    digest: e8ad011bfd66aa43901791b40aa6e681bfc388b562324eb5a00ec71714d3314a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/bzip2/bzip2_1.0.8-deepin1_arm64.deb
+    digest: 5fc6a22a0ad720a1b8fc7f8ef83ddfbb0c59bfa43ad383c7052cf2adf9f3d0d7
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/debconf/debconf_1.5.79-deepin_all.deb
+    digest: ded6aaa7927ae27337ceb23d49391b4c7ec460a00ba692020e8f4e28388f345f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_arm64.deb
+    digest: 11a42f07b2feefb7669441c3a67176cc32dc857c7d21b3290c464795fc514448
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dpkg/dpkg-dev_1.22.6deepin3_all.deb
+    digest: 52e7455da433b7e412afeec3848d3f6371a857653aea02d1a6e080db446f51d9
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dpkg/dpkg_1.22.6deepin3_arm64.deb
+    digest: 81d1a53d75115f01e303fcf8337493bc2850614b0a2e30b06b9e0fa67d0d5a80
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fontconfig/fontconfig-config_2.14.2-6_arm64.deb
+    digest: aa64934dbf43b0dd0ffee2b7fbcce324b50b957b0a4f04c10d062a85d8847d8e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fontconfig/fontconfig_2.14.2-6_arm64.deb
+    digest: 91c105d210849f97151c436e0cf9b77910bbc58ea9bbd40da4077219def10994
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
+    digest: afbaf120869a08aa7dd14da9ad014de48a751aa4330534b531410bb86c411b55
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-dejavu/fonts-dejavu-core_2.37-deepin_all.deb
+    digest: 5982963d05dbf4efa009c3ab6db3576a03f680199d75d7d5edda89c55def912c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-freefont/fonts-freefont-otf_20120503-10_all.deb
+    digest: c66666da94b9a0477351ee9d6d7a247a0a3c842e428da770991b45f03be2ee72
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-freefont/fonts-freefont-ttf_20120503-10_all.deb
+    digest: 79b23c3945d4628463672a804a0e81bc4c262ef87cb6316afb40167a50bc3145
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-liberation/fonts-liberation_2.1.5-3_all.deb
+    digest: 9285213fd8d6515bc6c1be5b810bf39918a668a17024a9fd3541879ce7fb5344
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-noto/fonts-noto-core_20201225-deepin_all.deb
+    digest: fa09d95f516c498d55e516d549b8ee41d9a7b6f17cdf0bb4b43744d672ce1366
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb
+    digest: f66d6f798c4b99d8490558cc8209c069b0fe5577c11378c0e01f9e87ddf10824
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-urw-base35/fonts-urw-base35_20200910-7_all.deb
+    digest: 4800c0b08fbeac0335f1e23df2d41528a242383324c256ebece00c8f438eefbd
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gcc-13/gcc-13-base_13.2.0-3deepin3_arm64.deb
+    digest: b39326ffa5eb7901d47273247b7da0ed48cd88d4d468606a48d25c0d6cff2b70
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/gir1.2-glib-2.0_2.80.1-1deepin1_arm64.deb
+    digest: 44c091f38ef3e76d0b4d249b584a05e88b8e24a754834ba0bcde925734229ce3
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgudev/gir1.2-gudev-1.0_238-2deepin1_arm64.deb
+    digest: 1afc84a191b5f3819a8bc441315d4ab876409ec711acf1af3eda81659f9e3abb
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/acl/libacl1_2.3.1-1_arm64.deb
+    digest: 51808064361bdae539f985645eaee59b53c703b293174f761d996b27f2b8d860
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/avahi/libavahi-client3_0.8-5_arm64.deb
+    digest: caef7cbebe662623b30149c2a4301d2ffeb03071e545f030bb0cff9ba881d2da
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/avahi/libavahi-common-data_0.8-5_arm64.deb
+    digest: 5995162791c2d06696885bb9a0ba3f160071b28a810b0f0e68f13fcbb6e83fc8
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/avahi/libavahi-common3_0.8-5_arm64.deb
+    digest: 811cd69fd19e3765e96a76121722a3ed06966590e529793cb311dd3c0e27ceaf
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libb/libb2/libb2-1_0.98.1-1.1_arm64.deb
+    digest: cac541f3cf746d006b71a08f88364b6743222b8956fda9a7cbd35ffb1cf32ed9
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/libbinutils_2.41-6deepin4_arm64.deb
+    digest: a8b2e62f7a5b915def9b46d968118d26cf25df7695e28d13a6b1d58ebb6b400f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libblkid-dev_2.39.3-6deepin1_arm64.deb
+    digest: a86d6e3229a0af4e39de917b5c49ab2b228ddf5dccd6e841a8944d19e62495b1
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libblkid1_2.39.3-6deepin1_arm64.deb
+    digest: 9956f16990e98ff4a62e1730feec46eb2d57e4da93b9c138514423f593f272ae
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/brotli/libbrotli-dev_1.1.0-2_arm64.deb
+    digest: 016574d411e89311351ae6117b766a6bfa1ef7c0f49a4e17601200a33c2a19b5
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/brotli/libbrotli1_1.1.0-2_arm64.deb
+    digest: 982215712f2faad9f502b5d82d60152aab99acbef30457c9839988264a7c9190
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libb/libbsd/libbsd0_0.11.7-4_arm64.deb
+    digest: cb575189104cacfa40cd228b6fb11f4a90e1c2f6b258e1627c843ebe5cb36f09
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/bzip2/libbz2-1.0_1.0.8-deepin1_arm64.deb
+    digest: 0728bcbf280531a397947cba90fe861f3fde48a5811736509e2075c1f832dee4
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_arm64.deb
+    digest: 502bf30d0f5d2a06d33495526cb4f5f7929623e87ed3c716aafb91f29565c1c3
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glibc/libc-dev-bin_2.38-6deepin7_arm64.deb
+    digest: 03dfd6ed282ba7086528a4d17621f64ddf8c2009cad2397379579be1fb678a3e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glibc/libc6-dev_2.38-6deepin7_arm64.deb
+    digest: 5e337ca9bd7ca1a8e23ae5b5063e80f21d13d1abf9ca523e71fba78c607332a9
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glibc/libc6_2.38-6deepin7_arm64.deb
+    digest: 22797cb5249c2a072b970159b606dbf4b6218e20e37b014b6a22bfc41642d6c3
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libc/libcap2/libcap2_2.66-5_arm64.deb
+    digest: 6f196062b90716256bf2a57e919d18c74eb6cc19d98f1cf88e603cbd8d68b188
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin5_arm64.deb
+    digest: 544520612dc6697c5165126dab9ec2cabae88d42678aaa5a762674559a6ace92
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/llvm-toolchain-17/libclang1-17_17.0.6-5deepin5_arm64.deb
+    digest: 167b974f0fc6e2547f68b5b2f7add39efb575f3f0e36a14806fd779216d7b62e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/e/e2fsprogs/libcom-err2_1.47.0-2deepin1_arm64.deb
+    digest: 32582278847580e89bdab5abc948478e0dbe3c24959ff2b15d9af5a46cb111fe
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcrypt/libcrypt-dev_4.4.36-5_arm64.deb
+    digest: fbc8cb951f3a23a095dd6fc672832bb8dbfdde96725939bc3dc162584a9f2efc
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcrypt/libcrypt1_4.4.36-5_arm64.deb
+    digest: 037584e67001e5de6f78c0d3acabe70a7b2e7dc592252ae0d9397c263c41c9f4
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/libctf-nobfd0_2.41-6deepin4_arm64.deb
+    digest: ba46c758512962bd4c7ec4b8a7856417ea16fd6b8eb1687b446adcf6afb83f6b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/libctf0_2.41-6deepin4_arm64.deb
+    digest: 3d0da144ea8f7405082586db7756754f3068936428e06abab6cb7b8c826c8199
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cups/libcups2-dev_2.4.2-5deepin1_arm64.deb
+    digest: 1557184d0ba255ee05b5c929396c4c925e10782f9cba74f3514f96d3bf581ca1
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cups/libcups2_2.4.2-5deepin1_arm64.deb
+    digest: e9754a238fed47dac0e3e6255697563494f6ca4b58313bc7f6183d4d0995d32f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin1_arm64.deb
+    digest: d0a1e93cb1b63e0040b50c924c8a7c9464494ef3547447913584d0a62999590a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cups/libcupsimage2_2.4.2-5deepin1_arm64.deb
+    digest: 12003d3e5acd0a1c379f81e075b6171fb784666763813528fd18189beea9735d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8deepin0_arm64.deb
+    digest: ee20a140ab90ce9fa2ab045eab6195b426d5c441459a788e15966687a1d57221
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dbus/libdbus-1-3_1.14.10-3_arm64.deb
+    digest: 7b736881f8730994a643683bec66e7105c23d0ecf5e407e21c427faf2428c237
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/deepin-ocr-plugin-manager/libdeepin-ocr-plugin-manager-dev_1.0.0_arm64.deb
+    digest: 99c9abd71701a13b095fa8ee5d49f5cae74f022129bb429cca11d17605343f10
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/deepin-ocr-plugin-manager/libdeepin-ocr-plugin-manager_1.0.0_arm64.deb
+    digest: c7ce110cfba125f9d77633ef9a110755e55905fc5512a45d4f4e2d44e58670ed
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdeflate/libdeflate-dev_1.18-1_arm64.deb
+    digest: d5e52d889f15c80ffe7214c06605d831488c2650ec00d7c9eb9b50ebbc108133
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdeflate/libdeflate0_1.18-1_arm64.deb
+    digest: 044cb710b30d6019492308216ead89b7a7357e4e63a2574929a85a167967f515
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_arm64.deb
+    digest: 78e9245e377c8f61009cc60d2b55001aaddd7b656fceb916b3ba8f07344251b7
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dpkg/libdpkg-perl_1.22.6deepin3_all.deb
+    digest: 71989ccb16cfcc04aa5a86f06e4dff837a4fa755d04d17d5f0cf329fc09dda04
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdrm/libdrm-amdgpu1_2.4.123-1_arm64.deb
+    digest: ea011d2a1b77d97ea5d538786dc3aece9a24e317489827cf5e4dfc6032cb61f4
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdrm/libdrm-common_2.4.123-1_all.deb
+    digest: b8289eaa6341a8493f4c191a45165fe944248da69f675d09005a29058e7ae5a6
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdrm/libdrm-radeon1_2.4.123-1_arm64.deb
+    digest: e1b45eb0e3b7599cb1010679fa97507f0c3a814d00ed37d7912fc2bb95270e35
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdrm/libdrm2_2.4.123-1_arm64.deb
+    digest: 6c900feb79b1e5f847a5b9f53c6bda3f6aa12a9abfcf106f872a3812ef78bbc4
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6core/libdtk6core-dev_6.0.25_arm64.deb
+    digest: b8693fdd024188f811597e28d7d7e03dba17e811711883716b7ff76376801e02
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6core/libdtk6core_6.0.25_arm64.deb
+    digest: 3442eb4010d5176f27e5062d6fb07f1d8afca80c59375f9c37aa65eea62a727c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6gui/libdtk6gui-dev_6.0.25_arm64.deb
+    digest: 5b30d2ade934bf6b80f4fd6e9eecf7549d44e9df70c8e97266b720811c90ffb3
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6gui/libdtk6gui_6.0.25_arm64.deb
+    digest: 34a82a6a255c9d9ea99e12432c047cf0efafd61101a90ef319689d4940fa9767
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6log/libdtk6log-dev_0.0.2_arm64.deb
+    digest: 0e714a576b19f5a920d224ef1a1877e93c4b8aea1e49eba99df7316c72319910
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6log/libdtk6log_0.0.2_arm64.deb
+    digest: 67e687906a183922d6e510666f7637c45946e68f61bc4f0ce7fc2a840aaff3e0
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6widget/libdtk6widget-dev_6.0.25_arm64.deb
+    digest: d77647f1b8ddc312041ad612cf3c1343bd3fbd8193b2a72e8bfae9ba64d4053b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6widget/libdtk6widget_6.0.25_arm64.deb
+    digest: 146b21a131932f6ced35c1b74c912ae9794b9bdadbdceff37babece4c9eb90bb
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtkcommon/libdtkcommon-dev_5.7.5_arm64.deb
+    digest: 11cf667515ce2bcbc7ac6ae27bafc324f6cea17772d8e7aa43cfda6288713e67
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtkcommon/libdtkdata_5.7.5_arm64.deb
+    digest: b468b48c1f8fe5b98f4294edbe3b757726fcefbfdfb79ab54d3adffc293d17cb
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libe/libedit/libedit2_3.1-20230828-1_arm64.deb
+    digest: ba394c531b520e3ee365d29c127505bce3554df15885dd53dbe9a9deee191326
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mesa/libegl-mesa0_24.1.5-1deepin2_arm64.deb
+    digest: e724f5cd1b97bacc4f2166cd81c970017ba8c57279c5d4879134ffc6b4ecd407
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libegl1_1.7.0-1_arm64.deb
+    digest: e545d436bd07777713063cbbafcb75c2e2581d2f04ec697862380caf2074c471
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/e/elfutils/libelf1_0.191-1deepin2_arm64.deb
+    digest: a3926debe22263846a70333372425e555a2ed796d44b8fe87eecd8116dedaf2c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libe/libevdev/libevdev-dev_1.12.0+dfsg-1_arm64.deb
+    digest: d2e39d9eadc5fc955478dbe6f1a66627a770ffbe8f165f1f8700934f8263e576
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libe/libevdev/libevdev2_1.12.0+dfsg-1_arm64.deb
+    digest: fbbe2a51d531e25bc6bd01b2a732ea480411f065940a2b581d47dcd98ec7fcc3
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libe/libexif/libexif-dev_0.6.23-1_arm64.deb
+    digest: 48a63cf58da3e26ee5ef2cc4542a4bf43c828f10e563993ccbe914d748240696
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libe/libexif/libexif12_0.6.23-1_arm64.deb
+    digest: 0286b248296c6e66e209cb3f9b365e8133ede3911089ee68d8030a2a5212a8a9
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/e/expat/libexpat1-dev_2.5.0-2_arm64.deb
+    digest: 06c39c3e78aba8616d2c7b43d7cc33cd60bcbfb7bc362e997b2bce1b24fd7460
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/e/expat/libexpat1_2.5.0-2_arm64.deb
+    digest: 2c66c6eb5bb8e1f8dbb6449e3948e3a75add01415561c10a89ac1b238a9a24b1
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libf/libffi/libffi-dev_3.4.6-1_arm64.deb
+    digest: 44b6f1a9aceead0cac121cfd13cdd9a529eb2b60522f8482c7dc4f67432d1904
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libf/libffi/libffi8_3.4.6-1_arm64.deb
+    digest: dd69564a592502ee67ae166c13d6d6a0a62021a47c2f3154589ed3bc62fe6b52
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4_arm64.deb
+    digest: 65fdd731df6fc44891d7c77da9d16717fd23df0d4251085dc0c43b4313e903eb
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fontconfig/libfontconfig-dev_2.14.2-6_arm64.deb
+    digest: d965d2bee11b03bb0b86e876a78f5f3b3f5ae3b66ed3f74a8baed4f1a2edb058
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fontconfig/libfontconfig1_2.14.2-6_arm64.deb
+    digest: 2088236fc9be4b0b363707d88c00eac4c082aa64f00c10f869c33884dee5772b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libf/libfontenc/libfontenc1_1.1.4-1_arm64.deb
+    digest: 222148f71812a1026457b2d86edfe68eac087f0063ab5e8159439e3d11793425
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/freetype/libfreetype-dev_2.13.2+dfsg-1deepin1_arm64.deb
+    digest: dc1cc27076ac172ffd75b7fe88d5889be20c84eb0dbbeeff2a29f24c84d965dd
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/freetype/libfreetype6_2.13.2+dfsg-1deepin1_arm64.deb
+    digest: 5363e03d3eb944c73fbc75e303cca2814077607480b2e7f7c9015d70aee31a27
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mesa/libgbm1_24.1.5-1deepin2_arm64.deb
+    digest: f43c0fa547c29116b1343f099253a24855539412e6b9a5ac3a80eb27b12cc01b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gcc-13/libgcc-s1_13.2.0-3deepin3_arm64.deb
+    digest: 79f939554ee45564dc0ccef376ce412f1f7a92c1d0d953e61c65de40b1b484e5
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgcrypt20/libgcrypt20_1.10.3-2_arm64.deb
+    digest: 86a50d1b85ed82764e7f356b2e3e5543149cc778edca29dae9765ddbc3789d9a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gdbm/libgdbm-compat4_1.22-1_arm64.deb
+    digest: d7dc16662376708bef84fd84bb79a769c443cfb2ce69e608c16c98f85080848c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gdbm/libgdbm6_1.22-1_arm64.deb
+    digest: ba32e543ec6296045f2680d23a890c315ab00c4a34201a7a55d3f72384518930
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin1_arm64.deb
+    digest: 67fb7f1a7f5bf707a6dcead0b5b044c1704f454c2a51050fcb020ea9b1317913
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libgl-dev_1.7.0-1_arm64.deb
+    digest: dc7f67af872323ece8087a4dfdd6106b9faa71d490447003ef964043066bb2e1
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mesa/libgl1-mesa-dri_24.1.5-1deepin2_arm64.deb
+    digest: a657f11469217681177afb16fe5189e4613f33781abfa91ea772bd0d92fdd185
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libgl1_1.7.0-1_arm64.deb
+    digest: 93917761c2f8cdc9dfec793a9e6aaedd05973aca3a19eb74f2d33e926c0d7c3e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mesa/libglapi-mesa_24.1.5-1deepin2_arm64.deb
+    digest: 90c916a34445b4fdb459cada39bdce3efce4b8048576295952016b5b94dd35ef
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/libglib2.0-0_2.80.1-1deepin1_arm64.deb
+    digest: bcd728365b170a9b2598f2c3a13a7b4b27bcbcc5c966610496f7a66c13d93394
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/libglib2.0-bin_2.80.1-1deepin1_arm64.deb
+    digest: 5306892a7f1ea756d7c63a92aa346da632b78072b44ce30cf5f0567e22d7d39b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/libglib2.0-data_2.80.1-1deepin1_all.deb
+    digest: 4e75a1c9e56c81ed2c1737e3e6fe590163a77ff45179101a4fcfb90b4c0d135d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/libglib2.0-dev-bin_2.80.1-1deepin1_arm64.deb
+    digest: 4a16ad0b756f1336f01999c1c55cd69bb576416f985bf0445c5f08cbc889ab96
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin1_arm64.deb
+    digest: 894d0a7818c905544b7114e8c7268a3c8dded4395d3d859bdcb774e546e7ac98
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libglvnd0_1.7.0-1_arm64.deb
+    digest: 3eaae06ffb183872a95c2c966050099ab9824b50ccab6802c1fdc95a7f6b25d5
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libglx-dev_1.7.0-1_arm64.deb
+    digest: ef37a90a94a9e4ba16352663b2703df57e3816e406eec0225e6339a91ad498fa
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mesa/libglx-mesa0_24.1.5-1deepin2_arm64.deb
+    digest: 32dca1addaca5c867106d908bcd58e08ecd1df65447a774d0a41d338cea8b76f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libglx0_1.7.0-1_arm64.deb
+    digest: 41d194b986ca2e07171948e6b0d09b2b51f068117ae2f0bd11105e0c7cae8d7f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gmp/libgmp10_6.3.0+dfsg-2deepin0_arm64.deb
+    digest: ccfd8cc3ef27d1a32ddb9f3a57f05ee35576482f640532be70dddeb98395193f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gnutls28/libgnutls30_3.7.9-2_arm64.deb
+    digest: 88703de5a0a7bc5c03730e2de61ae40894fa6f4d6d1f89def93ec44055c6771d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gcc-13/libgomp1_13.2.0-3deepin3_arm64.deb
+    digest: 894e50ae04621a65bf49f140666a798f2b39ccc22b980a588d056ad20bcba348
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgpg-error/libgpg-error0_1.47-3_arm64.deb
+    digest: e67f481218dd4fc506bb97ebccacbbd39e5420caca6c71ba011b1efcc0f1f5a0
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/libgprofng0_2.41-6deepin4_arm64.deb
+    digest: 24f98baf5394f7976a7f9f41b9acf40df8983090e1f24b35fa66a53a0d10e0a9
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/graphite2/libgraphite2-3_1.3.14-2_arm64.deb
+    digest: bf8f6e987ba71ddd6161066f0828663b4ffc4af78acbdbff04b71e5c2b1e207f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/krb5/libgssapi-krb5-2_1.20.1-5_arm64.deb
+    digest: e09ffd8646be9798699b1324b7d6292382f7c8c3665fbd0a6aed4536561ff06c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgudev/libgudev-1.0-0_238-2deepin1_arm64.deb
+    digest: c952bbe64709d944821b367c5c211af4447ddb59f58f1c2b2fa264ab234890bd
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgudev/libgudev-1.0-dev_238-2deepin1_arm64.deb
+    digest: 97b751c1e82af92962c3688f1bc9c0cdded3ea5bacc43d478f0780d22f8d6e6d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gumbo-parser/libgumbo2_0.12.0+dfsg-2_arm64.deb
+    digest: 1af178c5a43fc3f1a40d90a4890bf8a00372449495bc32e6ddd82165927b3591
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/h/harfbuzz/libharfbuzz0b_8.0.1-1+rb1_arm64.deb
+    digest: b50ec89e04006c13764afac632d9fd4793c187d20fc54670018f76241fbe8495
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/nettle/libhogweed6_3.7.3-1_arm64.deb
+    digest: 0caf1aec7651bca8c8c0646eb87b064e522fbdc654edebc8c7e10e0a12f77c94
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libi/libice/libice6_1.0.10-1_arm64.deb
+    digest: a1910186258a924c4367673da786e7200f32e54ea54f65e2b885e3e451197e0e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/i/icu/libicu74_74.2-1deepin0_arm64.deb
+    digest: 1c4e3bdde2f6491c580aa9ffd47e42c5ac310614b9f042f9bbb40a10ec5a4367
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libi/libidn2/libidn2-0_2.3.2-2_arm64.deb
+    digest: 66be80634fd2243b4741bc12bf02ae140d4af694da58e23415130322eb8e17cc
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libi/libinput/libinput-bin_1.26.0-1deepin3_arm64.deb
+    digest: 0c312f699653f007733afd743554d7200cc43d9fa3d74ba23622165f75cf23f0
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libi/libinput/libinput-dev_1.26.0-1deepin3_arm64.deb
+    digest: 18bc7373f096e8017e59bfdeb551589ca0fe341dbbba016b2d648914770fe3e7
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libi/libinput/libinput10_1.26.0-1deepin3_arm64.deb
+    digest: 9a6aaef5f1bd4c34230d194a5d13354b0e614fe330d77bee0c293b9a627ca752
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/j/jansson/libjansson4_2.14-2_arm64.deb
+    digest: ef540161f4618cca67a1e5c14ff7e1531f85b8066ced54f873e249bbd89287de
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/j/jbigkit/libjbig-dev_2.1-3.1-deepin1_arm64.deb
+    digest: d554b612e70c2416c6d831b575c1bc1c3f4c0143454ada80203e08f918143e77
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/j/jbigkit/libjbig0_2.1-3.1-deepin1_arm64.deb
+    digest: cce7a06a6c026ffde094ac6555c1feff1763121dd88bba0d2977bfa59cdf403b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libj/libjpeg-turbo/libjpeg-dev_2.1.5-2_arm64.deb
+    digest: 7eb0cf9914476bdf669f0087c7fcba1d0cfd49f9697804d72fd2869e6fc3ecf6
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libj/libjpeg-turbo/libjpeg62-turbo-dev_2.1.5-2_arm64.deb
+    digest: 4355b250325f762945b8d68dbb1e39fd0847230f9bf56284c35d4a69aa819e5a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.1.5-2_arm64.deb
+    digest: 127ab1d74ddbf0f1620b8a2b907d9160a359079c49fdef8e07ee6ef795b502ff
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/krb5/libk5crypto3_1.20.1-5_arm64.deb
+    digest: b25339e6e18dbdd4ea57d508158d999a86e539045789a5885667c6d6ecb81c9d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/keyutils/libkeyutils1_1.6.3-3.1_arm64.deb
+    digest: 91223dc8480403e5770986e2fd73b8a92ce1e74b9f52b442616cc3ef0ff59dc7
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/krb5/libkrb5-3_1.20.1-5_arm64.deb
+    digest: 32e10af6aefa67b71ea312c55b8f9a3f7c016d1edc6bd30907ed38ec27aef8d8
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/krb5/libkrb5support0_1.20.1-5_arm64.deb
+    digest: 50aefca2b75fd2478e62ac9c7c5571e7e510ffa697207e78e29bfa6d40f3271d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lcms2/liblcms2-2_2.14-2_arm64.deb
+    digest: ce6ca7ecc06a131d36a0cf01b7e0a2774bc0b75abc8c29aa432a6c6ed2d2ba3f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lcms2/liblcms2-dev_2.14-2_arm64.deb
+    digest: e0454d960ef62b53fea41da4f5abb52173811dc4aac4c255f6938081a1d30e68
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_arm64.deb
+    digest: 1084fe140088878214dd72f6c8ebf4f4835b83f542ed443ce79cc2f43821d6d9
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lerc/liblerc4_4.0.0+ds-3_arm64.deb
+    digest: b2510d375b08fc5b324dcc39a234971675c787d7b9a5cdfcbd8fbb414f9549e7
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/litehtml/liblitehtml0_0.9-0deepin1_arm64.deb
+    digest: 82d472f20711c3b0eee4afb2b8bc8a0971f6fb7ced7612317f07597768e6ddad
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/llvm-toolchain-17/libllvm17_17.0.6-5deepin5_arm64.deb
+    digest: 7faa4f0b4e3c95e4f0fa1ef4bc52329dbed095bdf87d495d0f8c21b934c78319
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lz4/liblz4-1_1.9.3-deepin_arm64.deb
+    digest: 9de94343c0eaf87ec1b298d8f5dbfe42f06316f8dc608968e0718437035c1ee9
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xz-utils/liblzma-dev_5.4.5-0.3_arm64.deb
+    digest: 0e91a2383f5ab980fb06cb347c66dc6b6480a7b76cb67ded44bb4b183f295d21
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xz-utils/liblzma5_5.4.5-0.3_arm64.deb
+    digest: 89bd6cb9e9f756b25b0e973012a88d2df0c273c0dc44ab0cbc2a0bb6b773ba55
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libm/libmd/libmd0_1.0.4-1_arm64.deb
+    digest: a1f7a672a07a62b85c2651bdba09552498db565da6ecf5748be618812124acc2
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/md4c/libmd4c0_0.4.8-1_arm64.deb
+    digest: 8b58cf124cb0a435765f6cbc7bc8a59d431a8f84babbc2956beb1a46b53b99f5
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_arm64.deb
+    digest: 15763cf880b4073ba036e05f2a3b9b46aa43802f9d2c49848fd315a9229d9be8
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libmount-dev_2.39.3-6deepin1_arm64.deb
+    digest: e04e69e0e1079164c9625eeee3c2153f7a642c4dcc270c0e9a0aa359e3127d09
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libmount1_2.39.3-6deepin1_arm64.deb
+    digest: 34cacc70e4fb7db8f0fef17546f574e900975b0b6136ffdc8b79e0840ba9009d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mtdev/libmtdev-dev_1.1.6-1_arm64.deb
+    digest: 17fc6b739d5d25e6139f8786daa9ac90b81315dfde9df401d7a8896831bc1828
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mtdev/libmtdev1_1.1.6-1_arm64.deb
+    digest: 646172dd88b260728ef1da45a78d41c78161a8341d0ce43de738c63f2e4089ca
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/ncnn/libncnn_1.0.20240820-0deepin2_arm64.deb
+    digest: 623d4b99b83d091b82e9122c3b6091e89ea0d11fdc07bb4f91355fddcb84fa72
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/ncurses/libncursesw6_6.4-4_arm64.deb
+    digest: 4919576b45fe077f2b0f1365cafa0abb0cd29232a6bb2ffa4016df8926c64ce0
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/nettle/libnettle8_3.7.3-1_arm64.deb
+    digest: 94f6240b06e89b83e43b85f3ac482f57468f7b78b3a356f692a9a2508b4b62f2
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libn/libnsl/libnsl-dev_1.3.0-2_arm64.deb
+    digest: f6267e06818bde69c32fcb07f15807e9c0240561de3c4bbe90e1cc4189a12d22
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libn/libnsl/libnsl2_1.3.0-2_arm64.deb
+    digest: 08c95ea4d7177490751748ac26160236580dd2351a4e8ffdb57774e7874a40a7
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/community/o/opencv-mobile/libopencv-mobile_4.5.4+14_arm64.deb
+    digest: 0836b275f8b55b241c8f722ea94c2a6ae46a5779b0072157ce1c60df8fffac0b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libopengl-dev_1.7.0-1_arm64.deb
+    digest: 4183274244acfc897705999133091b52af3c9c1ec54ed4b67319e9b044281434
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libopengl0_1.7.0-1_arm64.deb
+    digest: 84392d66b03e40078cb2fc079e1a3b8bdcc5d6606e24e9846b552ee73e2ffb03
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/p11-kit/libp11-kit0_0.25.5-2_arm64.deb
+    digest: a8cf0f0f9be1f016846baa4b2d2012fbef8b560dfc3cfa920b3d8ebb920038a4
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pcre2/libpcre2-16-0_10.39-2_arm64.deb
+    digest: b417f72e1d3895f3350645ac7f10859246808db988273031cecc41fbec6f567c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pcre2/libpcre2-32-0_10.39-2_arm64.deb
+    digest: c50abb1ce61a1a2d6a3ec98848f179da3b9e000672f7278f0f1c865cb998fb37
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pcre2/libpcre2-8-0_10.39-2_arm64.deb
+    digest: f721d2c4a9224b106c26b793af1f4a0c884184766e8e3d005369b4f265e0637e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pcre2/libpcre2-dev_10.39-2_arm64.deb
+    digest: ba71787ac1c892e4b8fe9aa1544ecd81a7d9436538c3bb28b0d710fc391143d3
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pcre2/libpcre2-posix3_10.39-2_arm64.deb
+    digest: 6bb5a3b25014a1b3d0daff71338861f704defc4a1d7d5a2896b58604716914f3
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/perl/libperl5.36_5.36.0-10_arm64.deb
+    digest: efe41ac688ac3c99eb41a36854ac9883e877d0b5f0a52a844b752ded579ebc57
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pkgconf/libpkgconf3_1.8.1-4_arm64.deb
+    digest: 225ac12d1f1dbf507b8b994fcd0e127f24287b2f5cef5a2b86d85677c8576ec9
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libpng1.6/libpng-dev_1.6.40-2_arm64.deb
+    digest: 9fa36c78edb32a573134c374484986e40a8a69867676919726a14264e1658a02
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libpng1.6/libpng16-16_1.6.40-2_arm64.deb
+    digest: 2c5ca3dc54e748c3b7df0a89a2f1e2379ed60ead17d15a6c9cb18e0bf706dc3b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libproxy/libproxy1v5_0.4.18-1.2deepin0_arm64.deb
+    digest: 641e0a94a253612ff4e7be672d7ee28f5a9c98e263a5f065d9e4cf47dfe00681
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_arm64.deb
+    digest: 3c2fef66a85ca8d8219283c1402eb66500b8587fa4f4495d327515e12b71e710
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3-defaults/libpython3-stdlib_3.12.1-1deepin1_arm64.deb
+    digest: 94be53c10a1ed8538483d1dbd426700ff5a79ffffc7632c3a3eee0cd9ba2e869
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3.12/libpython3.12-minimal_3.12.4-0deepin1_arm64.deb
+    digest: b7e82676b670321d2d402bf6cfd9f8b031d1e25711409981609d86c11ce66395
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3.12/libpython3.12-stdlib_3.12.4-0deepin1_arm64.deb
+    digest: 7aa6784e459332f64d348c4d2e8d2f78ce167651d2be6361bd4e993c0923aac4
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin5_arm64.deb
+    digest: 4487ef000bab280d24e5796107f266dbcc7bd98da9107fa46622ec2466c7b16e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin5_arm64.deb
+    digest: 8e79cc85474e16b11086c3943e9f68ba2980cd02c25126441d5787a9cac9f126
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin5_arm64.deb
+    digest: 7b23577876590b68e561e40905d17bdd102d05ec005bd3f3aa02085435f729c5
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_arm64.deb
+    digest: 82c28b84f82cbf7e3d9098c0f856b955e811a65b1fd42c8515711aecd05fb894
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_arm64.deb
+    digest: c183e82838d5b340b4273253e90667078512862e1f8e9781b72b7ce048bf54d3
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin5_arm64.deb
+    digest: fbc7604f9d54ffef67fac1b67eed229d14ca15d06a45984e316768b7c63bd930
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_arm64.deb
+    digest: d725d7423abfc45ea48abf3d9cc444b95af145636802254bb44565f31d4d4245
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin5_arm64.deb
+    digest: 34ef8390fb279d048e66d691572247d54ea7e04222db0507c44ac113914c0cd8
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin5_arm64.deb
+    digest: 2280d74bd82b5e9d3a065c9acaeedc7d9f3c222517588c7777a62de2b30ff51a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin5_arm64.deb
+    digest: d79ad717b4275bb2dec400e7fa3ae8045c4d93b38fbc5a9c5eece9e9d7d3d14b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin5_arm64.deb
+    digest: 0a2c121bca7a1b60607aed1855b50fd2c630622bbb2f4b9fe5362a4a187893eb
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin3_arm64.deb
+    digest: 8c18da39ba69ceef945d4c64e3a0e62a1bdcbe2b41921ead0aa08f4cc52c459e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-declarative/libqt6qmlmodels6_6.8.0+dfsg-0deepin3_arm64.deb
+    digest: 27a13b40585767a4e67f2aecfc130574be84c8f42b086c3479aa4aa178465dcb
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-declarative/libqt6quick6_6.8.0+dfsg-0deepin3_arm64.deb
+    digest: 19c0e1c50056e4bffc43d46122f7661ebb8985750066dc772884cf1196ef1f44
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin3_arm64.deb
+    digest: 9e46187cdd05eae2b1113623f827e080aa663da7919c1d87b44dbb03792b4dbf
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin5_arm64.deb
+    digest: 1f084ff72c612db83096eb3dec73f6101af9fe977f3376badf680a07926ccaef
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin5_arm64.deb
+    digest: b8b4da1591cec015ace3dd8953ccca06f19f3430ddfc39faadcc6a65eda21965
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin1_arm64.deb
+    digest: 9902fd043a3e62bba9f7d13edccd49a25d8d17ffa0ec5cdc761dd7a5c0d8b63a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin1_arm64.deb
+    digest: 34f386ccca09b000fd6621ede73daa2fac0b94f8fd9af514767a94ed39a15bf7
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin5_arm64.deb
+    digest: a69495c011e5db7fd0552ffbe180cfb43640c35271ffe21be3bcf44053ff72b8
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_arm64.deb
+    digest: 75ef6edab7f429e473a3f73bed21049eaa774f3e6333cc583e55b1f6bda9f016
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin4_arm64.deb
+    digest: 5b45baf715d8ee4a73b7e018ab9558efbcfd7e284a6da9082b9d83a0481af8b8
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin5_arm64.deb
+    digest: 3f27c16a00798b99ae45f723331d3601e3c3741e6041a0ea4bbaec0ee7873c16
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin5_arm64.deb
+    digest: e1cdb4a74a5f30c6580796070a19e575e0f6c5f9467c5f1c9561bb113cf66d78
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libr/libraw/libraw-dev_0.21.1-7deepin1_arm64.deb
+    digest: dab85604ce19abe1ff453ea7be578a1467305bfabb6123f98a773deaed919016
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libr/libraw/libraw23_0.21.1-7deepin1_arm64.deb
+    digest: 59fc3963d505de503d87e672ada94960c4b0548aad5229937a7533f507b870ba
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/r/readline/libreadline8_8.2-3_arm64.deb
+    digest: 9bb27a75806c579d3ec78f6a455fccbd771b345a4b72014614392cf835a249df
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin2_arm64.deb
+    digest: 503a2e758120d6eb2225f02eb4f509ed636560c343e42a685b68a74345c7c11d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libselinux/libselinux1_3.5-1deepin2_arm64.deb
+    digest: 9a9a27dec46d935b4ae8318b26d91c347e2adf9d6e7904f4e465c0ccfed535bc
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lm-sensors/libsensors-config_3.6.0-7_all.deb
+    digest: 164115506dfd335f26101e76cb49e2162b0440398ccf2d0c969ebc465dfd7867
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lm-sensors/libsensors5_3.6.0-7_arm64.deb
+    digest: 1d958884723ef414ba8ac8c05701ec36cbf81ac586ea2b5a2a042b3efd0f2342
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsepol/libsepol-dev_3.5-2_arm64.deb
+    digest: c55790b3f227a9f9b3736f40c03c8881adcf60732ce7be9a04c7b79fed7240e4
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsepol/libsepol2_3.5-2_arm64.deb
+    digest: 2b1f781c87f8381b9cb83ae410f7607c56e42cc15c1c5d85cc2ef9c0364141c7
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/libsframe1_2.41-6deepin4_arm64.deb
+    digest: 930fcc8a3d3ff4200dd9a39b1bf61d0422cf9754d31787776412fb1f605232e4
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libsharpyuv-dev_1.3.2-0.2_arm64.deb
+    digest: d989b877a836aa9d00d3d211dec9ecdbd06a1a18bd5683f154ad12c42f8b5bff
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libsharpyuv0_1.3.2-0.2_arm64.deb
+    digest: e3544fe81f21e00b53d6b9bf1be9efbc2aea360e5e074d726832f228db44cd82
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsm/libsm6_1.2.3-1_arm64.deb
+    digest: 04dcd31830a75668f1114bff0dd08033af565b7f4f05cdb411d101ccff99d6e3
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_arm64.deb
+    digest: ffeba610e1f0ffa299499d88562b65eece4f9865d8810d3a6194ff5d2cd02b38
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/sqlite3/libsqlite3-0_3.46.1-1_arm64.deb
+    digest: cae5a428e02558cdccde604a755eb1fb983a252597224050f4683437147e6af1
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/o/openssl/libssl3_3.2.0-2deepin2_arm64.deb
+    digest: f7644a7984de1e0c7d867c5794537d7df6f0ee634850ed607a3098d3368cc163
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_arm64.deb
+    digest: 6afa3a2ae947564d05b220d89298c7e6e1f875cb05b4ed1a9a450be99a3ba47d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gcc-13/libstdc++6_13.2.0-3deepin3_arm64.deb
+    digest: 8a8f599b667a55f52af1059338cbe93cc1415301cd688f6cb206e6efe5b34736
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/sysprof/libsysprof-capture-4-dev_46.0-1_arm64.deb
+    digest: 41ff44785effab7f081c3d4744d9e9cf25e374c13a00ab8ef93052a0a4d57114
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/systemd/libsystemd0_255.2-4deepin3_arm64.deb
+    digest: b30e099836df2bc77e96a03c45fffdd484de29c357009cccdf95b692259f046b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libtasn1-6/libtasn1-6_4.18.0-4_arm64.deb
+    digest: a193d7e19d36227ab39cc199ed2601bd6bbb91baddaa26dad3a2530288a57cab
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tiff/libtiff-dev_4.5.1+git230720-1deepin0_arm64.deb
+    digest: e540263bfa05d263acc1f89a45a416399ac8b02a2837ab5de3c23c7de833410b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tiff/libtiff6_4.5.1+git230720-1deepin0_arm64.deb
+    digest: 761b852f1061b80cedbb6a60415d883c0ed00b027a773786c2ebb88d0f5c8b7d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tiff/libtiffxx6_4.5.1+git230720-1deepin0_arm64.deb
+    digest: 357960be12d31ebc9f21ab28dbd3ac650fcdcd35c9246d23070d8b4af1850580
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/ncurses/libtinfo6_6.4-4_arm64.deb
+    digest: fe1fa74066ca1e08a176095b1aa5b6782e427a10c30650e33b189e7a30da9436
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libtirpc/libtirpc-common_1.3.2-2_all.deb
+    digest: 74bddc18e3289947b20653433e82025873f5679ccba52f258ca4912e435a09ee
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libtirpc/libtirpc-dev_1.3.2-2_arm64.deb
+    digest: 02edc284e6a4be67f3bc1bdd8660f0a310ca8901c583cd18542450cdc947ebc3
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libtirpc/libtirpc3_1.3.2-2_arm64.deb
+    digest: 917ce3bf402df16ea74ccc1f67e1b1d97b09286609087461dd09c9c265f694c0
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tslib/libts0_1.22-1+rb3_arm64.deb
+    digest: 790a0e469c3b174d03eb0eb64f4a69ddddd95ddfd4b8daf930e4b4ac7cde179b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/systemd/libudev-dev_255.2-4deepin3_arm64.deb
+    digest: 43a672ea158c20ea80ce9f3181d219646455d04f9582ee796976688c29f0daaa
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/systemd/libudev1_255.2-4deepin3_arm64.deb
+    digest: 0061474a0f2cd7e2645c49e354f3bec5fb471bee654c194edabdaa927d926d25
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libu/libunistring/libunistring2_0.9.10-6_arm64.deb
+    digest: 55c2f09476f2f0e2949afdab39939e5cb62cd99976bf36ee189011e34553b06f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libuuid1_2.39.3-6deepin1_arm64.deb
+    digest: f085d875204b2c41158ad83c96da354d4ce53c724106857b861cca425170ed2f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/v/vulkan-loader/libvulkan-dev_1.3.268.0-1_arm64.deb
+    digest: 358dfa214cce0157b019b7f2016e7a112c6461a708e2e8d54af0d2b25c26feda
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/v/vulkan-loader/libvulkan1_1.3.268.0-1_arm64.deb
+    digest: 3f4142af12fb84600c5f5b9458f7fd06d28ff6f7f5bcafff4c507624d16e3126
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwacom/libwacom-common_1.12-1_all.deb
+    digest: ae18d0c6d1b68084756ae6a5ca4d4d680659ad6a9e5384bdbb49de48ffb75bd8
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwacom/libwacom-dev_1.12-1_arm64.deb
+    digest: 3d5a7ebd49f242956b1058290b1a909c4b5e687529d3b4e8530c1556f3d99b40
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwacom/libwacom2_1.12-1_arm64.deb
+    digest: c07692f2fda707855dbdd2f4586f8f1acf5b9cfc9618db7c08bf3442e4b7af3a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/w/wayland/libwayland-client0_1.23.0-1_arm64.deb
+    digest: a4670daba8af6be69669976cad828b8e161c15f2707a4dfd2a67e7e1c56e775c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/w/wayland/libwayland-cursor0_1.23.0-1_arm64.deb
+    digest: c055857df620bf9ae756fdb5f55c8aad8a74d32eb26fe4a7d8df5e97589cdefc
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/w/wayland/libwayland-server0_1.23.0-1_arm64.deb
+    digest: 4f70d6062b322d7a3fd0a56c01399b5e24ea2dab26b1a5530392b26ac315d1a5
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libwebp-dev_1.3.2-0.2_arm64.deb
+    digest: f783e2d15596e657a9077db7a3dd7e8de84360a27ab504644069df49922a9545
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libwebp7_1.3.2-0.2_arm64.deb
+    digest: 72524d566f18c5461925b1bb5d352d312034f118bf5b039d76f248a682c64449
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libwebpdecoder3_1.3.2-0.2_arm64.deb
+    digest: 9115ed02a3d0d9de956bc1474b608f922aa61feecfd27e267d88e2687caa19b1
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libwebpdemux2_1.3.2-0.2_arm64.deb
+    digest: 55519f654e68fcbcb5aecd7812a217b8ee836e7f6372487571a355b210f07224
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libwebpmux3_1.3.2-0.2_arm64.deb
+    digest: 5473ae2903e00b0fa112a226da1db479e7ad8006ef170a650a4292704f5d9723
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libx11/libx11-6_1.8.7-1_arm64.deb
+    digest: ac2d623345cb425a3c38685f0b2d61022ac9c4092a141099dcf818d8361e7d7d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libx11/libx11-data_1.8.7-1_all.deb
+    digest: 400aaa7eaab268850d8c2c512474228204d47774f2aac79cef29d1c125e0c656
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libx11/libx11-dev_1.8.7-1_arm64.deb
+    digest: 1c6d4a10271b55eaf39aa83f76851047669a842f2c15b18282f2851bf29644d0
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libx11/libx11-xcb1_1.8.7-1_arm64.deb
+    digest: 6293185372418e4f14c17d5c4d14cb631ecb1474be1b3d81d00a61f984bef922
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxau/libxau-dev_1.0.9-1_arm64.deb
+    digest: 28ba4c91230a4d8e3caa43b0897bc56960e5b07eb6e8297ddfe3d57c3514457e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxau/libxau6_1.0.9-1_arm64.deb
+    digest: 82a1fcfe359eeb57e4c0dedd434719360650ed2423d08af807a06d0a0ba91bae
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xcb-util-cursor/libxcb-cursor0_0.1.1-4_arm64.deb
+    digest: 3e5079ca95b7a9f560cd332344e808d35a4cc1d90b57737abd43c8807fd9cd93
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-dri2-0_1.15-1_arm64.deb
+    digest: 76c404684ca22486f102a44dc00bb8c0240aa02dcbf321f9733759da84fd4286
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-dri3-0_1.15-1_arm64.deb
+    digest: 66f3b86e8de5a56edf32de02641ad515380cf3fa84d219523c2a04dd7d2bd602
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-glx0_1.15-1_arm64.deb
+    digest: 8f251424b4a32ab7b0341578f3421c3eb15d25362117994350a6786f0b251f00
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xcb-util-wm/libxcb-icccm4_0.4.1-1.1_arm64.deb
+    digest: 58945d6723d8d5b00b0524877f5dd8c4cd4292ff73c561d72feb68f46e1acc42
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xcb-util-image/libxcb-image0_0.4.0-deepin1_arm64.deb
+    digest: 15b4c9739300d22125e53ccd84636ed156d0df2b62b49519649aa2076cd0c343
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xcb-util-keysyms/libxcb-keysyms1_0.4.0-deepin1_arm64.deb
+    digest: 1044daab8cffa74f4c4dcbe8009ba2efa1cc9b5dd4dd615b0ef1207d3feed915
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-present0_1.15-1_arm64.deb
+    digest: 4eb85646303b49b352e71e9c83e41ab3d66bf6729728e6b0a5545e9383a10c7c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-randr0_1.15-1_arm64.deb
+    digest: 57ae90f4b2a203258755300a18e6cdf3bdd30055b49f2b2931d76e4f39930691
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xcb-util-renderutil/libxcb-render-util0_0.3.9-deepin1_arm64.deb
+    digest: 1cc4fbb689677ac40edd81fdf7fad185847826720e9b4a974b4de4fa505ba7a5
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-render0_1.15-1_arm64.deb
+    digest: a94a481050202abd6227bb5df04eebd5d41243c51ac611490f79bffc9210d56a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-shape0_1.15-1_arm64.deb
+    digest: 02dec7d7fa38f1a3bcc8df6f3d3882fe660e5e84abaffd73055d495b558fae7d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-shm0_1.15-1_arm64.deb
+    digest: 8270f8631c37a5ce16edb733617bebfdaa4bfe0d9885a95b565ac39d76c7dba0
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-sync1_1.15-1_arm64.deb
+    digest: c447e06e8318215b440f20992c69647cee90c31d9158cef9f16ec00424f7f509
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xcb-util/libxcb-util1_0.4.0-deepin1_arm64.deb
+    digest: 18e3bc7f50b606984f78dcd7f2a137f68a8fde96ef17da18c7195242f1313c84
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-xfixes0_1.15-1_arm64.deb
+    digest: c3c442fc82728a145e47ff2ce37bf173cc96bd26dc3329f8eed3daec2d47c211
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-xkb1_1.15-1_arm64.deb
+    digest: 0386603371b588c01d5d5114b96c0a05c62b9107ee8033807a9c14e8e466da98
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb1-dev_1.15-1_arm64.deb
+    digest: f655f75fb5205cb90667bd2e1b1c08ccd93e0f937d1b4124b10afbab5bd4bc54
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb1_1.15-1_arm64.deb
+    digest: 6a66b765b483884d4a8edb62dcbca87acae889488fba889b8e631982d0e35467
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxdmcp/libxdmcp-dev_1.1.2-3_arm64.deb
+    digest: 26b4210ed6ce4e5d1dc2f766ae3b47dc36442294c8b7e8eaed61da9792f76130
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxdmcp/libxdmcp6_1.1.2-3_arm64.deb
+    digest: 1ac4558b1438d14fbc93d8c969bafac2ac7cfe4f4ec609d6ef34a47d73eda2dc
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxext/libxext6_1.3.4-1_arm64.deb
+    digest: 1018afc359feea593e136caed0273075e2d92aa9848bbb63b70fd55730fc4046
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxfixes/libxfixes3_6.0.0-1_arm64.deb
+    digest: a7bdf32460674bb76bb938273beac4003841dec058b335a609884287cf8d5326
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxi/libxi6_1.8.1-1_arm64.deb
+    digest: 7469379eee4164ad50e2d1369cff5f8394b1da88c92fac8f04fee521da5634b7
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxkbcommon/libxkbcommon-dev_1.6.0-1_arm64.deb
+    digest: 941544912030ac7a4ef2b1c3944932245be753179c8b83f93f2ecce2286ad833
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxkbcommon/libxkbcommon-x11-0_1.6.0-1_arm64.deb
+    digest: baaa366b8142ee3eac7bb178b46096caf39bcfb7b4772857af8b795d2dc6cd29
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxkbcommon/libxkbcommon0_1.6.0-1_arm64.deb
+    digest: f17db6332bf3598ce69a9e82ead1270c456976d1313365c0f4b2414a919338da
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxml2/libxml2_2.9.14+dfsg-1.3+rb2_arm64.deb
+    digest: 821afd2170d402ff5a6f4cf852f27b329dd267a2a3d8ef10a0dd84c034ba83df
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxshmfence/libxshmfence1_1.3-1_arm64.deb
+    digest: 60d857474c350e734ae71d52d2f178bb094040eee606ad3b492e7bad7d105e35
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxxf86vm/libxxf86vm1_1.1.4-deepin1_arm64.deb
+    digest: 03c6008b099fcb1e65cb6616159d20db0bdb71c201ca864f7b88e54e82d8541d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/z/z3/libz3-4_4.8.12-deepin2+rb1_arm64.deb
+    digest: 0ef6e252cc4bc0db0aa9ac30c918a210d8abcdcd059f4c5f7cc6d6cef7b10600
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libz/libzstd/libzstd-dev_1.5.6+dfsg-1_arm64.deb
+    digest: ca9575f6503945c733c4dc2ce78dee09745bdb6eef34f631212d2311e1d635f1
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libz/libzstd/libzstd1_1.5.6+dfsg-1_arm64.deb
+    digest: 36724ed79e7cc83e5357ab2f3e8c2ca75362b5352611bf5bc3c54289191f3e02
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_arm64.deb
+    digest: 467675c0f4007bad669a8fefe0ec4ab45f1d356f947afd7aabba2f17b88401fb
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/linux-upstream/linux-libc-dev_23.01.00.41+STE_arm64.deb
+    digest: a82c1e4813646205565ce061878a2a4b044fb2c01fbe310f2e42baaf840147a6
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_arm64.deb
+    digest: 0e32f0eef7e7f5effe89929ad9a1c14a2838e5033fa9142cf0b3e6bcb81f8573
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mailcap/mailcap_3.70_all.deb
+    digest: 7ca67d118c03eaf58346eb1e676ff16f4d1aa5252a8cc6b5b3b1ed44556180f1
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/make-dfsg/make_4.3-4.1_arm64.deb
+    digest: 5605fd4da45b98e233ed57ac481699a81a65c06194983be07892ff1a60be0c76
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/media-types/media-types_4.0.0_all.deb
+    digest: cd124053950ab8b0373203bceb7eab841791017daf1d50db2ece09e4da52406a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mime-support/mime-support_3.66_all.deb
+    digest: 20294deda4378616c2b48614ee226731ec09663c3497c35a467e8ea5fa03f16a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/netbase/netbase_6.4_all.deb
+    digest: 5fd05a5d63864b96453ba55a4c5efa287b8e7e53fbd833e7a944e066d30e1eb1
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/patch/patch_2.7.6-7_arm64.deb
+    digest: d69d6e60753f09647125fa0991f7bda438f75c33708a9ca01dd6f1b6b87a3bd7
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/perl/perl-base_5.36.0-10_arm64.deb
+    digest: 304683781e224018ad5ded38b86cf929281ced3eb79e456761479b7db9dbf641
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/perl/perl-modules-5.36_5.36.0-10_all.deb
+    digest: 907542b9a413bd0276d5ef94fef77083715a692fd33c52ece44d11fff847bab0
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/perl/perl_5.36.0-10_arm64.deb
+    digest: 78c75ef3cfd45150fdae9a88e5fca3d7d5c2b1f4d1ad84fe914a3aa0bccfe77c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pkgconf/pkg-config_1.8.1-4_arm64.deb
+    digest: 8b40ce5f7439c482fa8800f2a60160fb34fd46492d8ed397480ca0471b7fc9d8
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pkgconf/pkgconf-bin_1.8.1-4_arm64.deb
+    digest: fb3f32b7b567509b63afab51fdf5afbef9f9af569f10aac490b98d34feab8670
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pkgconf/pkgconf_1.8.1-4_arm64.deb
+    digest: 141f5145e6adf2f9519d95a6e4ec3b1410e829621777b48c7c48bc02bc779c40
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3-defaults/python3-minimal_3.12.1-1deepin1_arm64.deb
+    digest: 2456806adbaacfe2d195ee74a70141e692fbc364152c5f7a19d36697a518ed8d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python-packaging/python3-packaging_24.0-1_all.deb
+    digest: acf9e0347764b07624b219b64fa7721705d6eeea5a98871f892aff3ab0293ae4
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3.12/python3.12-minimal_3.12.4-0deepin1_arm64.deb
+    digest: 836c3af36831db46782bf20488cac27e14f2ce63e4d186c9cd8972593dc47056
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3.12/python3.12_3.12.4-0deepin1_arm64.deb
+    digest: 0ce1f946a32af79b183fdb194c49a21742209a5c4b123608de8f39443f9a57ab
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3-defaults/python3_3.12.1-1deepin1_arm64.deb
+    digest: 18b254c8a2ea4801a79cab3d7946d9730e41360e251094765cf8c4928f448a23
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_arm64.deb
+    digest: 2608678aef17e7c03c4b1fc3f3e8e10b91c7ec523471e4e4cd7790be50ef8a40
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin5_arm64.deb
+    digest: 01b961cefebb3c8c0f30ffd65c461f0000340eb4413763f621a42b41418eb905
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin5_arm64.deb
+    digest: 3b73805c92b8937fddc76aeaae447efca88be5c4edb906dbe86185adc47da0fb
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin3_arm64.deb
+    digest: 3f2442b73e48918050635d141f1ea8112442ff9217e92bd998bc9155ad201411
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin3_arm64.deb
+    digest: 96f2f1d1953e3a48542911d7d13f179fc9e7766a462f5941a995f56455c9fc63
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin5_arm64.deb
+    digest: f1c60c7ab3ec69c9fd52a1d42fe8afdb1555e7e54bca71f417e48908b8868038
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin5_arm64.deb
+    digest: 65ffeb095fc0fb17977dd797bb410d7a401f94e8dfb981813a3e6af39c54b7b2
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin5_arm64.deb
+    digest: 3c69f6dc4b35a09be2f9d76b42be9d47a633fa223a34119dbdf33baca1fed658
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_arm64.deb
+    digest: 719086d3983481e4d78e4c7424a796831db3925c1ca6b3495513e9cde674565b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-imageformats/qt6-image-formats-plugins_6.8.0-0deepin_arm64.deb
+    digest: 4e4323c9a9a51342c64424187e92f7653a7aead8899f523561bc2bf8215ed513
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_arm64.deb
+    digest: 9265848cc3a9da02d8de859a7705604e75d2baef2fc16cd243485e56f15ccf5a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin5_arm64.deb
+    digest: 87651591e1fd396c4af3a4073c2ae33690e34706110f882a05d984bdd895a2f4
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin1_arm64.deb
+    digest: e6732e7d1132d2a84254c8868b2c4cbf36e2afc4db8f82859bd8e5b9f40bbc7c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/qt6-tools-dev-tools_6.8.0-0deepin3_arm64.deb
+    digest: c45c4550873e94c31f4372e71b06dd80d8e634f532585d496dbfc60218fa49d4
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/qt6-tools-dev_6.8.0-0deepin3_arm64.deb
+    digest: 03bb344dd34bd0076551e13b833b014c2c379d13213a0d0668af15544e509de4
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/r/readline/readline-common_8.2-3_all.deb
+    digest: 35fe59faceb8d9def8b6aa664e091eac8444887bc1f33ba2cf22099c3646e7bd
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/r/rpcsvc-proto/rpcsvc-proto_1.4.2-4_arm64.deb
+    digest: ae2f397b418bbed8a068fdc9223133120390dbe734734c72b8e152962a76da91
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/shared-mime-info/shared-mime-info_2.2-1_arm64.deb
+    digest: e026d478f271cdce55bcc623fea311ee9605e39bf17ee3919b2502221d0e86e0
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tar/tar_1.35+dfsg-3_arm64.deb
+    digest: 9e736851d33ca49a6e7ae4b188c480ea0929cb8e322da77174570c64a1037175
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tzdata/tzdata_2023d-1deepin1_all.deb
+    digest: fe503c524801260208482a1dfc061e79c2a7450111dd90f88ed40d70ac935832
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/uuid-dev_2.39.3-6deepin1_arm64.deb
+    digest: 7094c9e4b23c9651ba3bb49b5c13883ff2bcd12cd4f30d291a2c29cc4fd34d52
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xorg/x11-common_7.7+23-deepin1_all.deb
+    digest: 9a7643db11023a8bec126312edec4b1b7357b93416bdfbaf9b0cb8bc04506d49
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xorgproto/x11proto-core-dev_2024.1-1_all.deb
+    digest: 82bff9dab1d74e30bdbc6130f94d1bd361c3c1d3cdad660bd92e5b730c4cba7b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb
+    digest: 39e14817ff2ab4eedade206fefebb7b2632e4dd7c358a9cfe36bcdd477554a04
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xfonts-encodings/xfonts-encodings_1.0.4-2.1deepin1_all.deb
+    digest: 07d68c68eeeca62cea0558b4f0bc25896bd82fddfa6c4b02693ee0adc4bde224
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xfonts-utils/xfonts-utils_7.7+6-deepin_arm64.deb
+    digest: c92b2bd8b458619a6f6fdca530fe2b8d9faf3ed273cd867126898275078c1ec7
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xkeyboard-config/xkb-data_2.38-2deepin1_all.deb
+    digest: 6fdc32f08737735128e20a10f9a8425bde19855e3917d8f26a62ea3a12a9a720
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb
+    digest: c3ac4805a75219ecc8a92a79697d39fa9abf6a7fa16da540800a0d30bdcc2847
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb
+    digest: ab37e512128e066d7225deb7f51f0c77f9b0c3913d75f2a7f9b1d708327a099d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xz-utils/xz-utils_5.4.5-0.3_arm64.deb
+    digest: 8df904affdf74d76f6a265ba072c57844c981ae39074c5526c763752cb03f100
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.1-1deepin1_arm64.deb
+    digest: 29a1888f6b7be54992868b36050c68d6063820ae6c4a2e09ffa2317a7e0b6d6f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/z/zlib/zlib1g_1.3.dfsg+really1.3.1-1deepin1_arm64.deb
+    digest: 2c38eb2adccdb6baf292a182b5963a7eee5895afd657917be10282bdb2b2139f

--- a/deploy_dep
+++ b/deploy_dep
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: 2023 - 2025 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+#!/bin/bash
+set -e
+
+# 生成安装目录/文件和运行时依赖的必要库
+# 获取应用id
+ID_VALUE=$(awk -F ': ' '/^  id: / {print $2}' linglong.yaml)
+
+## 获取安装的文件列表并写入安装脚本（排除头文件、pc和cmake文件）
+# cmake 安装
+if ! grep -- "-- Installing:" install.log | sed 's/-- Installing: //' | grep -vE '\.(h|cmake|pc)$' > ${ID_VALUE}.install; then
+    echo "cmake install files are empty!"
+fi
+# qmake 安装
+if ! grep -- "-install qinstall" install.log | awk '{print $NF}' | grep -vE '\.(h|cmake|pc)$' >> ${ID_VALUE}.install; then
+    echo "qmake install files are empty!"
+fi
+# 动态库软连接
+if ! grep -- "^ln -f -s " install.log | awk '{print $NF}' >> ${ID_VALUE}.install; then
+    echo "Get library softlink empty!"
+fi
+
+# glib-compile-schemas 文件添加到 install 文件
+for SCHEMAS in "${PREFIX}"/share/glib-2.0/schemas/gschema*; do
+    if [[ -f "$SCHEMAS" ]]; then
+        echo "$SCHEMAS" >> "${ID_VALUE}.install"
+    fi
+done
+
+# 获取依赖的所有文件
+for LDFILE in "$@"; do
+
+    # 判断文件是否以 .so 结尾
+    if [[ "$LDFILE" == *.so ]]; then
+        FILE_PATH="${PREFIX}/lib/${TRIPLET}/$LDFILE"
+
+        # 添加依赖库到 install 文件
+        for SOFILE in "${PREFIX}/lib/${TRIPLET}"/${LDFILE}*; do
+            if [[ -f "$SOFILE" ]]; then
+                echo "$SOFILE" >> "${ID_VALUE}.install"
+            fi
+        done
+    else
+        FILE_PATH="${PREFIX}/bin/$LDFILE"
+    fi
+
+    # 获取依赖库
+    DEPENDENCIES=$(ldd "$FILE_PATH" | grep "$PREFIX") || continue
+    if [[ ! -z "$DEPENDENCIES" ]]; then
+        echo "$DEPENDENCIES" | while IFS= read -r line; do
+            LIB_PATH=${line##*=> }
+            LIB_PATH=${LIB_PATH%%(*}
+
+            # 获取基本库名并匹配相关库
+            LIB_DIR=$(dirname "$LIB_PATH")
+            BASE_LIB_NAME=$(basename "$LIB_PATH")
+
+            # 使用通配符查找相关库文件并将结果倒序存储到 install 文件
+            for FILE in "$LIB_DIR"/${BASE_LIB_NAME%.*}*; do
+                if [[ -f "$FILE" ]]; then
+                    echo "$FILE"
+                fi
+            done | sort -r >> "${ID_VALUE}.install"
+
+        done
+    fi
+done
+
+# 排除静态链接库
+#echo '^'${PREFIX}'/'${TRIPLET}'/.+(?<!\.a)$' >> "${ID_VALUE}.install"
+#echo '^'${PREFIX}'/lib/.+(?<!\.a|\.pc|\.cmake|\.h|\.sh|\.prf|\.inc)$' >> "${ID_VALUE}.install"
+
+# 删除调试符号
+files=`cat ${ID_VALUE}.install`
+for file in $files
+do
+    if [[ -f "$file" && -x "$file" ]] || [[ "$file" == *.so ]]; then
+        strip -g $file || true
+    fi
+done

--- a/install_dep
+++ b/install_dep
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: 2023 - 2025 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+#!/bin/bash
+set -e
+project_dir=$PWD
+cache_dir=${LINGLONG_FETCH_CACHE:-$PWD/linglong/cache}
+mkdir -p "$cache_dir"
+# 文件名 deb-source.bash
+# 包含要解压的deb目录
+deb_dir=$(realpath "$1")
+# 将deb解压到输出目录
+target=$(realpath "$2")
+# 默认会跳过base已安装的包，可以强制解压已安装的包
+include="$3"
+# 临时目录，将内容处理后再移动到 target
+out_dir="$(mktemp -d)"
+cd "$out_dir"
+# 临时文件，用于记录deb文件列表
+deb_list_file="$out_dir/deb.list"
+# 临时文件，用于记录强制安装的包名
+include_list_file="$out_dir/include.packages.list"
+# 临时文件，用于记录跳过安装的包名
+exclude_list_file="$out_dir/exclude.packages.list"
+# 包数据存放的临时目录
+data_list_dir="$out_dir/data"
+# 生成文件列表
+find "$deb_dir" -type f -name "*.deb" >"$deb_list_file"
+echo "$include" | tr ',' '\n' >"$include_list_file"
+# 用于记录安装的所有文件来自哪个包
+mkdir /tmp/deb-source-file || true
+
+# 如果base和runtime已安装则跳过，旧版本base没有/packages.list文件就使用/var/lib/dpkg/status
+grep 'Package: ' /var/lib/dpkg/status >"$exclude_list_file" || true
+# 跳过base和runtime已安装的包，也可使用install_dep_skip.list文件控制跳过哪些包
+cat /packages.list /runtime/packages.list "$PREFIX/packages.list" "$project_dir/install_dep_skip.list" >>"$exclude_list_file" || true
+
+# 遍历文件列表
+while IFS= read -r deb_file; do
+    # 输出deb名，但不换行，便于在包名后面加skip
+    echo -n "$deb_file"
+    # 提取control文件
+    control_file=$(ar -t "$deb_file" | grep control.tar)
+    ar -x "$deb_file" "$control_file"
+    # 获取包名
+    pkg=$(tar -xf "$control_file" ./control -O | grep '^Package:' | awk '{print $2}')
+    rm "$control_file"
+    # 如果在base和runtime中已安装，并且不包含在include（强制安装）列表则跳过安装，否则安装到$PREFIX目录
+    if grep -q "^Package: $pkg$" "$exclude_list_file" && ! grep -q "^$pkg$" "$include_list_file"; then
+        echo " skip"
+        echo "$deb_file" >>/tmp/deb-source-file/skip.list
+        continue
+    fi
+    # 记录到 packages.list
+    echo "Package: $pkg" >>"$PREFIX/packages.list"
+    # 换行
+    echo ""
+    # 缓存解压后的data.tar文件，便于在下次使用时，加快安装速度
+    deb_sha=$(sha256sum "$deb_file" | awk '{print $1}')
+    data_cache="$cache_dir/install_dep_$deb_sha"
+    if [ ! -e "$data_cache" ]; then
+        data_cache_tmp="$cache_dir/install_dep_tmp_$deb_sha"
+        # 查找data.tar文件，文件会因为压缩格式不同，有不同的后缀，例如data.tar.xz、data.tar.gz
+        data_file=$(ar -t "$deb_file" | grep data.tar)
+        case "$data_file" in
+        *.xz) ar -p "$deb_file" "$data_file" | unxz >"$data_cache_tmp" ;;
+        *.gz) ar -p "$deb_file" "$data_file" | gunzip >"$data_cache_tmp" ;;
+        *.zst) ar -p "$deb_file" "$data_file" | unzstd >"$data_cache_tmp" ;;
+        *)
+            echo "unknown file type"
+            exit 1
+            ;;
+        esac
+        mv "$data_cache_tmp" "$data_cache"
+    fi
+    # 解压data.tar文件到输出目录
+    mkdir "$data_list_dir"
+    tar -xvf "$data_cache" -C "$data_list_dir" >>"/tmp/deb-source-file/$(basename "$deb_file").list"
+    # 清理不需要复制的目录
+    rm -r "${data_list_dir:?}/usr/share/applications"* 2>/dev/null || true
+    # 修改pc文件的prefix
+    sed -i "s#/usr#$PREFIX#g" "$data_list_dir"/usr/lib/"$TRIPLET"/pkgconfig/*.pc 2>/dev/null || true
+    sed -i "s#/usr#$PREFIX#g" "$data_list_dir"/usr/share/pkgconfig/*.pc 2>/dev/null || true
+    # 修改指向/lib的绝对路径的软链接
+    find "$data_list_dir" -type l | while IFS= read -r file; do
+        linkTarget=$(readlink "$file")
+        # 如果指向的路径以/lib开头，并且文件不存在，则添加 /runtime 前缀
+        # 部分 dev 包会创建 so 文件的绝对链接指向 /lib 目录下
+        if echo "$linkTarget" | grep -q ^/lib && ! [ -f "$linkTarget" ]; then
+            ln -sf "$target$linkTarget" "$file"
+            echo "    FIX LINK" "$linkTarget" "=>" "$target$linkTarget"
+        fi
+    done
+
+    # 修复动态库的RUNPATH
+    find "$data_list_dir" -type f | while IFS= read -r file; do
+        fileinfo=$(file "$file")
+        # skip non-dynamic librarie
+        if ! echo "$fileinfo" | grep -q 'shared object'; then
+            continue
+        fi
+        # skip debug file
+        if echo "$fileinfo" | grep -q 'with debug_info'; then
+            continue
+        fi
+        runpath=$(readelf -d "$file" | grep RUNPATH | awk '{print $NF}')
+        # skip without runpath
+        if ! echo "$runpath" | grep -q '^\[/'; then
+            continue
+        fi
+        # 如果RUNPATH使用绝对路径，则添加/runtime前缀
+        runpath=${runpath#[}
+        runpath=${runpath%]}
+        newRunpath=${runpath//usr\/lib/runtime\/lib}
+        newRunpath=${newRunpath//usr/runtime}
+        patchelf --set-rpath "$newRunpath" "$file"
+        echo "    FIX RUNPATH" "$file" "$runpath" "=>" "$newRunpath"
+    done
+    # 复制/lib,/bin,/usr目录
+    cp -rP "$data_list_dir/lib" "$target" 2>/dev/null || true
+    cp -rP "$data_list_dir/bin" "$target" 2>/dev/null || true
+    cp -rP "$data_list_dir"/usr/* "$target" || true
+    rm -r "$data_list_dir"
+done <"$deb_list_file"
+
+# 修复相对路径的软链接(dev包内的软连接尝试修复指向base)
+find "$target" -type l | while IFS= read -r file; do
+    # 获取链接的绝对路径
+    linkTarget=$(readlink -m "$file")
+    # 如果链接指向的文件不存在
+    if [ ! -e "$linkTarget" ]; then
+        # 去掉前缀查看/lib下是否存在
+        linkTarget="${linkTarget#$target}"
+        if [ -e "$linkTarget" ]; then
+            ln -sf "$linkTarget" "$file"
+            echo "    FIX LINK" "$file" "=>" "$target$linkTarget"
+        fi
+        # 添加usr前缀查看/usr/lib下是否存在
+        linkTarget="/usr$target"
+        if [ -e "$linkTarget" ]; then
+            ln -sf "$target$linkTarget" "$file"
+            echo "    FIX LINK" "$file" "=>" "$target$linkTarget"
+        fi
+    fi
+done
+
+# 更新ld.so.cache
+if [ -n "$LINGLONG_LD_SO_CACHE" ]; then
+    ldconfig -C "$LINGLONG_LD_SO_CACHE"
+fi
+
+# 清理临时目录
+rm -r "$out_dir"

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -1,53 +1,1067 @@
+# SPDX-FileCopyrightText: 2024 - 2025 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+version: '1'
+
 package:
   id: org.deepin.image.viewer
-  name: "deepin-image-viewer"
+  name: deepin-image-viewer
   version: 6.0.10.1
   kind: app
   description: |
     view images for deepin os.
 
-variables:
-  extra_args: |
-    -DVERSION=${VERSION}
+command:
+  - deepin-image-viewer
 
-runtime:
-  id: org.deepin.Runtime
-  version: 23.0.0
+base: org.deepin.base/23.1.0/x86_64
+runtime: org.deepin.runtime.dtk/25.2.0/x86_64
 
-depends:
-  - id: "dde-qt-dbus-factory" 
-    version: 5.5.12
-  - id: qtmpris
-    version: 0.1.0.1
-  - id: icu
-    version: 63.1
-    type: runtime
-  - id: xcb-util
-    version: 0.3.8.1
-    type: runtime
-  - id: qtdbusextended
-    version: 0.0.3
-  - id: freeimage
-    version: 3.18.0
-    type: runtime
-  - id: jxrlib
-    version: 1.1.1
-    type: runtime
-  - id: openexr
-    version: 2.2.1.4
-    type: runtime
-  - id: ilmbase
-    version: 2.2.1
-    type: runtime
-  - id: libraw
-    version: 0.19.2
-    type: runtime
-  - id: deepin-ocr-plugin-manager
-    version: 1.0.0.2
-    type: runtime
+build: |
+  bash ./install_dep linglong/sources "$PREFIX"
 
-source:
-  kind: local
-  patch: patches/fix-linglong.patch
-build:
-  kind: cmake
+  # add path for searching OpenGL
+  export PATH=$PATH:/runtime/include:/runtime/lib/${TRIPLET}
+
+  VERSION=$(head -1 debian/changelog | awk -F'[()]' '{print $2}')
+  cmake -B build \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+        -DCMAKE_INSTALL_LIBDIR=${PREFIX}/lib/${TRIPLET} \
+        -DVERSION=${VERSION}
+  cmake --build build -j`nproc`
+  cmake --build build --target install >install.log 2>&1
+
+  # 项目生成应用名和动态隐式加载的依赖库，ldd无法找到的其他库
+  LDD_FILES=(
+    deepin-image-viewer
+  )
+
+  # 生成.install 文件
+  bash ./deploy_dep "${LDD_FILES[@]}"
+
+  ID_VALUE=$(awk -F ': ' '/^  id: / {print $2}' linglong.yaml)
+  # deepin-ocr-plugin-manager model 文件添加到 install 文件
+  find "${PREFIX}/share/deepin-ocr-plugin-manager/model/" -type f -o -type d >> "${ID_VALUE}.install"
+
+sources:
+  # linglong:gen_deb_source sources amd64 https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release/ beige main community
+  # linglong:gen_deb_source install libdtk6gui-dev, libdtk6widget-dev, qt6-svg-dev, qt6-tools-dev, qt6-tools-dev-tools, qt6-base-dev, qt6-base-dev-tools, qt6-base-private-dev, qt6-l10n-tools, libraw-dev, libexif-dev, libdeepin-ocr-plugin-manager-dev
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_amd64.deb
+    digest: b6175963d3e4cf00d76fe431e75e52450bad93604945040d706d97b65cd8623d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/binutils-common_2.41-6deepin5_amd64.deb
+    digest: 48d5bb1b38c184c7099393a89ffd3c01abb2d2f64c3c9aab4045e2ba1271570a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/binutils-x86-64-linux-gnu_2.41-6deepin5_amd64.deb
+    digest: 4becb0add7af644bb663a914d805394e6b9a84d148950d12a1e6148a827f657a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/binutils_2.41-6deepin5_amd64.deb
+    digest: db40885cb122564840d3f259169e1dbcfc7f0dfd5e210ababf2bbbb99eb92283
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/bzip2/bzip2_1.0.8-deepin1_amd64.deb
+    digest: a67b553f354a824475090fcd7a1b6fe237598a1445158526027f2970aa976def
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/debconf/debconf_1.5.79-deepin_all.deb
+    digest: ded6aaa7927ae27337ceb23d49391b4c7ec460a00ba692020e8f4e28388f345f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_amd64.deb
+    digest: f0e1fe7a35fc386fb5944eb9bc4325c4e2d8913f43639ab6791ed3ea6084f584
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dpkg/dpkg-dev_1.22.6deepin3_all.deb
+    digest: 52e7455da433b7e412afeec3848d3f6371a857653aea02d1a6e080db446f51d9
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dpkg/dpkg_1.22.6deepin3_amd64.deb
+    digest: f9c758ed0204b1fe515c70b6419f80fdeb4773ac3f498a79ea1e6a6e6971157f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fontconfig/fontconfig-config_2.14.2-6_amd64.deb
+    digest: ca239a17d79f439fc02525b3b3c83d6cdf0be1a90c6aa6ec6c19b2b92b0d6586
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fontconfig/fontconfig_2.14.2-6_amd64.deb
+    digest: 1018476410ec372cb5f96e3a4d4b4d51781c613212eb71f91bcc939c2de0e8f2
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
+    digest: afbaf120869a08aa7dd14da9ad014de48a751aa4330534b531410bb86c411b55
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-dejavu/fonts-dejavu-core_2.37-deepin_all.deb
+    digest: 5982963d05dbf4efa009c3ab6db3576a03f680199d75d7d5edda89c55def912c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-freefont/fonts-freefont-otf_20120503-10_all.deb
+    digest: c66666da94b9a0477351ee9d6d7a247a0a3c842e428da770991b45f03be2ee72
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-freefont/fonts-freefont-ttf_20120503-10_all.deb
+    digest: 79b23c3945d4628463672a804a0e81bc4c262ef87cb6316afb40167a50bc3145
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-liberation/fonts-liberation_2.1.5-3_all.deb
+    digest: 9285213fd8d6515bc6c1be5b810bf39918a668a17024a9fd3541879ce7fb5344
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-noto/fonts-noto-core_20201225-deepin_all.deb
+    digest: fa09d95f516c498d55e516d549b8ee41d9a7b6f17cdf0bb4b43744d672ce1366
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb
+    digest: f66d6f798c4b99d8490558cc8209c069b0fe5577c11378c0e01f9e87ddf10824
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-urw-base35/fonts-urw-base35_20200910-7_all.deb
+    digest: 4800c0b08fbeac0335f1e23df2d41528a242383324c256ebece00c8f438eefbd
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gcc-13/gcc-13-base_13.2.0-3deepin3_amd64.deb
+    digest: d9c679af2dd0d3878d823075b2fb1433618bd3227cbae336e11d8e89274b5ab1
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/gir1.2-glib-2.0_2.80.1-1deepin1_amd64.deb
+    digest: 19242756d4cc8125e5b18e34319ba4f4445aeff9bc3c1560e9dc5a87fcacb0d2
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgudev/gir1.2-gudev-1.0_238-2deepin1_amd64.deb
+    digest: 3cbcb69c6edaebc428fc9f7c19a4a4e7a057bb980ab6b6f754561e3aee3ea011
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/acl/libacl1_2.3.1-1_amd64.deb
+    digest: f06e936eb913b8e9271c17e6d8b94d9e4f0aa558d7debdc324c9484908ee8dc8
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/avahi/libavahi-client3_0.8-5_amd64.deb
+    digest: 28bdf7a8c0529f6397921fe59358e8d94cf3d3f1e498f09e9b4035254ee15baf
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/avahi/libavahi-common-data_0.8-5_amd64.deb
+    digest: 5fdc5ef24ff229630b683db663cb26e108aa719fd288b808c4607c680de52c75
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/avahi/libavahi-common3_0.8-5_amd64.deb
+    digest: a966db72e688d76b06a665dfe894c66faae8d2033cf5dd8776bf56f41912035f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libb/libb2/libb2-1_0.98.1-1.1_amd64.deb
+    digest: ad82b2de93cc49cdf37c861b03275245318b1555255639e5e805cf612a40171e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/libbinutils_2.41-6deepin5_amd64.deb
+    digest: 6ddab823f38eb647e3c438c08401f450384d8b63e3b872f0ed8a31f854e1fbe8
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libblkid-dev_2.39.3-6deepin1_amd64.deb
+    digest: e9a309e022e159bcd90fdf4b710e8a6597368a234fd3d102af67cf471ae16703
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libblkid1_2.39.3-6deepin1_amd64.deb
+    digest: 1c0d4c5b5efec4a282652df9793083bdd4e7fc0ed634dc76f3bf6ee700dfa8c4
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/brotli/libbrotli-dev_1.1.0-2_amd64.deb
+    digest: 87226cff96c560b3ea8b15110f7f2b00047b0cc9dd29c9fdbc372b4d9154de80
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/brotli/libbrotli1_1.1.0-2_amd64.deb
+    digest: c90c041d2069cc78a80e07d62ce3e251306a81b23f9b95fa35a65ce7af87ad04
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libb/libbsd/libbsd0_0.11.7-4_amd64.deb
+    digest: 40e8755d2d6de7ee5c90483c74d586c6270f088eaf630acdc32bc848c09cedfe
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/bzip2/libbz2-1.0_1.0.8-deepin1_amd64.deb
+    digest: 42c04d805408bc1f10872e8394e26d3ff1bc6aa3477efac7e94612f9b7b2d972
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_amd64.deb
+    digest: 60e1d9cbac4fafa4f7823e6495212ec02805997e64dead0f40de1d86ff138d41
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glibc/libc-dev-bin_2.38-6deepin7_amd64.deb
+    digest: 2fb2db05a0e86ea279c81e5c4a3bbbcc8931d7fb54296748853061e44e6ae0f3
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glibc/libc6-dev_2.38-6deepin7_amd64.deb
+    digest: 6659347f85e23081d30ea809ceba563fd696bd21f8831a5e37115131864a8f35
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glibc/libc6_2.38-6deepin7_amd64.deb
+    digest: d8928f5bfe6dfaa9b64ea2354c9d933c51805aa137e52d834efdd4a1b220f031
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libc/libcap2/libcap2_2.66-5_amd64.deb
+    digest: f4f581c5ed9c6576ff284117ee51ae8b4e47e6799d71fabc7c0aa2d3a260752a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin5_amd64.deb
+    digest: a34b10500cae17c2c122760901c453df850a968a32699978c2015cf355fd5580
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/llvm-toolchain-17/libclang1-17_17.0.6-5deepin5_amd64.deb
+    digest: 7fd516db3504bc518b5c3911819880a8296964af7089e4c6d39753096a668fed
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/e/e2fsprogs/libcom-err2_1.47.0-2deepin1_amd64.deb
+    digest: 016e7e4d9ff3fa97f1631669aba86aebe7bd1d1c8d04fd8ec66b38c87cccab05
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcrypt/libcrypt-dev_4.4.36-5_amd64.deb
+    digest: 3505f9548808b3e2e06dac00d3c674a023815c011ab6ddad1bc85283e899adc6
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcrypt/libcrypt1_4.4.36-5_amd64.deb
+    digest: a7af8c9a2b767781d83f60fa32553f6a713569a0f7c4666e68dab41c46feaf1c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/libctf-nobfd0_2.41-6deepin5_amd64.deb
+    digest: c5320294cbb1a5a19f7eb0de0a2669a613f576db2612037a766a5bf44f766191
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/libctf0_2.41-6deepin5_amd64.deb
+    digest: dd486930909e67f021d0739101803cb08c8491e2ce2923bb5b65a88311a24105
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cups/libcups2-dev_2.4.2-5deepin1_amd64.deb
+    digest: 45ca2c611835e500875ddd500f2618ec97d6bfa51735ec3d276a72fb110e544e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cups/libcups2_2.4.2-5deepin1_amd64.deb
+    digest: e48aff0e7bd13a310516cfc5dcbdb68d789ef8e4c949afe7e638fb402a90f150
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin1_amd64.deb
+    digest: 14f6bb47e2fb92849593a1440cd87393d7920f5b7a0fa1932165c6bc8c96e890
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cups/libcupsimage2_2.4.2-5deepin1_amd64.deb
+    digest: 7e35233d2f74d5344630efc3bb2f91d2efb8ba7e62f01d5b095bb6bacc3c7010
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8deepin0_amd64.deb
+    digest: 98830ff429c7212767f0de4d239870f1936b37527ce365287de30eb8276a8330
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dbus/libdbus-1-3_1.14.10-3_amd64.deb
+    digest: 1dff3a63259f14e7de7c4502e7083f7077b30a274f09d195176d566406b1b827
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/deepin-ocr-plugin-manager/libdeepin-ocr-plugin-manager-dev_1.0.0_amd64.deb
+    digest: 248f0c6c7677b64f1757a17c17946e974019f79b887a9a636b96f2495ac629ab
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/deepin-ocr-plugin-manager/libdeepin-ocr-plugin-manager_1.0.0_amd64.deb
+    digest: ec26271cc8ed06fcdaa3819ac871c2bbf4b64ee05b2e4ea0b131ac78ceb29549
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdeflate/libdeflate-dev_1.18-1_amd64.deb
+    digest: 04a8d4c536a9f106a9f4b38fdc012fbe745b928e32ef3f05db4704d30c1023b5
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdeflate/libdeflate0_1.18-1_amd64.deb
+    digest: 1b411007d982c5f2f2a6d1e2d0af7a85cbc274770e533fbd895fc54956a995ba
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_amd64.deb
+    digest: e6c6d028a74d0a752ae638ec19b8239f404c36d676c7569936f31000d25a75f4
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dpkg/libdpkg-perl_1.22.6deepin3_all.deb
+    digest: 71989ccb16cfcc04aa5a86f06e4dff837a4fa755d04d17d5f0cf329fc09dda04
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdrm/libdrm-amdgpu1_2.4.123-1_amd64.deb
+    digest: f58eaae37579b2a3964f84993a8893fe00a05447b23f5e937102c30f64fead50
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdrm/libdrm-common_2.4.123-1_all.deb
+    digest: b8289eaa6341a8493f4c191a45165fe944248da69f675d09005a29058e7ae5a6
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdrm/libdrm-intel1_2.4.123-1_amd64.deb
+    digest: 9de0a6e4bea3c7244aa6c88ccb46c7297fac4b475756b4885b7eec53191eaa17
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdrm/libdrm-radeon1_2.4.123-1_amd64.deb
+    digest: 6c5a1a1849b24b6b02608d28fe9294c85f366f3bdf94f46cc622c4f2e980774e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdrm/libdrm2_2.4.123-1_amd64.deb
+    digest: c2f1676c3335ab76ff829190951052abef661b735f2ddfefdb8d6c0698c41756
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6core/libdtk6core-dev_6.0.25_amd64.deb
+    digest: 8ceffb3810d88965cf8f4b9cff067f53011112dd32a211495e0c37a9a8a948bc
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6core/libdtk6core_6.0.25_amd64.deb
+    digest: 60ed25c9a9cb998a21b97cbd0451f4df0f5bd9f3872eef1d809575eaa6048c9f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6gui/libdtk6gui-dev_6.0.25_amd64.deb
+    digest: 9a7716eaa20196761a0f87a86035bfb1bb2b0be1bf485b0697a70927f60a99cf
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6gui/libdtk6gui_6.0.25_amd64.deb
+    digest: 2c91aaf3f276058f1c190d355ccdccbe699c6c1b5999edf9256fee34b5343d66
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6log/libdtk6log-dev_0.0.2_amd64.deb
+    digest: 203f1e94dcaa537929ad7df2c33f9ae6f006985fc56829a37c67dce2c11660c8
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6log/libdtk6log_0.0.2_amd64.deb
+    digest: 4af48ee588e9a27ca3663193177c4fd2b4e455cff00dbff0aa5fc2ec4bdd24d5
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6widget/libdtk6widget-dev_6.0.25_amd64.deb
+    digest: 34b0abc672d2c5af743d1a0836af2a258428422c3d1b87fb71507b0abc8073c5
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6widget/libdtk6widget_6.0.25_amd64.deb
+    digest: 2d4d30307bcc41eb6cef9608603ee999aabf3a81d4ba2a7008e6bfbc232e0689
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtkcommon/libdtkcommon-dev_5.7.5_amd64.deb
+    digest: 880d256182fe9891a7874473fdd1f18439e5c1625160214adb9167fdba3159da
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtkcommon/libdtkdata_5.7.5_amd64.deb
+    digest: 75824b67ac4979f023f9a22ed326157e76f0c4d7739474145e4b51fdf55f83a0
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libe/libedit/libedit2_3.1-20230828-1_amd64.deb
+    digest: 72d015604676696e4e10e238f4795fbdc3d7c0e241147d55c9782ea8baf9a03c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mesa/libegl-mesa0_24.1.5-1deepin2_amd64.deb
+    digest: c74aaf2b940df7a190e076c949c46064371bd71a7f72c3068364b093a5c502ac
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libegl1_1.7.0-1_amd64.deb
+    digest: 8c883a493c299a9cc4bf8814dc98b8d22ef4902f2e29b84e47c05075807785b9
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/e/elfutils/libelf1_0.191-1deepin2_amd64.deb
+    digest: 27dd39d5858cff9969ff58d01f7fe44a846dc9e9477898e250633c7b96c72757
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libe/libevdev/libevdev-dev_1.12.0+dfsg-1_amd64.deb
+    digest: 7e338355abfb198b7fe4ff9d02f4b950f822965712d429e3a623e25509e41daf
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libe/libevdev/libevdev2_1.12.0+dfsg-1_amd64.deb
+    digest: 48c0a7c73d835054b291645fa21fd597271e28a6eb98d8b22f2283e364e83893
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libe/libexif/libexif-dev_0.6.23-1_amd64.deb
+    digest: 717f1d0dbc6464516c5898479a9907f526dfc9e42df66db1d44dcd3a9c54c93c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libe/libexif/libexif12_0.6.23-1_amd64.deb
+    digest: 777bcea02800cf2c508fff7e5af7fac426da67dd4d9fc21599f5fb43a7dd171d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/e/expat/libexpat1-dev_2.5.0-2_amd64.deb
+    digest: 4d0a6ecc7857dc60dddbbd6872c2587f1081ce0d75b84c22ee8641a082fd6e24
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/e/expat/libexpat1_2.5.0-2_amd64.deb
+    digest: 5be8be254b82a58e77549b1784520f1f7ebb395b57982f87524533e1f061f75a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libf/libffi/libffi-dev_3.4.6-1_amd64.deb
+    digest: eadc61825e77bad028fd5eff398ac0e13da7a08870261058525d3f620d90cb7b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libf/libffi/libffi8_3.4.6-1_amd64.deb
+    digest: daa2aeb5a23c7dea09b2f16b94d15fa6f015ad5ff8c3db15bd0ab890fc920dd2
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4_amd64.deb
+    digest: 63b2c4d61d1e41070896b399b52c4b38cd5cc529b66692394b4dbe7f5375dad4
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fontconfig/libfontconfig-dev_2.14.2-6_amd64.deb
+    digest: 1b8d5463ae362465a609408e932ad0bb6968737a59af9669c1c1d3801a31ef16
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fontconfig/libfontconfig1_2.14.2-6_amd64.deb
+    digest: c4c5fa416637a08cf925dd4ec0115631b69e4f2f5f46f2094f3239167f781085
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libf/libfontenc/libfontenc1_1.1.4-1_amd64.deb
+    digest: 758a94a3acf10d671cc056981255d2bca91e42d74e46edb27f3c89b9c5d5d3cf
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/freetype/libfreetype-dev_2.13.2+dfsg-1deepin1_amd64.deb
+    digest: 96d67a80be9adf8a9418e1dd33d2bf12d36bb12d4518297842fc8de29bf50763
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/freetype/libfreetype6_2.13.2+dfsg-1deepin1_amd64.deb
+    digest: 362fcb4c7c381338fd78bfa018b17b25f00596afb9c7d99c28b075944b20eb2b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mesa/libgbm1_24.1.5-1deepin2_amd64.deb
+    digest: 48a32e67388800832f6a893ac7227ca6d21235f4f4394029d4adafb0e4db4f52
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gcc-13/libgcc-s1_13.2.0-3deepin3_amd64.deb
+    digest: bfe5009a5995e8e9d8206188394c5422b9c7fbbbea954bc632abab9e6699f35c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgcrypt20/libgcrypt20_1.10.3-2_amd64.deb
+    digest: f377a741b54094b2b71a461878bf012c8d602d9af146be9826ce058767e396d5
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gdbm/libgdbm-compat4_1.22-1_amd64.deb
+    digest: 35bdaf12b3222875708f4f3967f4517897062a05730f38893695d6344e4f496e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gdbm/libgdbm6_1.22-1_amd64.deb
+    digest: af88f48a9978a03543cb1bb5170ef936fb80595c8621d73137ba47bfef0de0d3
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin1_amd64.deb
+    digest: 6340c9628c7bcfda4c6826a49c52bc8bf28bfb8d12c163eb19ebde7b0ad61578
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libgl-dev_1.7.0-1_amd64.deb
+    digest: 0682d06faaefd4fb61e5b8daf45ff4318d9bd96e279792bb4a6eb16b0cc61ba3
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mesa/libgl1-mesa-dri_24.1.5-1deepin2_amd64.deb
+    digest: 354d263de6831a20606a81fec21621d4040252cf7a7b0e0d91c149b61e244dc0
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libgl1_1.7.0-1_amd64.deb
+    digest: 1889b6be38cb7319734d330c232b64aff31845745c74732bf824fe39bcbfdb6e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mesa/libglapi-mesa_24.1.5-1deepin2_amd64.deb
+    digest: 008619449b06981f0bc592e88bc8af8abb5e3c76ce90d047ba9b37db1f5a7e9a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/libglib2.0-0_2.80.1-1deepin1_amd64.deb
+    digest: 33857078b63370d9edfbceec5a4f8d159db6f75da9f486dd12c97711598f43de
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/libglib2.0-bin_2.80.1-1deepin1_amd64.deb
+    digest: a90fbe965ef03785f21e55dc04d550243495e96ba47107ddf0874bd0bde8a416
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/libglib2.0-data_2.80.1-1deepin1_all.deb
+    digest: 4e75a1c9e56c81ed2c1737e3e6fe590163a77ff45179101a4fcfb90b4c0d135d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/libglib2.0-dev-bin_2.80.1-1deepin1_amd64.deb
+    digest: 47e6ec3f082c09540ec0ce8ec0358e9d0d28ea7822e9e7cd5000672f6fd35adb
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin1_amd64.deb
+    digest: f6e2df667c442e8ad0305ec62c85227aead61ff85d591ef32ec9de31d086a74e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libglvnd0_1.7.0-1_amd64.deb
+    digest: dbc3b9a38a5527c8a02d8edf0f87779993272d61d9b24c3209df69d1ebf3e540
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libglx-dev_1.7.0-1_amd64.deb
+    digest: 31a76ec3d0a13d2340d8f89769770655ead3d477c918082fe4fad249c6d51258
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mesa/libglx-mesa0_24.1.5-1deepin2_amd64.deb
+    digest: f0dd6385f2f49cd6f955c090b1409b8cfe528a1bd712e47516a60f09ee627bfd
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libglx0_1.7.0-1_amd64.deb
+    digest: 30197452c9ee62b7a7063d1a9f208ffae0eefec86800340a104a884543d133d0
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gmp/libgmp10_6.3.0+dfsg-2deepin0_amd64.deb
+    digest: a809596d1ce3a18f2965759b2443fdcb83edd50ae143d61c60cd26862b57850b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gnutls28/libgnutls30_3.7.9-2_amd64.deb
+    digest: d56ddf6802b16bc9c2ba21d8c5d6312e0620c9b96dfc11f8345d42c8233e9e74
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gcc-13/libgomp1_13.2.0-3deepin3_amd64.deb
+    digest: d61e37e7145c09d12cc290022c5361750c93a2f6e4435c52b88dd5a098c19102
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgpg-error/libgpg-error0_1.47-3_amd64.deb
+    digest: c7c00dbad22e7c549a25c147e3d471fae76d0c22d479c0de61aac4cf60e97f36
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/libgprofng0_2.41-6deepin5_amd64.deb
+    digest: 0d8d6027c510e0e063e26a85eed097089887027ff8cdbb29cac437cba43e4675
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/graphite2/libgraphite2-3_1.3.14-2_amd64.deb
+    digest: b4697179666eb012313127a7ff04d286f427b49523f50ada6d593694030c0b51
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/krb5/libgssapi-krb5-2_1.20.1-5_amd64.deb
+    digest: dfa250b0e4ecb5b3c359f49161b460b0139c38b1592b6d6538395855f6c952f1
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgudev/libgudev-1.0-0_238-2deepin1_amd64.deb
+    digest: fb9f1c72e40fd7fece5eab37c9eb473bf3d19c84fb808512d60af3bc909a8c5f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgudev/libgudev-1.0-dev_238-2deepin1_amd64.deb
+    digest: b0b603d7732573aed035c0ab43d92a054eb4351a7098fe6f37e4c736c1b5bd12
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gumbo-parser/libgumbo2_0.12.0+dfsg-2_amd64.deb
+    digest: b4036cefbbc4f6a5f73f6ac19d3065c52dc6b923691268c5b3032971465c35ac
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/h/harfbuzz/libharfbuzz0b_8.0.1-1+rb1_amd64.deb
+    digest: 29f8f51877821f22adc742cab010c0f627ff4db8ffb03a1479441c5f2061f9e3
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/nettle/libhogweed6_3.7.3-1_amd64.deb
+    digest: 0557f0e34a15444b6792c2726b5d1eb48f9ea8cd42bc7f4d697081e804ced558
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libi/libice/libice6_1.0.10-1_amd64.deb
+    digest: 03da9ec604f5bd9ba6526c4e6cf90c5b4266818b2c9a34110d74c42b9be87646
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/i/icu/libicu74_74.2-1deepin0_amd64.deb
+    digest: 880a9b880d1b4d6f31901541483fa40c9c041dd0949c136e27ace3af3541ddfe
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libi/libidn2/libidn2-0_2.3.2-2_amd64.deb
+    digest: 0ac47209fe66a5906497d6fb1c76a2addaa8daa2becaa434b17d32b98dd057cc
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libi/libinput/libinput-bin_1.26.0-1deepin3_amd64.deb
+    digest: eb9aca98fdaf66cc394f87b65799ae177c2f97ca300e0c55a34ac736525c9733
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libi/libinput/libinput-dev_1.26.0-1deepin3_amd64.deb
+    digest: 9153a6287da744a308744636d0e39ed6a92c25f51d00d50e0376203a48e300c3
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libi/libinput/libinput10_1.26.0-1deepin3_amd64.deb
+    digest: 52cbd20e0fc0708991bf66a0af9f5ad9a18d88a7552a8a1b46e209a2f54d25f0
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/j/jansson/libjansson4_2.14-2_amd64.deb
+    digest: bbf5325c3ccfd468e1d8fdafb68c3ffaa89db1e0043e8e757b9f240452c67c26
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/j/jbigkit/libjbig-dev_2.1-3.1-deepin1_amd64.deb
+    digest: 7ce8d535aa0768ca1cf24178b956b3bbbc82cca19ce4bbe91ab32c36038ae336
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/j/jbigkit/libjbig0_2.1-3.1-deepin1_amd64.deb
+    digest: 98eb75afc9dd66ec83f782a46aad59b0add9aad5ac521e91e35d606bb6313147
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libj/libjpeg-turbo/libjpeg-dev_2.1.5-2_amd64.deb
+    digest: fbc596effd2b0a596b71e306d120e5b660bd478c8c9d24e47c61b4ce2db33d27
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libj/libjpeg-turbo/libjpeg62-turbo-dev_2.1.5-2_amd64.deb
+    digest: 126fa110768ecfbb4569ddb66d53621f7007dcefa1234e0ba4f37e364903a607
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.1.5-2_amd64.deb
+    digest: 664abd1a931622f6d14cced9ea87f3b4f201adf9616e6ef2daf1b044903f699f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/krb5/libk5crypto3_1.20.1-5_amd64.deb
+    digest: 203bda60f112a6eb51bfb431c1c9287ff1dbfd4f8bacb931b8ab5aacf52ed4e3
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/keyutils/libkeyutils1_1.6.3-3.1_amd64.deb
+    digest: 784e45679941a3e3de3d747f94f215a6fd4b3767aa0b92c4e66a43cc5d628d33
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/krb5/libkrb5-3_1.20.1-5_amd64.deb
+    digest: ae4f1183b97f1f376f8caac13b739865aba4b4b77bcfec8d9dd86c85e6977411
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/krb5/libkrb5support0_1.20.1-5_amd64.deb
+    digest: bdc056efb59abe666c17a028924d456a5660c45b68259d2525b9a0d08a8524a2
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lcms2/liblcms2-2_2.14-2_amd64.deb
+    digest: a8630b7a9f07ca87612fdfe486941211598f4fe3148235746f001e68ce91114b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lcms2/liblcms2-dev_2.14-2_amd64.deb
+    digest: 129824080ce539c696a2696223de64ec2745031ed1a38d7915213aea370908bf
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_amd64.deb
+    digest: 9bf199c57795a3e4c8e7cce1ef1803e32e9d31fc7cb82b5db8275f654e19b655
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lerc/liblerc4_4.0.0+ds-3_amd64.deb
+    digest: 4024f109044643693dad079fce71b942ffba3bf3ec994d523130c33e776ea06e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/litehtml/liblitehtml0_0.9-0deepin1_amd64.deb
+    digest: 44596cdf0fefdc6412af3e1e0d0a4bdee4762d348cdf3818a2cca0daab437285
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/llvm-toolchain-17/libllvm17_17.0.6-5deepin5_amd64.deb
+    digest: f2d4e6214fdc72ee0c23079e0418dcf190fb41fc10612f9ef21ac3cbcbd701d3
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lz4/liblz4-1_1.9.3-deepin_amd64.deb
+    digest: 9808e49cf41c4a38f0ff4f4de7080ae392682f3cea166abc079a26625c8233aa
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xz-utils/liblzma-dev_5.4.5-0.3_amd64.deb
+    digest: 0e611c43cc8cee4b31dd530ef21f4efbb16caab257685a770b612146e18a6b8b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xz-utils/liblzma5_5.4.5-0.3_amd64.deb
+    digest: e8051c2b44fa1cc020c12ef45f4918c1dd7595532af89df0c583b4b3f333fa56
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libm/libmd/libmd0_1.0.4-1_amd64.deb
+    digest: 755e2a59d76415999f46b0c307ade64df3788013286e902e2531e07ff58ca781
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/md4c/libmd4c0_0.4.8-1_amd64.deb
+    digest: 9f1630409adb3464aa42afc519d2163a7741d152b53c937eddea55b9fb6fb10a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_amd64.deb
+    digest: 256423c8e3c4afcbdf72973db84b1e919187b65955c685ee16f9a5635d436943
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libmount-dev_2.39.3-6deepin1_amd64.deb
+    digest: 5b8858e4a945774d52c40824a44668cd0b5e260c61b7f9bd6685fac1cad27698
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libmount1_2.39.3-6deepin1_amd64.deb
+    digest: a6c22f3b3c30d72424a05ee1c8874674d4e69b5dd703aa7b8936c7c21ab8c009
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mtdev/libmtdev-dev_1.1.6-1_amd64.deb
+    digest: 92553337dcd1837205a4f136419b0cf40956e0975a938ad8e8e7b586659d0e46
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mtdev/libmtdev1_1.1.6-1_amd64.deb
+    digest: 28686d830a44272e63013aae1e508f0f767ea28c2a4856d6c6724e11b2a6f93e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/ncnn/libncnn_1.0.20240820-0deepin2_amd64.deb
+    digest: 3b349acb9120e910a0f3f4dd98f55691cc37b2b679f904f3239ce79ac96cd627
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/ncurses/libncursesw6_6.4-4_amd64.deb
+    digest: 9993f7cfcc8cf37e6474d7b570faf1d5a19187af8a820f38cd5315461c765f2f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/nettle/libnettle8_3.7.3-1_amd64.deb
+    digest: d19dd4ebabccc00232223b414732c26b63d4ee67f4147ad5a105795f4514382a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libn/libnsl/libnsl-dev_1.3.0-2_amd64.deb
+    digest: f17e04a96da2dcb260bf75ac750a63d238942ecd9550ce41cc3530774c3ae807
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libn/libnsl/libnsl2_1.3.0-2_amd64.deb
+    digest: 27219179fd316e3bdc7f9556d1852fcec175d13334b5aadf6274c19be98fb268
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/community/o/opencv-mobile/libopencv-mobile_4.5.4+14_amd64.deb
+    digest: 59fd8f6437757fc0301b633ef8eb2a2957ef82c69dcbffc2600bcb9fc1fb9ee2
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libopengl-dev_1.7.0-1_amd64.deb
+    digest: b91f22b0ab692fa36eff6fe2acc7e5878ab99d56177f3983cec1db54bd9c7f72
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libopengl0_1.7.0-1_amd64.deb
+    digest: 85398c86d394fb5d1c7b1f75cc6f3f3045424224493853cb94880a82baaddf8b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/p11-kit/libp11-kit0_0.25.5-2_amd64.deb
+    digest: 3aae0a4770a313f4092d89d9603472fe9dbc0bfc9e69230868c168b3b30f860a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libpciaccess/libpciaccess0_0.16-1_amd64.deb
+    digest: 549736858b99dc151e23c249ff54a69d6c03c03784af6cf8af0b71094df33a69
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pcre2/libpcre2-16-0_10.39-2_amd64.deb
+    digest: 1219e0d46f5c584323ad7e41c6fb39cdb8c6ed242a64913b7dadf0c557d84b6b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pcre2/libpcre2-32-0_10.39-2_amd64.deb
+    digest: 313cb3eed5be9793ce6db51292ca3d08334e9799856d88c085d268a4a264a586
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pcre2/libpcre2-8-0_10.39-2_amd64.deb
+    digest: 26ba66e349a9d46978d24e5b165c327e1ef51007770c43a3a49eb35b5fe0310e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pcre2/libpcre2-dev_10.39-2_amd64.deb
+    digest: b2a505ec6ef461644bf946949dc7def6a22ae8627c59ede2a82e9f77500eb856
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pcre2/libpcre2-posix3_10.39-2_amd64.deb
+    digest: f1d82802bdf71d13b7fe0b95aa0efbef3d4c661920629686170eabaeb8f4ecff
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/perl/libperl5.36_5.36.0-10_amd64.deb
+    digest: 1cca8c85872210489e92326ca7fda2fcc8d9b37a085cd1a0c87d54aa685118e8
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pkgconf/libpkgconf3_1.8.1-4_amd64.deb
+    digest: e4677f42eb04cd63106e75ef1c008595a5b306129d6fdd58171a4b3732f2aca3
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libpng1.6/libpng-dev_1.6.40-2_amd64.deb
+    digest: cf53c0792230a4db2be1859a350683fe3831e58986622c8131e67ddd875fa93a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libpng1.6/libpng16-16_1.6.40-2_amd64.deb
+    digest: 3327085ceef26f45c52af3462d6e506721371991a983b398e2fb741c2c48ab29
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libproxy/libproxy1v5_0.4.18-1.2deepin0_amd64.deb
+    digest: 01182c680d643f335f63ae38016fef3d5f097ab718789f9aef79de42f00517d9
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_amd64.deb
+    digest: 8be922fba920a96d098288da4fa5f1d5dfb778b362d7a26ed738014305aa3787
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3-defaults/libpython3-stdlib_3.12.1-1deepin1_amd64.deb
+    digest: 7611dfe764b5a109e1fa516270c304d451aa2980190c480a83b90207a6b84158
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3.12/libpython3.12-minimal_3.12.4-0deepin1_amd64.deb
+    digest: fef2ce003db442a002e3c874de33656cae3ef4a6d00a2a72e267b386df647945
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3.12/libpython3.12-stdlib_3.12.4-0deepin1_amd64.deb
+    digest: 192a53ec08eb4b356fcc157b8ba97a4d2e1e4a2d8e8d32e37a9d70ce5ff2ea22
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin5_amd64.deb
+    digest: 2b27dda887d891e316750fb1b7bd56fafb097c1bcb0f03e7ae0062561da40a6f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin5_amd64.deb
+    digest: ebd40ac7c53cd6b669568467e3b9b010abbc030ea1201662a74e0cb95a49698c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin5_amd64.deb
+    digest: 54dc26fe98838334213678668a1cfd3c020f2f050ed8378c0b8924ec1af8cc31
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_amd64.deb
+    digest: a6864707b38a192dc89ad51546e958fc2095ca3b45e6ee99e190d48ef54793ea
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_amd64.deb
+    digest: 033f970ed9f2486fa265bf3a10332fc18fec0b9d0a83d74ba999007c4d647fc9
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin5_amd64.deb
+    digest: 41dd12c029ef2a97fc9524b773c007642948bb0968f71f6dd08538dd03f8d375
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_amd64.deb
+    digest: 18db346cbe4e81620934c3b232222482f5c1251725516d3fb620c10ef2bb2611
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin5_amd64.deb
+    digest: d8d2854d73ebeb2607bc90ba83cfa55b67cee62ac055bb1b6228bd426fea4363
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin5_amd64.deb
+    digest: 7e1f0b187c5e82d45c06a8b3849fcb4e2a6cb6a31b950f7622ead3747009c54f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin5_amd64.deb
+    digest: f87c83461bc1806acf203a7e52a8c47e32aa5e42ede0d26f0ecf8a26bc914576
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin5_amd64.deb
+    digest: 4c1a62bbfb23764fbfc250027bab219087940ba16fa680b1e7348dcf418906f4
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin3_amd64.deb
+    digest: 4f9d66873e7e085fb6909fd47be1fd50a41a8dd4b15b38bc77ab2dff42e43cf8
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-declarative/libqt6qmlmodels6_6.8.0+dfsg-0deepin3_amd64.deb
+    digest: 2fa585bcff6d8630d2e321e265b7cc592172a3676d6d2adf9ed2ff8ea1854c7d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-declarative/libqt6quick6_6.8.0+dfsg-0deepin3_amd64.deb
+    digest: d37c7d36dbe7ec33a2f8693f66505262e8f6b9911acc61e0f0d272f479913ba7
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin3_amd64.deb
+    digest: 21cd8eda13f476ec71438f56f43ed8933cc0b625302fff4c6f23baacbfb3b5b1
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin5_amd64.deb
+    digest: 528e27bb9f946d602265cd8a43853f56b2754f3c945ac7bd64a099d7cc589f34
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin5_amd64.deb
+    digest: 105370dae395895df950cca059ee1d11aa5f6677a554c7331a83bc0da959ba52
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin1_amd64.deb
+    digest: 0e43640fc49faf57d8454012338aac69b638356417a4a2361f3c0e47271ffbf1
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin1_amd64.deb
+    digest: ba29752fae4494fe62f5a4d3f139386078d8beb74e53eee1d7c673028a8adb97
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin5_amd64.deb
+    digest: ae45f73efa9232cbb98621c9ecc12488a7ebf687eaf9866c2e171aa37efd96c1
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_amd64.deb
+    digest: 5a2a509181e35a92f6effe0f2ef107c7dfadccefde35548bb1ae568aea003fb3
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin4_amd64.deb
+    digest: 88d55f6992afd8662d7050d82d0f23db38f74907b8f21e2d4ab8a5ca51d4eefb
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin5_amd64.deb
+    digest: 4ba7721998329f33d49cc6f82add0a1a6819b59c4c8ba1e82dd084bfa3235ca6
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin5_amd64.deb
+    digest: d311d6a7a8cf93949f715bbbb271149e3396966a60611a086b05b125dd17c77d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libr/libraw/libraw-dev_0.21.1-7deepin1_amd64.deb
+    digest: 1d6cd0fee49e30d92219f79c6335c75f261a38970b66d06624106c46ab9ee698
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libr/libraw/libraw23_0.21.1-7deepin1_amd64.deb
+    digest: f35f81423070586a3589e069a4163b1827c9ba9cf2ceeaac08f1653faf78dc6f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/r/readline/libreadline8_8.2-3_amd64.deb
+    digest: d7d4a492aa183701aad09f9ae4e156df8d4d5e336f40502f51c72cb5135cc296
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin2_amd64.deb
+    digest: ccc4c248f64dbef5e3b9711491fc93a903e4fa15d1616f5ee1bfa0a5cd82c73b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libselinux/libselinux1_3.5-1deepin2_amd64.deb
+    digest: 6702f261991679f2b5fb4643acf010396a12d3994e26dd568628f433e6f0f129
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lm-sensors/libsensors-config_3.6.0-7_all.deb
+    digest: 164115506dfd335f26101e76cb49e2162b0440398ccf2d0c969ebc465dfd7867
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lm-sensors/libsensors5_3.6.0-7_amd64.deb
+    digest: 5a730040a0326f0124822fb9ffd632d4891c5451873049d630d0f9da63f0db10
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsepol/libsepol-dev_3.5-2_amd64.deb
+    digest: 4a1b7141086a540294dfc0df7eb707f2ef1e57d2a2f4b30f80821164d0f97b7b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsepol/libsepol2_3.5-2_amd64.deb
+    digest: 47738eed5444661ac0a8a8f2ce6fee7bcd448cfab2701340c51464cf532ccbc9
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/libsframe1_2.41-6deepin5_amd64.deb
+    digest: ba80a62cedf20c1aacd7d5f5d4d4b9b8ad03ad3ead1487b3ac4bd213f9105bab
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libsharpyuv-dev_1.3.2-0.2_amd64.deb
+    digest: 7af3357f80d57fdc31a26596f9e93f0218a625929822228d312498cabdcea72e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libsharpyuv0_1.3.2-0.2_amd64.deb
+    digest: 9da48196bd083c4749d1b4814a15780fdfa5a962ce3c19c5abfe0fa98e4e870e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsm/libsm6_1.2.3-1_amd64.deb
+    digest: d8a6d0abf65a6fe4c5edcb5fa37b115477736e60c31118df74b701a468b49cab
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_amd64.deb
+    digest: 44381cd9ad35fa6ffa7a0b3e27611011602bb32093efaf0c80117dc9f97a371b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/sqlite3/libsqlite3-0_3.46.1-1_amd64.deb
+    digest: 73029e73a746e8723afe8e98469774dc3de39cc7ee59a5ad1e9dc4745c11f55a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/o/openssl/libssl3_3.2.0-2deepin2_amd64.deb
+    digest: 8b86b65fd2480dc342d16a1dd62da1cdb955ba34d830d245c67ed3857680dbec
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_amd64.deb
+    digest: b0e9783da04f53ba8da97660523021322c4477059c63d3684fab283b7f9aef9c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gcc-13/libstdc++6_13.2.0-3deepin3_amd64.deb
+    digest: b58b4f44e2a475c39749808c5b7f6bafbdd50e25e6b59dff28ac68ed1603234b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/sysprof/libsysprof-capture-4-dev_46.0-1_amd64.deb
+    digest: bbaacdcbf341e500cd8fbe0dfb75fc98156b0a5abf94e43105bb5f745c3168dd
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/systemd/libsystemd0_255.2-4deepin3_amd64.deb
+    digest: 2d65df5f46dba24e2cd25605b715ea7bf4b1a23ccf2fb789f50e4a1d9c0586f4
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libtasn1-6/libtasn1-6_4.18.0-4_amd64.deb
+    digest: 3f24f7a181f374bd6623bfdc7781e2cee5d948361a456d2f6216aa4ba5c44a2e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tiff/libtiff-dev_4.5.1+git230720-1deepin0_amd64.deb
+    digest: 5040a118bf35582b0a96581b1652a2f97b83a936d8f9ec90bfdcd39ca63b6341
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tiff/libtiff6_4.5.1+git230720-1deepin0_amd64.deb
+    digest: 5d0206a7996e6eca94109bc0c78fc968a5dbc8c46050e43f82cadcff0331823f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tiff/libtiffxx6_4.5.1+git230720-1deepin0_amd64.deb
+    digest: 88293e02a12cfeed11a657116b795318a07abf69b80599f8270a2d1148c15978
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/ncurses/libtinfo6_6.4-4_amd64.deb
+    digest: bb49775a3e3df73dbef25027937ddb2f714f262e8cb859ef228d26b3c146b6eb
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libtirpc/libtirpc-common_1.3.2-2_all.deb
+    digest: 74bddc18e3289947b20653433e82025873f5679ccba52f258ca4912e435a09ee
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libtirpc/libtirpc-dev_1.3.2-2_amd64.deb
+    digest: 801b243dc8b3ebecf2be9efc9ca69cd987f26830accede2e7142210c5640ee91
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libtirpc/libtirpc3_1.3.2-2_amd64.deb
+    digest: 4ded57b843774f3c65449d6ad7bed6efb97bf94cdb4aadb8554fe5cc12210291
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tslib/libts0_1.22-1+rb3_amd64.deb
+    digest: d7c7fffd808cd0b765d2287b98bea752d740994788dbf90de6db4f9710e41162
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/systemd/libudev-dev_255.2-4deepin3_amd64.deb
+    digest: 70e6473b554cedbd161ce7f55223f5fc921ae173025f92ee71d77df4afccd314
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/systemd/libudev1_255.2-4deepin3_amd64.deb
+    digest: 540b14570f244649ac7cc75094b0bb9ad8a16287747bc53b53cb85cf4404aedd
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libu/libunistring/libunistring2_0.9.10-6_amd64.deb
+    digest: dfa507aa9982a3ba8cca86bc571d47e0c30d8adadc833e16cba4edd6e4c68155
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libuuid1_2.39.3-6deepin1_amd64.deb
+    digest: 8cc7e43d37649c4ee3595f33589716d7eea70ea4ccde666039b2b1d01a4f8413
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/v/vulkan-loader/libvulkan-dev_1.3.268.0-1_amd64.deb
+    digest: b3a78dde8283c64a2dbfe25320506a89b8dff77169e6e195129088047a272d4c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/v/vulkan-loader/libvulkan1_1.3.268.0-1_amd64.deb
+    digest: ea988ba1798a25fa13e1a6b852f1f8f8550293daead86a931846e4131a9e6c2e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwacom/libwacom-common_1.12-1_all.deb
+    digest: ae18d0c6d1b68084756ae6a5ca4d4d680659ad6a9e5384bdbb49de48ffb75bd8
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwacom/libwacom-dev_1.12-1_amd64.deb
+    digest: 2e107e0a55003a2c223c792b5d505e566c553c42b0f6acc98f927f1a88bf4c2d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwacom/libwacom2_1.12-1_amd64.deb
+    digest: 2e0eb22e108ff3de178a570dcd21ab3d6cc16f6baf94bec37595008786789280
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/w/wayland/libwayland-client0_1.23.0-1_amd64.deb
+    digest: b5f2ac4f0acf93a0df4efefe38f34ebdc0e1724639c864e5777447bb5f9b7c2e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/w/wayland/libwayland-cursor0_1.23.0-1_amd64.deb
+    digest: e0acb5c50acbe13b427f9aa0ef9dd662d6e824b2f1d17e1a170bdf20422fcc36
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/w/wayland/libwayland-server0_1.23.0-1_amd64.deb
+    digest: a63916b242532f6c621674b8dea3fc9e0c55f6592409edeb9146f8b978ec5a6e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libwebp-dev_1.3.2-0.2_amd64.deb
+    digest: 0c60cd19f18fbd0cf299480c7e7cfcb7451e6b1b05dc8f2d5cae1cd248e4bc5f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libwebp7_1.3.2-0.2_amd64.deb
+    digest: f2271cabfa4d4847bef8a522e2775d4f9c09a2560911df4779a7cc06d650eec6
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libwebpdecoder3_1.3.2-0.2_amd64.deb
+    digest: 26d6ff4ed6bf1da7fe3eafe2514ef5c04a8792381b35e3bd3745fab1b6347246
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libwebpdemux2_1.3.2-0.2_amd64.deb
+    digest: bf245a91bfd56f199fc182030a8b9091c77ee4b3fa99754328ef6e4c31b9eafa
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libwebpmux3_1.3.2-0.2_amd64.deb
+    digest: 4732ad39b0b2d4504983466503fa0ea1ba286c42aca07feeca8055d91e17aede
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libx11/libx11-6_1.8.7-1_amd64.deb
+    digest: e21e2b12e455664dd8b6ceb201d853c120dea77e0703c95545a3176708ae699f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libx11/libx11-data_1.8.7-1_all.deb
+    digest: 400aaa7eaab268850d8c2c512474228204d47774f2aac79cef29d1c125e0c656
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libx11/libx11-dev_1.8.7-1_amd64.deb
+    digest: 93ec6c1345900f791549c12440757ba08e756379278bd6fe5133e6690c544621
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libx11/libx11-xcb1_1.8.7-1_amd64.deb
+    digest: 68341e587a81b03655ff00f0cc9ba543181285504475e66b422308b1bdd30e5f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxau/libxau-dev_1.0.9-1_amd64.deb
+    digest: 784b6358825482c6b8e0a5515c1ea33a84e1ae70999df930a75c344a476dbafa
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxau/libxau6_1.0.9-1_amd64.deb
+    digest: 0d55ab9b5634a7b635ebe263526719f3c5c925d847c0f4cb927bc61584cf269b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xcb-util-cursor/libxcb-cursor0_0.1.1-4_amd64.deb
+    digest: f3575052a14a5ec2d016bc667d466fc5bceec389db5b6ad9ab03ca53b50411f6
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-dri2-0_1.15-1_amd64.deb
+    digest: 691906c89f7d59cf4e8a244c333cd1e9a91b00241bd44e6d8f5b975905ac1a32
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-dri3-0_1.15-1_amd64.deb
+    digest: a55805048ef2bcbc16d6ed58879d173012291066e7e94f8ede8eb456d01c3079
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-glx0_1.15-1_amd64.deb
+    digest: b049c57d28e8785786edba1d9ff6139fb8e85f17dbeb921aa4437a160f28ecd9
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xcb-util-wm/libxcb-icccm4_0.4.1-1.1_amd64.deb
+    digest: be2ad80833f41279cad9ff66445251ea6ad3eec32cc9d2b9400ff8ad75ae255c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xcb-util-image/libxcb-image0_0.4.0-deepin1_amd64.deb
+    digest: f41b73e88b0dfb9a8b1cf7dc6b7717cdbf19b3eb0c4b9a395323b70cb3f22daf
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xcb-util-keysyms/libxcb-keysyms1_0.4.0-deepin1_amd64.deb
+    digest: f240c2c0304a253f65767ab856f995ceea9d999fca674f71e210704210218e65
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-present0_1.15-1_amd64.deb
+    digest: 548641b3568cf21f4359bed39375c1c8e873f92fa38955e310a27c3d0a0bd63c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-randr0_1.15-1_amd64.deb
+    digest: 20d03b2822771bfeaf4ba3ae40faa96cf48e3a7c9bdf1d8ec37de6064a0ee02b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xcb-util-renderutil/libxcb-render-util0_0.3.9-deepin1_amd64.deb
+    digest: c7bee3954ed81690c89b297ad68e14b95a634dc57ec1a235348efbf63de095b5
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-render0_1.15-1_amd64.deb
+    digest: ee032e334e48cdd15385fccde4b4baa399775d3a53aafa3a86e621012a47dae5
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-shape0_1.15-1_amd64.deb
+    digest: 135268523d9957b26d436eee5cbb699815e52d98077b4e99516a9078444c9fa9
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-shm0_1.15-1_amd64.deb
+    digest: 764d8a7b72cfcd3a4e3f1abb7b19c0af24e307a5595be04f06184b3817df8b44
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-sync1_1.15-1_amd64.deb
+    digest: 8e5d1b2a5e1bfca4c9408bc7b62c161359f4ef7c2f35a25ef1734fd857c08654
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xcb-util/libxcb-util1_0.4.0-deepin1_amd64.deb
+    digest: f0b0176f922757c116b36801584068ab4e0411c6d97a6ed9acb578a4ef56a7c7
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-xfixes0_1.15-1_amd64.deb
+    digest: c32ee9a285da0ddb94ab374cece23c5403e691539b5d604a1450f5120485d18a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-xkb1_1.15-1_amd64.deb
+    digest: d25d2db11b35fb8d8f7122805028094a0df945c59941f9b726b64dc48d0bf515
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb1-dev_1.15-1_amd64.deb
+    digest: 981d5049c153139995fa5d28ca1da252bbd5239a25111dc7bc28ab8c556d1b0b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb1_1.15-1_amd64.deb
+    digest: 7472219060504d69f13cea545dde78da4b42455c3018f211d161315c7d8aa9f1
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxdmcp/libxdmcp-dev_1.1.2-3_amd64.deb
+    digest: d0b1950a8dfb16ff2f3c6aac1296b508da0f25eef3bc636feed2116f7ba664bb
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxdmcp/libxdmcp6_1.1.2-3_amd64.deb
+    digest: ebcc2294de7d5fb853478096435000c2c262f0cc27bb6e9cbd1455984e58a72f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxext/libxext6_1.3.4-1_amd64.deb
+    digest: 59a91d747d250b40897b850d0aa7477a92aa671991287137875b1475a7708a85
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxfixes/libxfixes3_6.0.0-1_amd64.deb
+    digest: e4234708c3f3631d7f361a1429d8b9de9b8acc81244f23b8df64d599b62fcecd
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxi/libxi6_1.8.1-1_amd64.deb
+    digest: d8a2f9bd5ee841567db6b5aae74edb48c2fc11be2fd6354dc83cfca423905aa7
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxkbcommon/libxkbcommon-dev_1.6.0-1_amd64.deb
+    digest: fd7cb0bb0dc64c7417a6418bdf4d67145947902d5dd668eab4949811b170ee51
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxkbcommon/libxkbcommon-x11-0_1.6.0-1_amd64.deb
+    digest: d763060cdbffd1ed849ae63e091ca47b8b75c8777ccc2d0ee968fcbe66aa9b51
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxkbcommon/libxkbcommon0_1.6.0-1_amd64.deb
+    digest: c44ac854dbbe987c4a0ee11ddf526b8fff1b701edaa5d85b7495a81aeacc3686
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxml2/libxml2_2.9.14+dfsg-1.3+rb2_amd64.deb
+    digest: 36b25f4121dd6765f49a5249a94f675139c4fbaae04be5ccc1ac3ae59f1e40c2
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxshmfence/libxshmfence1_1.3-1_amd64.deb
+    digest: d112a8a931b29eed0b2c058cc53f03be11dcf4fe2dc28a570c38cec52f687c92
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxxf86vm/libxxf86vm1_1.1.4-deepin1_amd64.deb
+    digest: 6ab24dd183238d561320ff6ab17df620297d4058d82e02606354740c0b8180f8
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/z/z3/libz3-4_4.8.12-deepin2+rb1_amd64.deb
+    digest: 73dced8cb5640743208e7a7cf2d4ae7072610d14314584c21992e84c31179907
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libz/libzstd/libzstd-dev_1.5.6+dfsg-1_amd64.deb
+    digest: 92ec406d537e08271b66dbcf10d5730fff8eee067379c9fce7e74e4c53c6b4c3
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libz/libzstd/libzstd1_1.5.6+dfsg-1_amd64.deb
+    digest: 2ea949de45dfe27832a6e7816a03103dae4ed45ba2b380669de5d5c89c361cc5
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_amd64.deb
+    digest: 68fe4a526d73dd2ff6b75c593a5a4059486d1ec2535ec5e42cc52057a52744d2
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/linux-upstream/linux-libc-dev_23.01.01.14+STE_amd64.deb
+    digest: 6bdeb3308841d5a40930eeea4214170dcd222ff0394cda1e4d27aff5c212ba18
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_amd64.deb
+    digest: d184d5fd7e340055beee8115e1f28663e539c024ede10773ac03f4ca3f86e343
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mailcap/mailcap_3.70_all.deb
+    digest: 7ca67d118c03eaf58346eb1e676ff16f4d1aa5252a8cc6b5b3b1ed44556180f1
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/make-dfsg/make_4.3-4.1_amd64.deb
+    digest: faf91f05aec3d6779a1b53f28cc27ceeb6a173f9e395851c9c29090dcf2e3705
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/media-types/media-types_4.0.0_all.deb
+    digest: cd124053950ab8b0373203bceb7eab841791017daf1d50db2ece09e4da52406a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mime-support/mime-support_3.66_all.deb
+    digest: 20294deda4378616c2b48614ee226731ec09663c3497c35a467e8ea5fa03f16a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/netbase/netbase_6.4_all.deb
+    digest: 5fd05a5d63864b96453ba55a4c5efa287b8e7e53fbd833e7a944e066d30e1eb1
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/patch/patch_2.7.6-7_amd64.deb
+    digest: 4bf340095bbde164d3ca33360e3b9d89a2f92bb1912cf2b4fb21a266c2ca250c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/perl/perl-base_5.36.0-10_amd64.deb
+    digest: 50fa4a0bbefde86abf9ffd1fa092ee82af23ccc8f65b5b952526dc885c943169
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/perl/perl-modules-5.36_5.36.0-10_all.deb
+    digest: 907542b9a413bd0276d5ef94fef77083715a692fd33c52ece44d11fff847bab0
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/perl/perl_5.36.0-10_amd64.deb
+    digest: 59d13b610350339f3b273097011a3db6db60a99d587bf04eeb881c1a34168390
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pkgconf/pkg-config_1.8.1-4_amd64.deb
+    digest: e9751c5efad4e9fb2150686bfb82ad13ff8b8f7d00592d3571f70f17a61ba884
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pkgconf/pkgconf-bin_1.8.1-4_amd64.deb
+    digest: 6d6e880665acf6c1600e779d00259242e7f58e957dda43d760b65df472ddbfbd
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pkgconf/pkgconf_1.8.1-4_amd64.deb
+    digest: 3e8dd26853b621b7b1ef82533bfb3bfa0c9ba07f581df727cb3271e7a35edf33
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3-defaults/python3-minimal_3.12.1-1deepin1_amd64.deb
+    digest: 44712ddb4dd007c7916d3bb3e2539d0853251b4672e6b76d057733fcfb26fe03
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python-packaging/python3-packaging_24.0-1_all.deb
+    digest: acf9e0347764b07624b219b64fa7721705d6eeea5a98871f892aff3ab0293ae4
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3.12/python3.12-minimal_3.12.4-0deepin1_amd64.deb
+    digest: ad3ff722bfadedaeea33599b5ee43e88f7cb0c3a5f9185348058d0ddb7c9830e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3.12/python3.12_3.12.4-0deepin1_amd64.deb
+    digest: 5cf3eca309d9562d2c4b3102dc4fe89db6f670e634066d70f1d3c0af2843c852
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3-defaults/python3_3.12.1-1deepin1_amd64.deb
+    digest: 3e3840ef15b198763d57c130ef9675a46fbdf534f2d5d721f8ddf91b6d743c1c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_amd64.deb
+    digest: 1ddd2f46a8e6b858e589bb011fcafb498ea673c78dd248283284b8a188cf996d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin5_amd64.deb
+    digest: 2bd4061502b590e7e78fd5cfe089eb7e7fb173a15fed2ced98b50737549b8208
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin5_amd64.deb
+    digest: 17025348f2c9c6a1dd0742d8559771261dd4d297c9e3fc856ae8ba91a0ddb6bd
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin3_amd64.deb
+    digest: 359f5fd7d83789deee753300437ea35ef2004a4ac03c5367249246addcafc210
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin3_amd64.deb
+    digest: dcef2b6339bb7f19c33a710f6817b5f0512824a6139ac038a1626f766c2d3b91
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin5_amd64.deb
+    digest: 216615817367297df6cf55a42109f53ecedebdf973ad3ee5aca0a8335774c65a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin5_amd64.deb
+    digest: 655b85be8e6045818776113a226aa32bd3b5aee2edd6db07ad86ea65e565b490
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin5_amd64.deb
+    digest: 3fcdda184d430545018216f81c03df54de1f1a07d096cc6597b94e89d407441f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_amd64.deb
+    digest: b9e766a60ff54dc40cdd1307aead4f3c2c1997388e21fe36ec37650bcf650384
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-imageformats/qt6-image-formats-plugins_6.8.0-0deepin_amd64.deb
+    digest: 820f8a30e3cd001eca5a21403b060ea5f047017fc9450423717ee7a59461a8f5
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_amd64.deb
+    digest: 9ebce5aacbc3bd447f6fa109d03647369ec93d054f45a4b6f332b2643ebf9c0e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin5_amd64.deb
+    digest: 5264d118de60afa8f15122126da05a7663ed8cfe0b592bd9de18bf290f26d92b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin1_amd64.deb
+    digest: 0acef551ad9074060268eabb8d0b2b4703b005b00672a23406346e19d7346de7
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/qt6-tools-dev-tools_6.8.0-0deepin3_amd64.deb
+    digest: d2521c7f6a5efb286c34d765cf0cdfc2dda504204acb81ed39657315602350dc
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/qt6-tools-dev_6.8.0-0deepin3_amd64.deb
+    digest: e2b8c1f31715901d773e714ab0105534aa17ed64ce9e5065900e4fc8fa17ed58
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/r/readline/readline-common_8.2-3_all.deb
+    digest: 35fe59faceb8d9def8b6aa664e091eac8444887bc1f33ba2cf22099c3646e7bd
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/r/rpcsvc-proto/rpcsvc-proto_1.4.2-4_amd64.deb
+    digest: 76a363bd052b40394f829486c820967c1386539c2fbdd7aa2e77430132fccab0
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/shared-mime-info/shared-mime-info_2.2-1_amd64.deb
+    digest: 545413a218d5cd7e3103b5e277419a7e67044c95f83ed7fb700c6c99ba523c02
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tar/tar_1.35+dfsg-3_amd64.deb
+    digest: ee27ac0010bb1525067edda7b6b86110a00550232fb154f87491dbc3a3a2c8ff
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tzdata/tzdata_2023d-1deepin1_all.deb
+    digest: fe503c524801260208482a1dfc061e79c2a7450111dd90f88ed40d70ac935832
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/uuid-dev_2.39.3-6deepin1_amd64.deb
+    digest: 0ab4e3eb8b8b386bfb3718ba57f67acd57f07ee2f1ceade1beda197c0ab4af03
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xorg/x11-common_7.7+23-deepin1_all.deb
+    digest: 9a7643db11023a8bec126312edec4b1b7357b93416bdfbaf9b0cb8bc04506d49
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xorgproto/x11proto-core-dev_2024.1-1_all.deb
+    digest: 82bff9dab1d74e30bdbc6130f94d1bd361c3c1d3cdad660bd92e5b730c4cba7b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb
+    digest: 39e14817ff2ab4eedade206fefebb7b2632e4dd7c358a9cfe36bcdd477554a04
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xfonts-encodings/xfonts-encodings_1.0.4-2.1deepin1_all.deb
+    digest: 07d68c68eeeca62cea0558b4f0bc25896bd82fddfa6c4b02693ee0adc4bde224
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xfonts-utils/xfonts-utils_7.7+6-deepin_amd64.deb
+    digest: 5a83d9ea46a19255d820eebcf8c6a8a08339e1e37ad11ac3b8d89d1dcb719e13
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xkeyboard-config/xkb-data_2.38-2deepin1_all.deb
+    digest: 6fdc32f08737735128e20a10f9a8425bde19855e3917d8f26a62ea3a12a9a720
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb
+    digest: c3ac4805a75219ecc8a92a79697d39fa9abf6a7fa16da540800a0d30bdcc2847
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb
+    digest: ab37e512128e066d7225deb7f51f0c77f9b0c3913d75f2a7f9b1d708327a099d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xz-utils/xz-utils_5.4.5-0.3_amd64.deb
+    digest: 6144e64526111988775c0c78db08e9afded0f1f760fe924895017ac338f87553
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.1-1deepin1_amd64.deb
+    digest: 6d5bf0445a25257bc75a612224498ecddda2fa56edc8d17af5c4bdd2713edd4b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/z/zlib/zlib1g_1.3.dfsg+really1.3.1-1deepin1_amd64.deb
+    digest: d0bab03ed3981fbe2bae8799a3c45d9a3b1561ae3d7bcffe37f235d573ae24c6

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -1,0 +1,1058 @@
+# SPDX-FileCopyrightText: 2024 - 2025 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+version: '1'
+
+package:
+  id: org.deepin.image.viewer
+  name: deepin-image-viewer
+  version: 6.0.10.1
+  kind: app
+  description: |
+    view images for deepin os.
+
+command:
+  - deepin-image-viewer
+
+base: org.deepin.base/23.1.0/loong64
+runtime: org.deepin.runtime.dtk/25.2.0/loong64
+
+build: |
+  bash ./install_dep linglong/sources "$PREFIX"
+
+  # add path for searching OpenGL
+  export PATH=$PATH:/runtime/include:/runtime/lib/${TRIPLET}
+
+  VERSION=$(head -1 debian/changelog | awk -F'[()]' '{print $2}')
+  cmake -B build \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+        -DCMAKE_INSTALL_LIBDIR=${PREFIX}/lib/${TRIPLET} \
+        -DVERSION=${VERSION}
+  cmake --build build -j`nproc`
+  cmake --build build --target install >install.log 2>&1
+
+  # 项目生成应用名和动态隐式加载的依赖库，ldd无法找到的其他库
+  LDD_FILES=(
+    deepin-image-viewer
+  )
+
+  # 生成.install 文件
+  bash ./deploy_dep "${LDD_FILES[@]}"
+
+  ID_VALUE=$(awk -F ': ' '/^  id: / {print $2}' linglong.yaml)
+  # deepin-ocr-plugin-manager model 文件添加到 install 文件
+  find "${PREFIX}/share/deepin-ocr-plugin-manager/model/" -type f -o -type d >> "${ID_VALUE}.install"
+
+sources:
+  # linglong:gen_deb_source sources loong64 https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release/ beige main community
+  # linglong:gen_deb_source install libdtk6gui-dev, libdtk6widget-dev, qt6-svg-dev, qt6-tools-dev, qt6-tools-dev-tools, qt6-base-dev, qt6-base-dev-tools, qt6-base-private-dev, qt6-l10n-tools, libraw-dev, libexif-dev, libdeepin-ocr-plugin-manager-dev
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_loong64.deb
+    digest: f6ff5fd88f299cfe07c0c808da8795d6ba4a6add35435dde5be1a64a4403de0d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/binutils-common_2.41-6deepin4_loong64.deb
+    digest: fe840ed00fd544ea41df879fc2c46809674b622dabdec981998cd0fc28c8b870
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/binutils-loongarch64-linux-gnu_2.41-6deepin4_loong64.deb
+    digest: e60fa11631dd3043e03e9677b2e2c203e4106a280603695f6fbdc664c7674918
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/binutils_2.41-6deepin4_loong64.deb
+    digest: 565d6d2d33833a647520eb4129bef71f550982efa96a2af6cf2f566b4a3888e6
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/bzip2/bzip2_1.0.8-deepin1_loong64.deb
+    digest: 08d9f48f571bc206fe4e30a27e535a3a086b9dedba4a5f5055e898ff0dbea7a6
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/debconf/debconf_1.5.79-deepin_all.deb
+    digest: ded6aaa7927ae27337ceb23d49391b4c7ec460a00ba692020e8f4e28388f345f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_loong64.deb
+    digest: eab43bf5b5365d2839d6c319aa489eb239a581d8fadc3132920645bf20948a70
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dpkg/dpkg-dev_1.22.6deepin3_all.deb
+    digest: 52e7455da433b7e412afeec3848d3f6371a857653aea02d1a6e080db446f51d9
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dpkg/dpkg_1.22.6deepin3_loong64.deb
+    digest: eea7a8587865789ec9f40ae9c3e5310f82a5c8c295b27d65e91627c86c107951
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fontconfig/fontconfig-config_2.14.2-6_loong64.deb
+    digest: 17c510572e0a51ecc5a4eba486a1cfcb55d2ac297c84f35bc7c58cbc31e6471b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fontconfig/fontconfig_2.14.2-6_loong64.deb
+    digest: 85fed3d569a4fc895efd890e842e276016aa92848ddc3419c6fdaabc02280c7f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
+    digest: afbaf120869a08aa7dd14da9ad014de48a751aa4330534b531410bb86c411b55
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-dejavu/fonts-dejavu-core_2.37-deepin_all.deb
+    digest: 5982963d05dbf4efa009c3ab6db3576a03f680199d75d7d5edda89c55def912c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-freefont/fonts-freefont-otf_20120503-10_all.deb
+    digest: c66666da94b9a0477351ee9d6d7a247a0a3c842e428da770991b45f03be2ee72
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-freefont/fonts-freefont-ttf_20120503-10_all.deb
+    digest: 79b23c3945d4628463672a804a0e81bc4c262ef87cb6316afb40167a50bc3145
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-liberation/fonts-liberation_2.1.5-3_all.deb
+    digest: 9285213fd8d6515bc6c1be5b810bf39918a668a17024a9fd3541879ce7fb5344
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-noto/fonts-noto-core_20201225-deepin_all.deb
+    digest: fa09d95f516c498d55e516d549b8ee41d9a7b6f17cdf0bb4b43744d672ce1366
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb
+    digest: f66d6f798c4b99d8490558cc8209c069b0fe5577c11378c0e01f9e87ddf10824
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fonts-urw-base35/fonts-urw-base35_20200910-7_all.deb
+    digest: 4800c0b08fbeac0335f1e23df2d41528a242383324c256ebece00c8f438eefbd
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gcc-13/gcc-13-base_13.2.0-3deepin3_loong64.deb
+    digest: d633244b99267cb17e5591c3b221f74f65f1b31bb9f290acc8c255469e01fc63
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/gir1.2-glib-2.0_2.80.1-1deepin1_loong64.deb
+    digest: 9adbd030273cfacb0eb6223bfdce65e0106f5c811d96caa66978598bb40f3309
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgudev/gir1.2-gudev-1.0_238-2deepin1_loong64.deb
+    digest: df1346b7d3f97770fe21c1d05024d3d9583cfd1d4dd3da3036f8a306419eb1a1
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/acl/libacl1_2.3.1-1_loong64.deb
+    digest: 6a5d883c7ca1fb96e88290e5f80f2310b83e190d02133676ef19fcce44b5fc39
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/attr/libattr1_2.5.1-1_loong64.deb
+    digest: 405e34b981984b1e6d04b5093fdaa36013459af4687c62c3a7dbdd0b42766ecb
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/avahi/libavahi-client3_0.8-5_loong64.deb
+    digest: 9ccbd93fc9d06c9ddf2b4fa7a399f4695576f80624ce1742ecce86de1b31006e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/avahi/libavahi-common-data_0.8-5_loong64.deb
+    digest: 24752d796aa2f23c09e8bff308bffea8e605b818e77cd6af06e6fc2678e80396
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/a/avahi/libavahi-common3_0.8-5_loong64.deb
+    digest: 38d7141a270890e7a5e6dbbf668436061d17b6ec81abae9277b5171cc0677698
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libb/libb2/libb2-1_0.98.1-1.1_loong64.deb
+    digest: 43c9bedf808d5c2b85351f73dab25e81c5674c499c293be875ac5250c4b8cca0
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/libbinutils_2.41-6deepin4_loong64.deb
+    digest: 7aa139173a2527c2091b86730b83cf4f8ab922b18a89b4e11bc7047438712410
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libblkid-dev_2.39.3-6deepin1_loong64.deb
+    digest: 1ae31bcf267da44344974386315edea5a613a9fe7242cba4b1749e90e18c50e7
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libblkid1_2.39.3-6deepin1_loong64.deb
+    digest: 461e40f1f9e1aac09b577de585d654725476ee1d355d0ef508fb4ec0ee5e21c1
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/brotli/libbrotli-dev_1.1.0-2_loong64.deb
+    digest: c2388059363813c7ad5e42d91f514b1e93e3dd07432634eca0a6814e2d7edc10
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/brotli/libbrotli1_1.1.0-2_loong64.deb
+    digest: fa0a0735177fd06de4701acc3ccc180b7b45da0e3573cb82cdcda56dea9ded62
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libb/libbsd/libbsd0_0.11.7-4_loong64.deb
+    digest: 1a2e574f4385b39b0e1597f0220fb743d8f2cc4ed0a19047e97d361151d30c6b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/bzip2/libbz2-1.0_1.0.8-deepin1_loong64.deb
+    digest: a29abfb786ff0410774a943b1835520b9184b7bfeb4bbe24e1c1e244aec2cbfb
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_loong64.deb
+    digest: b073876e60d9f9ba41ff9f984d0895c37684272da7ea5389b2ceb85598e3154a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glibc/libc-dev-bin_2.38-6deepin7_loong64.deb
+    digest: 20388887631a10f107829e8b8bb7a2079adc25a243acd5a778781587491ecc7b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glibc/libc6-dev_2.38-6deepin7_loong64.deb
+    digest: 7b5a4acec8ae11ed60eb1fda0e2408056414335c2360796956a73eb3dd260c77
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glibc/libc6_2.38-6deepin7_loong64.deb
+    digest: 94e71f05ba2c63b39dd4b5ed2446d052e231795c058730c00cdf9beef4b8c53d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libc/libcap2/libcap2_2.66-5_loong64.deb
+    digest: d4cbe29713f415bd8679e79b2d4558a790c0749b1ee8f829ffa77cfc29695377
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin5_loong64.deb
+    digest: 8a7e85de84804dd73ec433de1ad3fb61905c8c8a943365620cea7cedd44a6967
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/llvm-toolchain-17/libclang1-17_17.0.6-5deepin5_loong64.deb
+    digest: ee391e47845900e8362b9cc01aa298a4bf662e354f17a91d2cada946f72fbce3
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/e/e2fsprogs/libcom-err2_1.47.0-2deepin1_loong64.deb
+    digest: 47f0cbde458a5b5998a470c7ccb6d7d299edda99007d79eede46b23ee2b26401
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcrypt/libcrypt-dev_4.4.36-5_loong64.deb
+    digest: b613149b2665f0c26951cf78b70777ae30ed60feecbd2c86a65233ffffdbebb5
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcrypt/libcrypt1_4.4.36-5_loong64.deb
+    digest: a9dcd576d5cd80ada64381a1727a3116545e93cf447f59c7414d1777e2993fec
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/libctf-nobfd0_2.41-6deepin4_loong64.deb
+    digest: 2865f6e5b84a2b879e3a28a2a9596658be420fe428903b5a99426a299d5d75f3
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/libctf0_2.41-6deepin4_loong64.deb
+    digest: d7f1a09ddd15c431f09a4f35f86e28f463821654a41902a02b9e74a617f0e4c2
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cups/libcups2-dev_2.4.2-5deepin1_loong64.deb
+    digest: a6bcb173e61ad5273becf725933fff6bb10cfbe068d4a9a23af53b542b47cb78
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cups/libcups2_2.4.2-5deepin1_loong64.deb
+    digest: f81c3066868743ee4c5cbf09088c1b7f8dfc38832b358012ebbeab92a1428051
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin1_loong64.deb
+    digest: 51248257d36d6528d3cf0cd7f038c6da2cf929267029b18a13ecdde2213cfb25
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/c/cups/libcupsimage2_2.4.2-5deepin1_loong64.deb
+    digest: 3c9ca124f4de35b207d02b042d1d25bacff0d4a642e0c34ace340d4667e7c037
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8deepin0_loong64.deb
+    digest: 976e0ae132630258702d76bc235bec36ea5820e506bc110585aee657fb487472
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dbus/libdbus-1-3_1.14.10-3_loong64.deb
+    digest: 78833b3973000dd505cd32d2301a8d5a9bdc5070360c2de5bebc9e9cc5289b17
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/deepin-ocr-plugin-manager/libdeepin-ocr-plugin-manager-dev_1.0.0_loong64.deb
+    digest: 9e0c8c0d8d57a661b9d4467941e0eea55a3024408753e26bb59f12dab6c1c97e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/deepin-ocr-plugin-manager/libdeepin-ocr-plugin-manager_1.0.0_loong64.deb
+    digest: 34f30fd6966a97fbe087fcd008ef68221679843df5db1ecaa464d252b98734df
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdeflate/libdeflate-dev_1.18-1_loong64.deb
+    digest: 6d218959ede7fd5ad4fde3c25dc2c26f113d1e07c487d344a7678c29b9ce0dfa
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdeflate/libdeflate0_1.18-1_loong64.deb
+    digest: 1b60dc1dbbef61987759b5254d408edbd7d653e28b94f857de22578b0ca62dae
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_loong64.deb
+    digest: 1cb1deef108f4163f884f564e9fcfd429adc315e9509c30ff3bcf936824ac543
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dpkg/libdpkg-perl_1.22.6deepin3_all.deb
+    digest: 71989ccb16cfcc04aa5a86f06e4dff837a4fa755d04d17d5f0cf329fc09dda04
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdrm/libdrm-amdgpu1_2.4.123-1_loong64.deb
+    digest: a26ef022dd15349da87ea50e9a8fa2799ab3f5287c93075bbf6c229c2eafd969
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdrm/libdrm-common_2.4.123-1_all.deb
+    digest: b8289eaa6341a8493f4c191a45165fe944248da69f675d09005a29058e7ae5a6
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdrm/libdrm-radeon1_2.4.123-1_loong64.deb
+    digest: d1ff95314f5b678d51fcbcb5c1adc603db5958e82fef41dfff3431c3274e18bf
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libd/libdrm/libdrm2_2.4.123-1_loong64.deb
+    digest: 9b28e3fcb6cff61e26352d3b426fe25b0c19961120d499fd5cb05f5177b411bd
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6core/libdtk6core-dev_6.0.25_loong64.deb
+    digest: 6c61509dbfa71c1bef66b405f76a18e4f68e62aed4d55626fb2fd2e2ac87c8cd
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6core/libdtk6core_6.0.25_loong64.deb
+    digest: d637527e884ee0fdcf6683013c932de3230c7c357afc87a4d2e31e0250c76d84
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6gui/libdtk6gui-dev_6.0.25_loong64.deb
+    digest: 7a16c5c6e9f9002a14350ca92bcd645a7b2fa0f1dc2fdf0ccece81628e65e530
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6gui/libdtk6gui_6.0.25_loong64.deb
+    digest: 4ae1e9b1b54e2c23bcb5d1bbe82d9e8914d86c8f6bd849e564a72cf0401d6e47
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6log/libdtk6log-dev_0.0.2_loong64.deb
+    digest: faecf60fdd232fce51578eee0380bfebfccc84cf7c00ae3d41af9a43572f2c0d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6log/libdtk6log_0.0.2_loong64.deb
+    digest: 9e03504ae093c9be1bec37e76dd97ef78bf4fe519320828ebb41096cebe47649
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6widget/libdtk6widget-dev_6.0.25_loong64.deb
+    digest: 55fe88c9f524afdbbb25ca361b1bb5d508848d94c9fcf8add1f9559ae717812a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtk6widget/libdtk6widget_6.0.25_loong64.deb
+    digest: 81a053ed14e32a37af815860e1a3f77c06c00956dbe840040b25098335b4e1de
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtkcommon/libdtkcommon-dev_5.7.5_loong64.deb
+    digest: a33416dbd875dda49e387dce675dfbfe364eef8c0237ed869714535deb97987d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/d/dtkcommon/libdtkdata_5.7.5_loong64.deb
+    digest: 7e6f8fa112dcfc39ddd784f68cb20629ac9fdf8a014035c4233fea7d3afeafc1
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libe/libedit/libedit2_3.1-20230828-1_loong64.deb
+    digest: 851c5523af03e9dc081aa14afbeade7eeb1a21de5597226f13e0dcbed4a6ade7
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mesa/libegl-mesa0_24.1.5-1deepin2_loong64.deb
+    digest: a44f7b45ca577b0d50ac305f25800316bd8beb63bee523dffd6c5bfa1206fcf1
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libegl1_1.7.0-1_loong64.deb
+    digest: bbc7f8773ad9b2cfa4a27a26d6ad4c276eada2db9b680d54bdf7eb59ee9e5012
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/e/elfutils/libelf1_0.191-1deepin2_loong64.deb
+    digest: 16e47795eed490234214777685afc5c411a8ad0fdaf3508469e3105fb2b364df
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libe/libevdev/libevdev-dev_1.12.0+dfsg-1_loong64.deb
+    digest: 1bb14f1d3b2a10316e1db8b888585b1486789cf2b060861e0281178dcd75b828
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libe/libevdev/libevdev2_1.12.0+dfsg-1_loong64.deb
+    digest: f2f047f2363dda33826f748756c5b1c8a2bf809c981a66509876eb150583b278
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libe/libexif/libexif-dev_0.6.23-1_loong64.deb
+    digest: 9de1e8e206fafff8cada2ce815ba093a01296b22330450da2d21a2002735c343
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libe/libexif/libexif12_0.6.23-1_loong64.deb
+    digest: f5365c63e491f48204faef20665b2b513c10338425d3e9b68c88ca999c087f24
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/e/expat/libexpat1-dev_2.5.0-2_loong64.deb
+    digest: 0e5c956c6ba2967eb8e61479c2bf56189c8bee0077ded44015b9240ab11ae4f6
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/e/expat/libexpat1_2.5.0-2_loong64.deb
+    digest: 845317fb7d0fdc029f3aa98c870826391b9bdb530c6aee296fd1671ed5dd8429
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libf/libffi/libffi-dev_3.4.6-1_loong64.deb
+    digest: 864ef36cd80bc0a9fadbdafca5a5ef05ff92458f945bc1c20753d7635d8f17b7
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libf/libffi/libffi8_3.4.6-1_loong64.deb
+    digest: e1d9a61065aea68e96e14f496d7bfd63e024f8874e1d320cb607efd82dd96910
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4_loong64.deb
+    digest: d1a3b1236183019b2d22d04f45e772ecf88e6d4bf36a4820eac7133be614c4f1
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fontconfig/libfontconfig-dev_2.14.2-6_loong64.deb
+    digest: 353ec48905f9c8553b1e46a60124deb598ff3a1c07ca6a0aff62b0c5ba5bae77
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/fontconfig/libfontconfig1_2.14.2-6_loong64.deb
+    digest: db05b74e370f34d39ff896e5070fee3351a4cb938e86bc6dc852c624cc9534cb
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libf/libfontenc/libfontenc1_1.1.4-1_loong64.deb
+    digest: 36450772f287a243ed0ff6c3b5e491021c7d63f6f68a9e71711fbb6e5884c868
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/freetype/libfreetype-dev_2.13.2+dfsg-1_loong64.deb
+    digest: acb0c01cf1db9cd8abf2ba2fb1deea3f6c52e90a471d0cba26e403d9fca7c292
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/f/freetype/libfreetype6_2.13.2+dfsg-1_loong64.deb
+    digest: ad56d47b6131633a5cd1f2a0e651c4bad65c92c35faf41e664ff79d9ca0df2c4
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mesa/libgbm1_24.1.5-1deepin2_loong64.deb
+    digest: 404e80e480804be07bbf59631365f4cf6dc9ec57c49fd6a0f07bf0cf4f940aee
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gcc-13/libgcc-s1_13.2.0-3deepin3_loong64.deb
+    digest: fe12d56b3510d451c1c494eef3fcc29b7cd05b847eddd533510c7645448a8b7c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgcrypt20/libgcrypt20_1.10.3-2_loong64.deb
+    digest: 5bdd589218c3c04dd4c23f14e1815e007f56c84bd45cd497a1bf4e720bdbb6cb
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gdbm/libgdbm-compat4_1.22-1_loong64.deb
+    digest: bc7c3017145d403f6935e564bbcf6ee8904dbff103b96ecd876a3a66cebb6ae1
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gdbm/libgdbm6_1.22-1_loong64.deb
+    digest: 2d965b1e2624d262111a5a767278f4f4ad51eb1c073096ce2dbc42e0c02f3fcf
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin1_loong64.deb
+    digest: 02f892b6d38643410cd753637657b9803eb718268927eec5232e68045e81d13c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libgl-dev_1.7.0-1_loong64.deb
+    digest: 34cc7650a8d538e59d44560580ff7d0819b2607877299a65585cb516d4136c03
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mesa/libgl1-mesa-dri_24.1.5-1deepin2_loong64.deb
+    digest: 3308be394c3ffbd105fa29d7df5af2996a74841afb297182be407d05af02463b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libgl1_1.7.0-1_loong64.deb
+    digest: 623a88c159a1e9eafc6316e91d3c55179c692fa950ecdd06f1955144813eb6b6
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mesa/libglapi-mesa_24.1.5-1deepin2_loong64.deb
+    digest: 1c7a900b9bd87aa232d2f74ce68fc6925ac3fb6102e244f654ff54aacd23711b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/libglib2.0-0_2.80.1-1deepin1_loong64.deb
+    digest: 796a8a4bfcc14d204bc23914f524a0dcb3b0545611060b3056547eb281e277f4
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/libglib2.0-bin_2.80.1-1deepin1_loong64.deb
+    digest: eb81bcc49501d0e04514a0fa968beb0a0b81d4d4a35199c0d5c660e7ea6a1575
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/libglib2.0-data_2.80.1-1deepin1_all.deb
+    digest: 4e75a1c9e56c81ed2c1737e3e6fe590163a77ff45179101a4fcfb90b4c0d135d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/libglib2.0-dev-bin_2.80.1-1deepin1_loong64.deb
+    digest: c7351415720634d89b5ddf7e809d78b458be23d09cf32365e14a72141d6d20c1
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin1_loong64.deb
+    digest: 1828aa1e6fe842d0713e1ae545f874d2335ab0c683638eb5bb594dd76037cd87
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libglvnd0_1.7.0-1_loong64.deb
+    digest: 4ac20b2ddbc5d3985d95befa3db331ebcf6bf9d8b9c13df462018e2e6fd91218
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libglx-dev_1.7.0-1_loong64.deb
+    digest: bdb1eb7fd4e391c38fc5a21da29b1569afb19bf9594e46fef10311bd4d4f0441
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mesa/libglx-mesa0_24.1.5-1deepin2_loong64.deb
+    digest: 17f2707c6c7f351fff8619c03124985d9b244dd1ba5f7a78ae37b0d9940e2b82
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libglx0_1.7.0-1_loong64.deb
+    digest: 51e7ebb3d6b78cc5f420d864eb898e91a1ab386fea5c51548439231aa66d8232
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gmp/libgmp10_6.3.0+dfsg-2deepin0_loong64.deb
+    digest: c09ccc302996ba01e2f836ad038b25f5039c750fe2e10bbf66154f65b4ab3e5d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gnutls28/libgnutls30_3.7.9-2_loong64.deb
+    digest: 2b68ea50a264b00dfae6f6b003939b618eb9b4a206e8f3c4e5f6601428d7711a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gcc-13/libgomp1_13.2.0-3deepin3_loong64.deb
+    digest: f8d21f6663dc0057e9ace95a9f4ed30d682eef089970ceee9e0027497c2c245b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgpg-error/libgpg-error0_1.47-3_loong64.deb
+    digest: 432b4819ad1edb46e6d8116596212dbc3a82d0d34c93c3574ded8db352188c8c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/graphite2/libgraphite2-3_1.3.14-2_loong64.deb
+    digest: 3fc95b46c6dc87a3991386255c381d00c68a6ae6bfb4390ccb05f8cc61949331
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/krb5/libgssapi-krb5-2_1.20.1-5_loong64.deb
+    digest: a74abdb1e7ddf88624513747e6591d1c799bc8774187470bd05d8d489834d596
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgudev/libgudev-1.0-0_238-2deepin1_loong64.deb
+    digest: 5930cfa21617d8103fad46534ba6d07b3930e28a3606600755a076d3eb95319b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libgudev/libgudev-1.0-dev_238-2deepin1_loong64.deb
+    digest: 1c2e9030c9a558915577dbf8047628b212c9b48c175709b244dfa794feaccfd2
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gumbo-parser/libgumbo2_0.12.0+dfsg-2_loong64.deb
+    digest: eb28d4bec657f7273f965bde361caca747436978ff2b8dfda5bb4ce292c8868c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/h/harfbuzz/libharfbuzz0b_8.0.1-1+rb1_loong64.deb
+    digest: 23f39df88cbc47f74e5a77408b2cdbc4fc47e41fdae3e5fb319a9cbe552c12a3
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/nettle/libhogweed6_3.7.3-1_loong64.deb
+    digest: fca8fa6138c16bfb7f8d8fb78f55799c24b9a01bbac0202816b22624cdd0da6a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libi/libice/libice6_1.0.10-1_loong64.deb
+    digest: 71f07175fac63f8a51f001299a9329a38c4320df6b46e6bdda20768aa90a3456
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/i/icu/libicu74_74.2-1deepin0_loong64.deb
+    digest: 02c3223e35ca49a4c9c167ccecd7c49590e8fd710a203dff70d476e038632320
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libi/libidn2/libidn2-0_2.3.2-2_loong64.deb
+    digest: b235fca3fd81c2e6918d54b8d71f79757d6b818cf897fde7cb3826dc23ce85b3
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libi/libinput/libinput-bin_1.26.0-1deepin3_loong64.deb
+    digest: 0fff2ff2f3f962bcc63f9d7379995197a1727ce30a91f908ea72a3fa662a6b51
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libi/libinput/libinput-dev_1.26.0-1deepin3_loong64.deb
+    digest: 6d985129e0600d7fe4a411a39bfadf4c73f8563ac1604635d19fda6a9cfc111e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libi/libinput/libinput10_1.26.0-1deepin3_loong64.deb
+    digest: f8251fc25fdbcef6b938b6be532237f63c3dff78dd83b1d3ff665748685f7f4b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/j/jansson/libjansson4_2.14-2_loong64.deb
+    digest: 4a8662b90c807a6afaf7ac4d89ae42e33725c60f5a0a26230366cd487425faec
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/j/jbigkit/libjbig-dev_2.1-3.1-deepin1_loong64.deb
+    digest: 0c3b4ccc6927abdfddb2d909ca139fbbf1c5e81ccfdba90c1ffcce9f460d4cb7
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/j/jbigkit/libjbig0_2.1-3.1-deepin1_loong64.deb
+    digest: 8940e6f4dce77f526bc32b5211d850389bc0875cf944520e9f0a4d85a170e9a9
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libj/libjpeg-turbo/libjpeg-dev_2.1.5-2_loong64.deb
+    digest: 152658aba54e2f163ba19c0fe53aa7666e1c6907eda79433f1ec38240a9670b7
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libj/libjpeg-turbo/libjpeg62-turbo-dev_2.1.5-2_loong64.deb
+    digest: 342808c163f19bfdfdb7f36cf51acce6401aa2c0df6fd5695d0b3a9f2731bd9b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.1.5-2_loong64.deb
+    digest: 47df0f4474b4722b6a741b7c8b33057f38f58245efa92c176abd489665e92c1f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/krb5/libk5crypto3_1.20.1-5_loong64.deb
+    digest: 4a83826bbb0da645b6f48c1de0682bd7ba1d61a2b903fed7738ec7c88f559b8b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/keyutils/libkeyutils1_1.6.3-3.1_loong64.deb
+    digest: 0f7646fd6ba7bcf29756eac9b72ce2b03ad5de6d90e131ce0ab97e51f1da29ab
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/krb5/libkrb5-3_1.20.1-5_loong64.deb
+    digest: 071d32ffb73b3feca3d9135ec6109730728b20f40dc194abb24d3f4506c964ef
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/k/krb5/libkrb5support0_1.20.1-5_loong64.deb
+    digest: 7ec7dcba628cbededb02866a71961599d1fc501303c2797f756381ce2026845c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lcms2/liblcms2-2_2.14-2_loong64.deb
+    digest: 0d4c7d34f69d56cc287e478af83d7cfddcf44a5ba77b6c4bf8a8afa7864c9f7d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lcms2/liblcms2-dev_2.14-2_loong64.deb
+    digest: c3984f83fb1014fdc5eeaf79691e937c3c78f6de2ac26a689b3bdda9ebd6b8e2
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_loong64.deb
+    digest: c0a9c5a24ac81fd6e5641d36d47600df17b732fe3a5c024753da8e32679a1447
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lerc/liblerc4_4.0.0+ds-3_loong64.deb
+    digest: 04d2a5b464a65ed87d48e331080c46b39c6b2e088c5b4d251f06a46355dc905a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/litehtml/liblitehtml0_0.9-0deepin1_loong64.deb
+    digest: 6b486a85ac27b4001d13fb43838047f46ea84c3b97baa48d0ede572ccd47817f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/llvm-toolchain-17/libllvm17_17.0.6-5deepin5_loong64.deb
+    digest: c3d8669054edf11e7182e2a5add9e6cd29e324da3ef1e51d6c251719547da66a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lz4/liblz4-1_1.9.3-deepin_loong64.deb
+    digest: 223608f8e5ab70c862665634392467d8cdb27b39d749f8367ecf8f709ffd0044
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xz-utils/liblzma-dev_5.4.5-0.3_loong64.deb
+    digest: 3ae2965f4f532a1dfc813c0d9ba0461219093f4f0ab50c9f3ca77ba99d71cf34
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xz-utils/liblzma5_5.4.5-0.3_loong64.deb
+    digest: 8922429eeb2d802e40eaba8567afb65504a70988e500d4d7a455f1ea6c79f20f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libm/libmd/libmd0_1.0.4-1_loong64.deb
+    digest: f54d26b7c46c848e15a460cd03140e8a436ea2f5b6b7e287e47994d1c627dbc8
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/md4c/libmd4c0_0.4.8-1_loong64.deb
+    digest: 38b04a9c6431d337342ef954a98ddc75b6ea0da7b17d321cf5f4ba17e73d9dea
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_loong64.deb
+    digest: 501c91fa0ba7cc9f6bceff658ffdba2323039a590719a2030f2dd37266d296aa
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libmount-dev_2.39.3-6deepin1_loong64.deb
+    digest: 73941c73eb241e1f14e1437904f999a5281cd7f9ab011c4fe07bc7bcda5de9cc
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libmount1_2.39.3-6deepin1_loong64.deb
+    digest: 09d325477885d70857f69af079ae718949684f01e4ef75de78bc39a08ba3c25d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mtdev/libmtdev-dev_1.1.6-1_loong64.deb
+    digest: 9b74501e7c7e6f5d5708bfb897a6710f2144da4806717be60cadb34d2e180353
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mtdev/libmtdev1_1.1.6-1_loong64.deb
+    digest: 4a5019080a0454a1380d3353dbc52b5bfebd3ad8f4c210425beeef8b6e5113e8
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/ncnn/libncnn_1.0.20240820-0deepin2_loong64.deb
+    digest: 49dd26fcdea6289777c3f084f38e3c2679c66de1b59177c0416f0e3d09c58105
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/ncurses/libncursesw6_6.4-4_loong64.deb
+    digest: 4db1ea7ab75ab8e38d6ea0e9c408766dd8328c84ded9e53aae7f6bba29e8e7e7
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/nettle/libnettle8_3.7.3-1_loong64.deb
+    digest: b49e593029d91c73f2240ffb5f129e3a47f613aadbf8ab5f50d592b2a5abdc98
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libn/libnsl/libnsl-dev_1.3.0-2_loong64.deb
+    digest: 20dfccabfb63024f4d18c0dddf6271436dd6b423643d8140ab157055c006b31c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libn/libnsl/libnsl2_1.3.0-2_loong64.deb
+    digest: 295c4fdb7405a01bac01bc50e542232014a5225cac5f675bfbe33ea41d1acd67
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/community/o/opencv-mobile/libopencv-mobile_4.5.4+14_loong64.deb
+    digest: 6cc5c8a4ce37eb0210d8b411d0e760357963767a88b9aff5f4c137fc48e374f8
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libopengl-dev_1.7.0-1_loong64.deb
+    digest: 72259f4ed0b1127c554e3747b8763fc18659dc5178fc2fe32ada313357c1802a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libg/libglvnd/libopengl0_1.7.0-1_loong64.deb
+    digest: c912f8a5180cda07f485be9334b8ca0c1bf779bc2449ec5fa08c347e5f18a132
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/p11-kit/libp11-kit0_0.25.5-2_loong64.deb
+    digest: 75dc180effd2912fd0a127952cc27c52ff0e900d7c8b79f3bb4b0d1ac1a120e3
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pcre2/libpcre2-16-0_10.39-2_loong64.deb
+    digest: c8062fb10212742a2ee3206282e185e1072fb891c17ae8bbb73777d7f4ebd93b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pcre2/libpcre2-32-0_10.39-2_loong64.deb
+    digest: c5694b615e555a112c2ec14ecd8002cf48bbeaefaa8a83c4c81f5bcb80825e31
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pcre2/libpcre2-8-0_10.39-2_loong64.deb
+    digest: ecc34edbd930aae24bd00654a682592d396e5f0b3d94ad3c40baa300e2cdd0c1
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pcre2/libpcre2-dev_10.39-2_loong64.deb
+    digest: 165eb3c1854d96d79f71a381b0ce8c04cdc8984d36587f15e77fa36e78320fd9
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pcre2/libpcre2-posix3_10.39-2_loong64.deb
+    digest: efb78bfaecc447039df6ceaf21a40055d692ceea4a38e700e280dfd05c521881
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/perl/libperl5.36_5.36.0-10_loong64.deb
+    digest: 04a865c6db98c65a2a540eb254174d4c012db34fc3b333ed5649fecedbfd0fbc
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pkgconf/libpkgconf3_1.8.1-4_loong64.deb
+    digest: 7fa4ed870a512323dc2bdebb32e85ab5c08036153b042a932beec468b3ba6089
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libpng1.6/libpng-dev_1.6.40-2_loong64.deb
+    digest: b264603a1bf9d98f62b3a2372c640f37c77a8eb45d7cef5fd450115c2cf8e2ce
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libpng1.6/libpng16-16_1.6.40-2_loong64.deb
+    digest: f865dc5b460fcb0d70dc87894a98da21ebde6149302056fe9a15a3687d388b9d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libproxy/libproxy1v5_0.4.18-1.2deepin0_loong64.deb
+    digest: 8c5d37ea50aeb08f936ee1e57b5f295cbc5d76690d92c265b26fbf0e14e687c6
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_loong64.deb
+    digest: 9d68b88d2e9de4c313b75ec6ebd8df51105856bf8998470dc7faf770308ddc40
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3-defaults/libpython3-stdlib_3.12.1-1deepin1_loong64.deb
+    digest: fccfbd0ff96d62aa2476f942b4e819b2bdce28f714ea360e036da7a0b3732597
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3.12/libpython3.12-minimal_3.12.4-0deepin1_loong64.deb
+    digest: 759e427492a789316db477eb515bcf7c94f688f88e5ed2cbb5da033a06b33966
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3.12/libpython3.12-stdlib_3.12.4-0deepin1_loong64.deb
+    digest: 86f63bfe267ae688785e96f5671516a53846e3459ff9ca54a4896f83968990e7
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin5_loong64.deb
+    digest: df1fb644c6f18c557df389f7c8caccb8041cdbcbb3ba64cc4bdf5bd9dfcf95f3
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin5_loong64.deb
+    digest: 05d37808475216a0a62fb277a78a21045f6a3371c9771eb614a38e175c67d861
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin5_loong64.deb
+    digest: b4bf3ee86fcbc0055e09cddc5cf75dadf7f2d92f2991207c6a0c591d9ddcf3cd
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_loong64.deb
+    digest: eefebd3f3d07b0f7d2f89e0ba469128aba20e0a1093ee0cc1853c3ddbdfa8616
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_loong64.deb
+    digest: 0cb93130f4822644f809425794909492760cee0cc6c3d5596883a07edfbf9993
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin5_loong64.deb
+    digest: 6512d39f8b25de932f919e8c1c5f6819ca71277f4c8a2ce5590ae347b98ca552
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_loong64.deb
+    digest: f748a917685218c990c97766bd2e9cf73caea758ba095bde0c76aed5d8b2c14f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin5_loong64.deb
+    digest: 32d4331abcf04409ac6526eb631f53c4d4d78e4c284441f6f22a468f17290dca
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin5_loong64.deb
+    digest: a3d00166167d5a06e1fbb75780ca2965eb064eee915591358584a7feef57968b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin5_loong64.deb
+    digest: 51d746486ddd8b214d7078de53fcc35701972f22cafd0248368176e06b80ea10
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin5_loong64.deb
+    digest: c2cd48cbfdef345b85b35d08ada160aa696a1b23afe9f9a224ad2fd9ba7c17ec
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin3_loong64.deb
+    digest: 31feabbf3ad584c4c450c37b5abb61ee289e05b11bbf04533131075201387b35
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-declarative/libqt6qmlmodels6_6.8.0+dfsg-0deepin3_loong64.deb
+    digest: 528f7878f461a24885cc8a1b453918d5225555a719a83cc1daf0d874d97af6a2
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-declarative/libqt6quick6_6.8.0+dfsg-0deepin3_loong64.deb
+    digest: 66477a2004afb5d4126dac018fba698d22e6e526f67e4531464ea04f8addd702
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin3_loong64.deb
+    digest: 889af35681f2708a99b089a4c9aa5f22e487da2125af9132d3f0e7b579b408fd
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin5_loong64.deb
+    digest: ac8528c19b56097b2476dce90edd35521971fab57e90fac1e44545866acf2e00
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin5_loong64.deb
+    digest: 34291f35a8454f65214fa6ae65d31569edb74d581aed75bd502885f575e20915
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin1_loong64.deb
+    digest: fc8cb023930b048f2caa531b913d991b4690a9f4692a9e4fbb423618ec67121b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin1_loong64.deb
+    digest: 7a0239be93289e6b8d54806f5ffec75a9f4aea7cee0af219fc1932e64abde72e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin5_loong64.deb
+    digest: 11eea51f1f01f37a4fecad877eaef15584bfd9792fa5cb6ed74bed8dce2119e2
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_loong64.deb
+    digest: a4651ca09a7927998b556155807a65a4b68d19a83f8a3a0907e4129f0ed983a3
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin4_loong64.deb
+    digest: 57068128d34bae2f408d6d8ca07061a6f034327b67ed03f27fc1e9aebff727a5
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin5_loong64.deb
+    digest: d3aa28809160e26462914fc87cd6b4fcb84bb59c9a925d864811c0fc8ab4a1d1
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin5_loong64.deb
+    digest: 26a96679e3356a3214126b3f58b1c6a2cd448f955925733340fe6fc1627ca7b9
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libr/libraw/libraw-dev_0.21.1-7deepin1_loong64.deb
+    digest: f55a0c473f041fcd076f58193292f68cd6e762376c0237f9616e7da4099c3530
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libr/libraw/libraw23_0.21.1-7deepin1_loong64.deb
+    digest: a4add147370c4417e729290c4b2d43a350de67d78b8e982f4c5085bab47b3fad
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/r/readline/libreadline8_8.2-3_loong64.deb
+    digest: a1c114f0856366970ce731783250b16f1a600a917ac54eb45b3fc765a7dc5e8d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin2_loong64.deb
+    digest: 704642e23cbbdbae01b29f6f6e9d7e8f23431a4cc5f33cdf74d7f119fcd12823
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libselinux/libselinux1_3.5-1deepin2_loong64.deb
+    digest: a19a49923398b268c9f2f8e45bca89a70779d5b1b788f9f295e428e731868fe6
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lm-sensors/libsensors-config_3.6.0-7_all.deb
+    digest: 164115506dfd335f26101e76cb49e2162b0440398ccf2d0c969ebc465dfd7867
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lm-sensors/libsensors5_3.6.0-7_loong64.deb
+    digest: 654049e53be85d4dab717bbfeb848f579c19d0cafd926a845357c62813263cb2
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsepol/libsepol-dev_3.5-2_loong64.deb
+    digest: cd6de58ec8972c1be0f4028a31b7b94d8079bd1c0bb6af78c21ab1c1a0b245a2
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsepol/libsepol2_3.5-2_loong64.deb
+    digest: ffe0ab79dca28bc304448ab0b91016fdd679746ce0d4395abbf9c38cf0c9774d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/b/binutils/libsframe1_2.41-6deepin4_loong64.deb
+    digest: aa7ec26e2e4c7d58d81c3887fb70e0fb352b36d0738b1b933d709052c21b7351
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libsharpyuv-dev_1.3.2-0.2_loong64.deb
+    digest: 9667bac75f00cdf47520a2ec5d444bcafb4c8eb3e13efdf86218f5c69d68652b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libsharpyuv0_1.3.2-0.2_loong64.deb
+    digest: ee12b9b2406d779965c510510bd32f01ab931f62eea583bc206c1d41f4a0711c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libs/libsm/libsm6_1.2.3-1_loong64.deb
+    digest: 9af2780f0816a5e2c10bbbe3abb974ba236ecf0beef15a49040433889c678847
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_loong64.deb
+    digest: 760ec85164e31b757b0e46274b5a1eafe5a6ce53ccd0e1c4c1d7e5338e93c31e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/sqlite3/libsqlite3-0_3.46.1-1_loong64.deb
+    digest: 7b26d965fb478c5ae7993ed753ffbb881ad0632063875a8c68585b56a7c70ee7
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/o/openssl/libssl3_3.2.0-2deepin2_loong64.deb
+    digest: 6c401bd2a8b58f0d6cbeed6121446336cee004f1a03701025112e090410c20d8
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_loong64.deb
+    digest: d5528cf8ef1dcf19b1b3245d894851bbddc35132ef3fd22e8c399fd5af91a514
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/g/gcc-13/libstdc++6_13.2.0-3deepin3_loong64.deb
+    digest: fa0ba450d1f551bce877461affc516d864f4c3413b6e49a22f31996483f9b462
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/systemd/libsystemd0_255.2-4deepin3_loong64.deb
+    digest: 00df4db71c335976879e8d9dbe2ec14f1fd13a7cfce8973e6b22e6a3a7cc2fc8
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libtasn1-6/libtasn1-6_4.18.0-4_loong64.deb
+    digest: 75dde4d8be25c4d18dcf4e27dffff588fabf9c2b365b3c22b2cbd12af97d90b3
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tiff/libtiff-dev_4.5.1+git230720-1deepin0_loong64.deb
+    digest: 753a87ac79cf923ae461b4f0fa6370faa6c0ec7fa99bb51a14eadddb545bbb0c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tiff/libtiff6_4.5.1+git230720-1deepin0_loong64.deb
+    digest: 7c8e051f81e8e0f70230d168a2addbd4717990953f7849ca9e7553d91313275a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tiff/libtiffxx6_4.5.1+git230720-1deepin0_loong64.deb
+    digest: a609eb6be988a394d8b968ce5980552f8ccd3b4617f32458a7d2c2e91213a1d7
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/ncurses/libtinfo6_6.4-4_loong64.deb
+    digest: e4acb568f126357a2ab0d6cccee72d797ec67d0a05dd39193d03ea3260a550b7
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libtirpc/libtirpc-common_1.3.2-2_all.deb
+    digest: 74bddc18e3289947b20653433e82025873f5679ccba52f258ca4912e435a09ee
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libtirpc/libtirpc-dev_1.3.2-2_loong64.deb
+    digest: 398023207ec9cd9852423ff943a2471c9e413273d3d6e654251d3a9d66820b34
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libt/libtirpc/libtirpc3_1.3.2-2_loong64.deb
+    digest: 9af8a36a1e38bb90c2cf99639596b5368ecdf03c5a51721bd723735eb3e7cfb8
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tslib/libts0_1.22-1+rb3_loong64.deb
+    digest: b2217959e0d34e5ce86a75b82acb235e1b887696044937815544c576c7abc9a7
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/systemd/libudev-dev_255.2-4deepin3_loong64.deb
+    digest: 436043a98f6b3de4f3ea6e930a8d85aca1a5352c8ad6d4f25eff0577064eb553
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/systemd/libudev1_255.2-4deepin3_loong64.deb
+    digest: a2c6c79a2af46a97ff9ad890557612531086eff933cb486361fb10daf4c44b45
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libu/libunistring/libunistring2_0.9.10-6_loong64.deb
+    digest: 100d2bd250eff9cdc1ce0492cb7fffc306e620aef5886e1b12245f3f020d569c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/libuuid1_2.39.3-6deepin1_loong64.deb
+    digest: 48c616dfb3a357311ea0507bf7c43740e66a2eb1f85027c116a3f7f20067f4e8
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/v/vulkan-loader/libvulkan-dev_1.3.268.0-1_loong64.deb
+    digest: 26506d91259634d45f99029bf6f969ca5b0e81c39630b0cacb7bd8f959e628f8
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/v/vulkan-loader/libvulkan1_1.3.268.0-1_loong64.deb
+    digest: 6d09f8d682a373ad28cdee87a1b7c0857d759688554d5b3ae751e5d7054c2ed8
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwacom/libwacom-common_1.12-1_all.deb
+    digest: ae18d0c6d1b68084756ae6a5ca4d4d680659ad6a9e5384bdbb49de48ffb75bd8
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwacom/libwacom-dev_1.12-1_loong64.deb
+    digest: 80b9f218239d0521b8c10264860dbf34673b210b56e82ee01ce149a997c57a0a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwacom/libwacom2_1.12-1_loong64.deb
+    digest: 87c13b7db15b7c19111c5af081825d48550cd48c351e3c5ddfac976939bd67b1
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/w/wayland/libwayland-client0_1.23.0-1_loong64.deb
+    digest: 97b7ea92806efbc9f377c790ca5200dd234c35230a6206927ee090097c4e8c85
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/w/wayland/libwayland-cursor0_1.23.0-1_loong64.deb
+    digest: b457f29596f3639d06b47104e9e9f34bea93014798fcce7aa018a27ad6d6b9ed
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/w/wayland/libwayland-server0_1.23.0-1_loong64.deb
+    digest: 4857b80945e09375cdbf0caa322f75fb243f8d6d97cf31bfae8111854f40e11e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libwebp-dev_1.3.2-0.2_loong64.deb
+    digest: d1393a8e0ee0c5e7110a47cd729f042ac19b418bc2560f4fcb330ff1addddada
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libwebp7_1.3.2-0.2_loong64.deb
+    digest: 2a7085499257d278cebe95b0cdc5e9f61c0375319a8683959155a6b7fa57dc78
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libwebpdecoder3_1.3.2-0.2_loong64.deb
+    digest: 6d33f9002478ee47a87b1906776df767e1248a29ff07c07e03aa44980d5326ef
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libwebpdemux2_1.3.2-0.2_loong64.deb
+    digest: 09f59a459dbd3ee2c0d7adebaccaa0fb9ce46598f13257bcbdfc6dd4a61dac1c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libw/libwebp/libwebpmux3_1.3.2-0.2_loong64.deb
+    digest: d52b6cde771aadcec6f49bfa11bcd2b8780f308f9640215fd30c2881d0dcf0a7
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libx11/libx11-6_1.8.7-1_loong64.deb
+    digest: 0e818e4cdefbcf50c1f4c632eb4f0a45ff5b7582d4072a4c64620dc684b49ccd
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libx11/libx11-data_1.8.7-1_all.deb
+    digest: 400aaa7eaab268850d8c2c512474228204d47774f2aac79cef29d1c125e0c656
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libx11/libx11-dev_1.8.7-1_loong64.deb
+    digest: 9ff2157ecf2cb67c552cb49d624b32ab2393991a184e5151b233288c9a71113d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libx11/libx11-xcb1_1.8.7-1_loong64.deb
+    digest: 727ef7465319b0edc7070f9b440a76a29ac1437608a23d98e5679f06d94f6fd5
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxau/libxau-dev_1.0.9-1_loong64.deb
+    digest: 15f907de0f88e9aac91b9fca3c609de2330cfe0c847b91d73ed5f3e2c4d098f7
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxau/libxau6_1.0.9-1_loong64.deb
+    digest: 13a646d0cdb63a9a5025ab6f5f692e077b51b5735fb06a1300f6fd544d6496bc
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xcb-util-cursor/libxcb-cursor0_0.1.1-4_loong64.deb
+    digest: faa6e26dcacc1349e55f3d40813207148897ff77d47c34ff17fb6585ede18f79
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-dri2-0_1.15-1_loong64.deb
+    digest: 25459f6ecf5eadd32fa1d076d9bb086c3b6d78720615d3f45280b135c002931c
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-dri3-0_1.15-1_loong64.deb
+    digest: 7bcaa840cef1cb99090ae88b987047b83388b4d2b7aef06b8063a211a8418fea
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-glx0_1.15-1_loong64.deb
+    digest: 19924e487af19c6fbe893bdf9cec301cf3225013122dbd9b40afce27b9cc3694
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xcb-util-wm/libxcb-icccm4_0.4.1-1.1_loong64.deb
+    digest: 812dc26f817bf6c032d5301a99fc395df44ad95306f8d6cd9f2aa74cbf547d1f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xcb-util-image/libxcb-image0_0.4.0-deepin1_loong64.deb
+    digest: 5573f2fe0db5d1ba31fee4ac95e63f7c29f05dfc1bd932cf702fe1e6b33461f4
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xcb-util-keysyms/libxcb-keysyms1_0.4.0-deepin1_loong64.deb
+    digest: a0fbc54aaff67469c3acf51904c2013621636668bf28b6918a207fd7f819acb1
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-present0_1.15-1_loong64.deb
+    digest: a47fb8a989a5a6844449830afe9a7234458acb96014de72cf64a18dc78a4707f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-randr0_1.15-1_loong64.deb
+    digest: bbc5a60430c0641edbdc2736cf3108d35bcb30388ef769e830646b8f4fc01b4f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xcb-util-renderutil/libxcb-render-util0_0.3.9-deepin1_loong64.deb
+    digest: fb2143791db0e7dee5969bd2b5459439a0d59052000bf26be30e023e2cff77ce
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-render0_1.15-1_loong64.deb
+    digest: f43e74d65d509258147ed6230046648a92fdc906733abf3445373b311032a2a3
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-shape0_1.15-1_loong64.deb
+    digest: 6bd302fe80140947738703a1d3a00fde8036d7b423ab9a591f7bad1b34c09606
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-shm0_1.15-1_loong64.deb
+    digest: f75b6dab7eea8f98e0264c63cbb31b5b21df9679c8b309ce7893d7a4866cb845
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-sync1_1.15-1_loong64.deb
+    digest: 6646259959aa296666facf3d598730c7789d51338cd2a81bf9aab79ea9a986cd
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xcb-util/libxcb-util1_0.4.0-deepin1_loong64.deb
+    digest: 09d6ff65d108b01df3a41e6ce112545c05e8d246bd441fa41e8c365a8f606272
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-xfixes0_1.15-1_loong64.deb
+    digest: 604e97953f434b25d0f23f6eed233ed6a797612c2de320262fbb1dff394f9075
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb-xkb1_1.15-1_loong64.deb
+    digest: d00aabdea0d36cb2980759bc6a56de64b6f74810aa8c25a31dc674ffe40c5f2b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb1-dev_1.15-1_loong64.deb
+    digest: 3d4b82cd16df0487be74f8f9f79d27fd7b0c5252c2a1c7bd2e03fa6453059728
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxcb/libxcb1_1.15-1_loong64.deb
+    digest: 6977bdf22da615ab81df4414e047090a560e73cffa04acc6f2ed27bf2c77e5fb
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxdmcp/libxdmcp-dev_1.1.2-3_loong64.deb
+    digest: fa296588f4f92220332e72311db7631b9e5734469551e34dfbef79b5bbd2b328
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxdmcp/libxdmcp6_1.1.2-3_loong64.deb
+    digest: ce4dc98b358a67e1b9653e4492845673a1f6d75512298389758bfb5f1ca2a463
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxext/libxext6_1.3.4-1_loong64.deb
+    digest: 151ada3ad16057453b554909ae0ae403c46b8d5560643043a92f4a18ca069de0
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxfixes/libxfixes3_6.0.0-1_loong64.deb
+    digest: 12c47fb6cbb173e015a075830b727791bf872ec2491e789658172f714566d297
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxi/libxi6_1.8.1-1_loong64.deb
+    digest: 87c3b78f2e6507074344c7afe0c56aee5a833e8076da0f43ddee28ab53d922f6
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxkbcommon/libxkbcommon-dev_1.6.0-1_loong64.deb
+    digest: ba47dce288d90726795169d45ddf9b07f57c9391776ab2a4833ac26fe01a9c90
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxkbcommon/libxkbcommon-x11-0_1.6.0-1_loong64.deb
+    digest: 0373a8af7f464e5daf826bb10a59fbb7e353b52447842d18555f79a9eff2eee9
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxkbcommon/libxkbcommon0_1.6.0-1_loong64.deb
+    digest: a4e72ca7887958f24270607f6d7897af906a345aa470bdd4a644fa5b66189538
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxml2/libxml2_2.9.14+dfsg-1.3+rb2_loong64.deb
+    digest: 6a26f4aaae7e9a8bbc63fd4b6bd8dfdc81a85238a63d7f38d479569bcabeaae0
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxshmfence/libxshmfence1_1.3-1_loong64.deb
+    digest: 0d235925c3c0d5ff0a3be29607a3800e616b58fcb46b0eafb7a9e3ba70d7d0fb
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libx/libxxf86vm/libxxf86vm1_1.1.4-deepin1_loong64.deb
+    digest: 8bf8c69d8210c9e7ca528ec7bb43bb8c39c9493cbe05aca024926e68602b83cd
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/z/z3/libz3-4_4.8.12-deepin2+rb1_loong64.deb
+    digest: 16dfedbf2e2e2882ca15f980b7c3df0b57a2a0989e5a6bf94b84b4847a68257d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libz/libzstd/libzstd-dev_1.5.6+dfsg-1_loong64.deb
+    digest: 542cb13caf60619314815e4a117fb1e39c3540a241aa52a34fb9cc7b4717f08e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/libz/libzstd/libzstd1_1.5.6+dfsg-1_loong64.deb
+    digest: a4bae41cbfe530058e9c63f4b3c34294f1b4b726d8f022b9eca8f7e81833fe13
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_loong64.deb
+    digest: e200be025cd227c34cb852eb20d4b7ad0d371095fdba7b7c4febc7ea7a2221e2
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/linux-upstream/linux-libc-dev_23.01.01.14+STE_loong64.deb
+    digest: 995dd21c2ade67bf170fcf9cf5d9b5f3edd4d964ce74f70fa242bebe3009f685
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_loong64.deb
+    digest: a6b376c2fd149cc6cabd93cd94dea5c9793fe8e9b9773c22bb9a12812ac52cf4
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mailcap/mailcap_3.70_all.deb
+    digest: 7ca67d118c03eaf58346eb1e676ff16f4d1aa5252a8cc6b5b3b1ed44556180f1
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/make-dfsg/make_4.3-4.1_loong64.deb
+    digest: 7869d745da7ed65da3280054b10c6763397a71bf22a8a7b55f2efccac6ce406b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/media-types/media-types_4.0.0_all.deb
+    digest: cd124053950ab8b0373203bceb7eab841791017daf1d50db2ece09e4da52406a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/m/mime-support/mime-support_3.66_all.deb
+    digest: 20294deda4378616c2b48614ee226731ec09663c3497c35a467e8ea5fa03f16a
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/n/netbase/netbase_6.4_all.deb
+    digest: 5fd05a5d63864b96453ba55a4c5efa287b8e7e53fbd833e7a944e066d30e1eb1
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/patch/patch_2.7.6-7_loong64.deb
+    digest: 713a6fe43f8c66f410ed5eca4b57361868d6da0f05e2ef9f7300f7fe524ee2e5
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/perl/perl-base_5.36.0-10_loong64.deb
+    digest: 2c2ff9c3322f33ec19ed0c0170001fde2d9ff60937d323f154aac0a1a660fe82
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/perl/perl-modules-5.36_5.36.0-10_all.deb
+    digest: 907542b9a413bd0276d5ef94fef77083715a692fd33c52ece44d11fff847bab0
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/perl/perl_5.36.0-10_loong64.deb
+    digest: dc3b0b73a582471f146be8f35e39d61ef9046a2a4f3ee2a29684f8ed12d2a598
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pkgconf/pkg-config_1.8.1-4_loong64.deb
+    digest: fb2ca56eebecd5c9dd6f9150062f349edcd4863390463d536927b6232658f8f0
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pkgconf/pkgconf-bin_1.8.1-4_loong64.deb
+    digest: 872f0376191a3cc26d0fcf9f60b5a2e81d68576cf18aa24449574147e7ce697f
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/pkgconf/pkgconf_1.8.1-4_loong64.deb
+    digest: 3e3b1b4df76ba6899f213996a11d75d1b01acc5ef6a9445ca9bb637cb8cd126b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3-defaults/python3-minimal_3.12.1-1deepin1_loong64.deb
+    digest: ab21a1c47406aa070515796262c63097b15c72fbcdc2e33d98a646c0471cfebb
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python-packaging/python3-packaging_24.0-1_all.deb
+    digest: acf9e0347764b07624b219b64fa7721705d6eeea5a98871f892aff3ab0293ae4
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3.12/python3.12-minimal_3.12.4-0deepin1_loong64.deb
+    digest: f90145024163b5f423db6765b8ced01439e819859419cfe9eb9fe7ffc6cfd0f7
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3.12/python3.12_3.12.4-0deepin1_loong64.deb
+    digest: a003a420b5bda72fb4bbea54eaf3a3a3c74fea3c741ce8141646832b82140be0
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/p/python3-defaults/python3_3.12.1-1deepin1_loong64.deb
+    digest: 2068886f43d893b3d801afe06bdbed2ac6cfbd3dd14b1d2b5658fb691d45615e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_loong64.deb
+    digest: 99aa344e806f799b1008841a76c4f83ad58f508aa7216f7df5adae3aa860fdbd
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin5_loong64.deb
+    digest: b2c23ea458f84eaf5df7f06ceeccf24047551cabc4abd35782060399cd2c8ad6
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin5_loong64.deb
+    digest: 4a50a0bec4830e8b4d5468af3ca9b8bb08bcea4892539c2133c6cfe8d06889de
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin3_loong64.deb
+    digest: 352c93151474b4e0843755cf4248d5678df53a42e9058d07408427a848b52b08
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin3_loong64.deb
+    digest: 5bebc32a419c38803377c01265c89450b74b82ab8098a71593f9292962919432
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin5_loong64.deb
+    digest: 2e76edf66678b456d8d2772efd47d38a50c140d74084a166fd2faf1a63da2b00
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin5_loong64.deb
+    digest: 6cc78a068f206bc90e8cea49b01dac72ac0356213fe52643cec12a23f6b82353
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin5_loong64.deb
+    digest: 89d3909a21672e5f10a559a89e5d81efb9056f516935422e9b2dbcd0126503ea
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_loong64.deb
+    digest: cf6fafc95fdce9f99b2bfd283100163a1c316fc596dd6ab9da30821d1faeb0d5
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-imageformats/qt6-image-formats-plugins_6.8.0-0deepin_loong64.deb
+    digest: d9703d3d43bc45d7190b56022d278654f40a2ef3a53314a6426f018ed1e0eca0
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_loong64.deb
+    digest: 64b8adf192160cd12b0e63cba2d112fe0f0f361f83df2666c5017e55e5383fd9
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin5_loong64.deb
+    digest: 13e2e5d5ae5fbaa5b971f6e5d4b48c1d72cef2e77af4344e7b802e0f4170228b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin1_loong64.deb
+    digest: 8d025380c93576e65ed0941ed9b0a568d366c9554497570335f4426be7068545
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/qt6-tools-dev-tools_6.8.0-0deepin3_loong64.deb
+    digest: 0f27c4de0f6b1d21b037e49d0d94effc72f061f8fbe742365dd83f2ccbb0c782
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/q/qt6-tools/qt6-tools-dev_6.8.0-0deepin3_loong64.deb
+    digest: 18aca243a15bb51fb26de8579e2fd58cc2234f31dd4db73fda2d734a41308887
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/r/readline/readline-common_8.2-3_all.deb
+    digest: 35fe59faceb8d9def8b6aa664e091eac8444887bc1f33ba2cf22099c3646e7bd
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/r/rpcsvc-proto/rpcsvc-proto_1.4.2-4_loong64.deb
+    digest: 5a68197175ff3bf8f57fdd1066b62efcb547e877ae2c3b057f5b5a9c8add94c4
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/s/shared-mime-info/shared-mime-info_2.2-1_loong64.deb
+    digest: a0cd2345f1c869975ba98b8ead9048f32746d72966162472ce531ae48ecb0e9e
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tar/tar_1.35+dfsg-3_loong64.deb
+    digest: 48cc0cc32829c68c7b58e74f141fe552f9a3f5c9e6da77ad54184530debc0cff
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/t/tzdata/tzdata_2023d-1deepin1_all.deb
+    digest: fe503c524801260208482a1dfc061e79c2a7450111dd90f88ed40d70ac935832
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/u/util-linux/uuid-dev_2.39.3-6deepin1_loong64.deb
+    digest: 54727a76b166231d74f5116fc6732bf97ac9aa2ee8f8b49bbf0ee5b8358c5483
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xorg/x11-common_7.7+23-deepin1_all.deb
+    digest: 9a7643db11023a8bec126312edec4b1b7357b93416bdfbaf9b0cb8bc04506d49
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xorgproto/x11proto-core-dev_2024.1-1_all.deb
+    digest: 82bff9dab1d74e30bdbc6130f94d1bd361c3c1d3cdad660bd92e5b730c4cba7b
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb
+    digest: 39e14817ff2ab4eedade206fefebb7b2632e4dd7c358a9cfe36bcdd477554a04
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xfonts-encodings/xfonts-encodings_1.0.4-2.1deepin1_all.deb
+    digest: 07d68c68eeeca62cea0558b4f0bc25896bd82fddfa6c4b02693ee0adc4bde224
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xfonts-utils/xfonts-utils_7.7+6-deepin_loong64.deb
+    digest: 7022910932f96b7af8fa6e5ffe31a20515e47e9ae3dbab9781012f132e4e3198
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xkeyboard-config/xkb-data_2.38-2deepin1_all.deb
+    digest: 6fdc32f08737735128e20a10f9a8425bde19855e3917d8f26a62ea3a12a9a720
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb
+    digest: c3ac4805a75219ecc8a92a79697d39fa9abf6a7fa16da540800a0d30bdcc2847
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb
+    digest: ab37e512128e066d7225deb7f51f0c77f9b0c3913d75f2a7f9b1d708327a099d
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/x/xz-utils/xz-utils_5.4.5-0.3_loong64.deb
+    digest: 914f9a81a1be1c08e1489ae0d463c9e68f725da465d2dda0cba519f87a00ddc8
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.1-1deepin1_loong64.deb
+    digest: b40d74ed9b2014e3a3bcb7c6121a17e16424d0ef19c9ee1aef977b7460b1b1b6
+  - kind: file
+    url: https://ci.deepin.com/repo/deepin/deepin-community/backup/23-release//pool/main/z/zlib/zlib1g_1.3.dfsg+really1.3.1-1deepin1_loong64.deb
+    digest: 135455e7368c3c73d5984305019c2574ebc5501f2d650e77addbc4d87db55503


### PR DESCRIPTION
Enable linglong build with Qt6.8 runtime.

Log: Enable linglong build with Qt6.8 runtime.