### PR TITLE
fix: Add command-line support for quick printing

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -98,3 +98,6 @@ install(DIRECTORY ${PROJECT_SOURCE_DIR}/translations
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/src/assets/deepin-image-viewer
     DESTINATION ${CMAKE_INSTALL_PREFIX}/share/deepin-manual/manual-assets/application/
     FILES_MATCHING PATTERN "*")
+#context-menu conf 文管右键菜单配置文件
+install(FILES ${PROJECT_SOURCE_DIR}/src/misc/context-menus/deepin-print-pictures.conf
+    DESTINATION /usr/share/applications/context-menus/)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,7 @@
 #include "src/imagedata/imagesourcemodel.h"
 #include "src/imagedata/imageprovider.h"
 #include "src/utils/filetrashhelper.h"
+#include "src/commandparser.h"
 #include "config.h"
 
 #include <DApplication>
@@ -47,17 +48,26 @@ int main(int argc, char *argv[])
     app.setApplicationDisplayName(QObject::tr("Image Viewer"));
     app.setProductIcon(QIcon::fromTheme("deepin-image-viewer"));
     app.setApplicationDescription(
-        QObject::tr("Image Viewer is an image viewing tool with fashion interface and smooth performance."));
+            QObject::tr("Image Viewer is an image viewing tool with fashion interface and smooth performance."));
     app.setWindowIcon(QIcon::fromTheme("deepin-image-viewer"));
 
     // LOG
     DLogManager::registerConsoleAppender();
     DLogManager::registerFileAppender();
     qInfo() << QString("%1 start, PID: %2, Version: %3")
-                   .arg(app.applicationName())
-                   .arg(app.applicationPid())
-                   .arg(app.applicationVersion());
+                       .arg(app.applicationName())
+                       .arg(app.applicationPid())
+                       .arg(app.applicationVersion());
     qDebug() << "LogFile:" << DLogManager::getlogFilePath();
+
+    // command
+    CommandParser::instance()->process();
+    if (CommandParser::instance()->isSet("h")) {
+        return app.exec();
+    } else if (CommandParser::instance()->isSet("print")) {
+        CommandParser::instance()->quickPrint();
+        return 0;
+    }
 
     QQmlApplicationEngine engine;
 
@@ -119,8 +129,8 @@ int main(int argc, char *argv[])
 
     status.setEnableNavigation(fileControl.isEnableNavigation());
     QObject::connect(
-        &status, &GlobalStatus::enableNavigationChanged, [&]() { fileControl.setEnableNavigation(status.enableNavigation()); });
-    QObject::connect(&fileControl, &FileControl::imageRenamed, &control, [&](const QUrl &oldName, const QUrl &newName){
+            &status, &GlobalStatus::enableNavigationChanged, [&]() { fileControl.setEnableNavigation(status.enableNavigation()); });
+    QObject::connect(&fileControl, &FileControl::imageRenamed, &control, [&](const QUrl &oldName, const QUrl &newName) {
         providerCache->renameImageCache(oldName.toLocalFile(), newName.toLocalFile());
         control.renameImage(oldName, newName);
     });

--- a/src/misc/context-menus/deepin-print-pictures.conf
+++ b/src/misc/context-menus/deepin-print-pictures.conf
@@ -1,0 +1,18 @@
+[Menu Entry]
+Actions=Zero
+Version=1.0
+
+[Menu Action Zero]
+Exec=/usr/bin/deepin-image-viewer --print %F
+MimeType=image/bmp:image/bmp24:image/jpg:image/jpe:image/jpeg:image/jpeg24:image/jng:image/x-panasonic-rw:image/x-jp2-codestream:video/x-mng:image/x-canon-crw:image/x-dds:image/x-olympus-orf:image/x-sigma-x3:image/x-ilbm:image/x-sgi:image/wmf:image/webp:image/vnd.microsoft.icon:image/pcd:image/pcx:image/png:image/tif:image/tiff:image/tiff24:image/dds:image/gif:image/sgi:image/j2k:image/jp2:image/pct:image/wdp:image/arw:image/icb:image/dng:image/vda:image/vst:image/svg:image/ptif:image/mef:image/xbm:image/svg+xml:image/x-minolta-mrw:image/vnd.adobe.photoshop:image/x-xpixmap:image/vnd.wap.wbmp:image/x-photo-cd:image/x-portable-graymap:image/x-xbitmap:image/x-portable-bitmap:image/vnd.zbrush.pcx:image/x-portable-anymap:image/x-tga:image/x-icns:image/x-fuji-raf:image/x-hdr:image/fax-g3:image/x-photo-cd
+Name=Print
+PosNum=6
+Separator=Top
+X-DFM-ExcludeMimeTypes=inode/directory:application/x-desktop
+X-DFM-MenuTypes=SingleFile:MultiFiles
+X-DFM-SupportSchemes=file
+Name[bo]=པར་འདེབས།
+Name[ug]=بېسىش
+Name[zh_CN]=打印
+Name[zh_HK]=打印
+Name[zh_TW]=打印

--- a/src/src/commandparser.cpp
+++ b/src/src/commandparser.cpp
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "commandparser.h"
+#include "printdialog/printhelper.h"
+
+#include <QUrl>
+#include <QCoreApplication>
+#include <QCommandLineOption>
+
+CommandParser::CommandParser(QObject *parent)
+{
+    initialize();
+}
+
+CommandParser *CommandParser::instance()
+{
+    static CommandParser ins;
+    return &ins;
+}
+
+bool CommandParser::isSet(const QString &name) const
+{
+    return cmdParser.isSet(name);
+}
+
+QString CommandParser::value(const QString &name) const
+{
+    return cmdParser.value(name);
+}
+
+void CommandParser::process()
+{
+    return process(qApp->arguments());
+}
+
+void CommandParser::process(const QStringList &arguments)
+{
+    QStringList args;
+    for (const auto &arg : arguments) {
+        if (!arg.startsWith("-")) {
+            args.append(QUrl::fromPercentEncoding(arg.toStdString().c_str()));
+        } else {
+            args.append(arg);
+        }
+    }
+    cmdParser.process(args);
+}
+
+void CommandParser::quickPrint()
+{
+    const QStringList &argumets = positionalArguments();
+    if (argumets.isEmpty())
+        return;
+
+    PrintHelper::getIntance()->showPrintDialog(argumets);
+}
+
+void CommandParser::initialize()
+{
+    cmdParser.setApplicationDescription(QString("%1 helper").arg(QCoreApplication::applicationName()));
+    initOptions();
+    cmdParser.addHelpOption();
+}
+
+void CommandParser::initOptions()
+{
+    QCommandLineOption printOption("print");
+    addOption(printOption);
+}
+
+void CommandParser::addOption(const QCommandLineOption &option)
+{
+    cmdParser.addOption(option);
+}
+
+QStringList CommandParser::positionalArguments() const
+{
+    return cmdParser.positionalArguments();
+}

--- a/src/src/commandparser.h
+++ b/src/src/commandparser.h
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef COMMANDPARSER_H
+#define COMMANDPARSER_H
+
+#include <QCommandLineParser>
+
+QT_BEGIN_NAMESPACE
+class QCommandLineOption;
+QT_END_NAMESPACE
+
+class CommandParser : public QObject
+{
+    Q_OBJECT
+public:
+    static CommandParser *instance();
+
+    bool isSet(const QString &name) const;
+    QString value(const QString &name) const;
+    void process();
+    void process(const QStringList &arguments);
+
+    void quickPrint();
+
+private:
+    explicit CommandParser(QObject *parent = nullptr);
+
+    void initialize();
+    void initOptions();
+    void addOption(const QCommandLineOption &option);
+    QStringList positionalArguments() const;
+
+private:
+    QCommandLineParser cmdParser;
+};
+
+#endif   // COMMANDPARSER_H


### PR DESCRIPTION
Implement command-line parsing functionality:
- Create CommandParser class to handle command-line arguments
- Add support for quick printing via "-print" option
- Integrate command-line parsing in main application startup
- Install context-menu configuration file for print functionality

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-303741.html
