### PR TITLE
fix: Set organization name and remove obsolete comment

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,8 +42,7 @@ int main(int argc, char *argv[])
     app.setApplicationLicense("GPLV3");
     app.setApplicationVersion(VERSION);
     app.setAttribute(Qt::AA_UseHighDpiPixmaps);
-    // TODO: ? 设置后在 DTK6 下菜单显示空白
-    // app.setOrganizationName("deepin");
+    app.setOrganizationName("deepin");
     app.setApplicationName("deepin-image-viewer");
     app.setApplicationDisplayName(QObject::tr("Image Viewer"));
     app.setProductIcon(QIcon::fromTheme("deepin-image-viewer"));


### PR DESCRIPTION
Description:
- Remove TODO comment about DTK6 menu display issue as it's no longer relevant
- Set application organization name to 'deepin' for better identification

Log: Set application organization name