### PR TITLE
fix: set title bar loader to synchronous loading

### DIFF
--- a/src/qml/ViewTopTitle.qml
+++ b/src/qml/ViewTopTitle.qml
@@ -117,7 +117,8 @@ Rectangle {
 
     Loader {
         anchors.fill: parent
-        asynchronous: true
+        // BUG: 315613 标题栏异步加载时，标题栏内容偶发无法显示
+        asynchronous: false
 
         sourceComponent: TitleBar {
             id: titlebar


### PR DESCRIPTION
Changed Loader's asynchronous property from true to false for
ViewTopTitle.qml's title bar component. This ensures the title bar
loads immediately when the view is opened, preventing any visual delay
or flickering during view transitions. The title bar is a critical UI
element that should be immediately visible.

fix: 设置标题栏加载器为同步加载

将 ViewTopTitle.qml 中标题栏组件的 Loader 异步属性从 true 改为 false。
这确保了标题栏在视图打开时立即加载，避免了视图切换期间的视觉延迟或闪烁问
题。标题栏是关键的 UI 元素，应当立即显示。

pms: BUG-315613