### PR TITLE
chore: Update version to 6.0.21

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.image.viewer
   name: deepin-image-viewer
-  version: 6.0.20.1
+  version: 6.0.21.1
   kind: app
   description: |
     view images for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-image-viewer (6.0.21) unstable; urgency=medium
+    
+    * Update version to 6.0.21
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Fri, 13 Jun 2025 16:55:08 +0800
+
 deepin-image-viewer (6.0.20) unstable; urgency=medium
 
   * Update version to 6.0.20. 

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.image.viewer
   name: deepin-image-viewer
-  version: 6.0.20.1
+  version: 6.0.21.1
   kind: app
   description: |
     view images for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.image.viewer
   name: deepin-image-viewer
-  version: 6.0.20.1
+  version: 6.0.21.1
   kind: app
   description: |
     view images for deepin os.


### PR DESCRIPTION
Bump version in configuration files to 6.0.21 for deepin-image-viewer.

Log: Updated version to 6.0.21 in linglong.yaml and debian/changelog.