### PR TITLE
fix: fix OCR recognition crash on sw architecture when viewing images

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,6 +25,7 @@ find_package(Dtk${DTK_VERSION_MAJOR} REQUIRED COMPONENTS
 # OCR
 find_package(PkgConfig REQUIRED)
 pkg_search_module(OCR_PLUGIN REQUIRED deepin-ocr-plugin-manager)
+pkg_check_modules(InferenceEngine REQUIRED ncnn opencv_mobile)
 include_directories(${OCR_PLUGIN_INCLUDE_DIRS})
 
 # 保证 src 目录下头文件全局可见
@@ -143,6 +144,7 @@ target_link_libraries(${BIN_NAME} PRIVATE
     Dtk${DTK_VERSION_MAJOR}::Declarative
     GL
     pthread
+    ${InferenceEngine_LIBRARIES}
     ${OCR_PLUGIN_LIBRARIES}
 )
 


### PR DESCRIPTION
- Crash caused by dependency issues

log: modify cmake dependencies

bug: https://pms.uniontech.com/bug-view-319961.html