### PR TITLE
fix: Optimize SVG image rendering resolution

### DIFF
--- a/src/qml/ImageDelegate/SvgImageDelegate.qml
+++ b/src/qml/ImageDelegate/SvgImageDelegate.qml
@@ -10,6 +10,19 @@ import "../Utils"
 BaseImageDelegate {
     id: delegate
 
+    // SVG 优化的实际分辨率，延迟更新以避免频繁重新栅格化
+    // 优先使用图片的实际分辨率，如果尚未加载则使用视图尺寸
+    property size optimizedSourceSize: {
+        var actualWidth = targetImageInfo.width
+        var actualHeight = targetImageInfo.height
+
+        if (actualWidth > 0 && actualHeight > 0) {
+            return Qt.size(Math.max(delegate.width, actualWidth), Math.max(delegate.height, actualHeight))
+        } else {
+            return Qt.size(Math.max(delegate.width, width), Math.max(delegate.height, height))
+        }
+    }
+
     status: image.status
     targetImage: image
     inputHandler: imageInput
@@ -27,8 +40,91 @@ BaseImageDelegate {
         smooth: true
         scale: 1.0
         source: delegate.source
-        // 设置为当前图像的图片源，调整因缩放导致的模糊
-        sourceSize: Qt.size(width, height)
+        // 使用延迟更新的优化分辨率，避免缩放过程中的卡顿
+        sourceSize: delegate.optimizedSourceSize
+
+        // 监听缩放变化，延迟更新分辨率
+        onScaleChanged: {
+            sourceSizeUpdateTimer.restart()
+        }
+    }
+
+    // 监听图片信息变化，当实际分辨率可用时更新 sourceSize
+    Connections {
+        target: targetImageInfo
+
+        function onWidthChanged() {
+            if (targetImageInfo.width > 0) {
+                sourceSizeUpdateTimer.restart()
+            }
+        }
+
+        function onHeightChanged() {
+            if (targetImageInfo.height > 0) {
+                sourceSizeUpdateTimer.restart()
+            }
+        }
+    }
+
+    // 延迟更新 sourceSize 的定时器，避免频繁重新栅格化
+    Timer {
+        id: sourceSizeUpdateTimer
+        interval: 150 // 150ms 延迟，平衡响应性和性能
+        repeat: false
+
+        onTriggered: {
+            if (!delegate.source) {
+                delegate.optimizedSourceSize = Qt.size(0, 0)
+                return
+            }
+
+            // 使用图片的实际分辨率，而不是视图尺寸
+            var actualWidth = targetImageInfo.width
+            var actualHeight = targetImageInfo.height
+            var currentScale = image.scale
+
+            // 如果图片信息尚未加载完成，使用视图尺寸作为备选
+            if (actualWidth <= 0 || actualHeight <= 0) {
+                actualWidth = image.width
+                actualHeight = image.height
+            }
+
+            // 使用正确的缩放比例计算公式：(paintedWidth * scale) / originalWidth
+            // 这与 ImageViewer.qml 中的 readableScale 计算保持一致
+            var actualScaleRatio = 1.0
+            if (actualWidth > 0 && image.paintedWidth > 0) {
+                actualScaleRatio = (image.paintedWidth * currentScale) / actualWidth
+            }
+
+            // 计算基于正确缩放比例的期望渲染分辨率
+            var desiredWidth = actualWidth * actualScaleRatio
+            var desiredHeight = actualHeight * actualScaleRatio
+
+            // 保持宽高比的前提下应用最大分辨率限制，分辨率太高会导致渲染失败
+            var maxDimension = 8000
+            var aspectRatio = actualWidth / actualHeight
+
+            var targetWidth, targetHeight
+
+            if (desiredWidth <= maxDimension && desiredHeight <= maxDimension) {
+                // 期望分辨率都在限制范围内，直接使用
+                targetWidth = Math.max(1, desiredWidth)
+                targetHeight = Math.max(1, desiredHeight)
+            } else {
+                // 需要按比例缩放以适应最大限制
+                if (desiredWidth > desiredHeight) {
+                    // 宽度是限制因素
+                    targetWidth = maxDimension
+                    targetHeight = Math.max(1, maxDimension / aspectRatio)
+                } else {
+                    // 高度是限制因素
+                    targetHeight = maxDimension
+                    targetWidth = Math.max(1, maxDimension * aspectRatio)
+                }
+            }
+
+            delegate.optimizedSourceSize = Qt.size(Math.round(targetWidth), Math.round(targetHeight))
+        }
     }
 
     ImageInputHandler {


### PR DESCRIPTION
- Introduced a new property `optimizedSourceSize` to manage the actual resolution of SVG images, reducing the frequency of rasterization.
- Implemented a timer to delay updates to `sourceSize`, improving performance during scaling.
- Added connections to monitor changes in image dimensions and trigger updates accordingly.

Log: This enhancement aims to improve rendering efficiency and maintain image quality during scaling operations.
Bug: https://pms.uniontech.com/bug-view-324585.html
