### PR TITLE
fix(dialog): fix InformationDialog appearing at top-left corner

### DIFF
--- a/src/qml/InformationDialog/InformationDialog.qml
+++ b/src/qml/InformationDialog/InformationDialog.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -23,7 +23,7 @@ DialogWindow {
     flags: Qt.Dialog | Qt.WindowCloseButtonHint | Qt.MSWindowsFixedSizeDialogHint | Qt.WindowStaysOnTopHint
     maximumWidth: 280
     minimumWidth: 280
-    visible: true
+    visible: false
     width: 280
 
     header: DialogTitleBar {
@@ -45,8 +45,9 @@ DialogWindow {
     }
 
     Component.onCompleted: {
-        x = window.x + window.width - width - leftX;
-        y = window.y + topY;
+        setX(window.x + window.width - width - leftX);
+        setY(window.y + topY);
+        show();
     }
 
     // 窗口关闭时复位组件状态


### PR DESCRIPTION
Set dialog invisible by default, position it before showing to avoid race condition causing the dialog to appear at (0,0).

修复图片信息弹窗概率性出现在左上角的问题，先定位再显示窗口。

Log: 修复图片信息弹窗位置异常
PMS: BUG-306419
Influence: 图片信息弹窗始终在主窗口右上角正确显示，不再概率性出现在左上角。