### PR TITLE
fix: add dynamic sourceSize optimization for zoom clarity

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -100,6 +100,7 @@ else()
             qml/ImageDelegate/MultiImageDelegate.qml
             qml/ImageDelegate/NonexistImageDelegate.qml
             qml/ImageDelegate/NormalImageDelegate.qml
+            qml/ImageDelegate/SourceSizeOptimizer.qml
             qml/ImageDelegate/SvgImageDelegate.qml
             qml/ImageDelegate/ViewDelegateLoader.qml
             qml/InformationDialog/ElideLabel.qml

--- a/src/qml/ImageDelegate/DynamicImageDelegate.qml
+++ b/src/qml/ImageDelegate/DynamicImageDelegate.qml
@@ -26,8 +26,22 @@ BaseImageDelegate {
         smooth: true
         source: delegate.source
         // 限制每帧解码分辨率为显示区域大小，动图帧数多时可显著降低内存峰值
-        sourceSize: Qt.size(delegate.width, delegate.height)
+        sourceSize: sourceSizeOptimizer.optimizedSourceSize
         width: delegate.width
+
+        onScaleChanged: {
+            sourceSizeOptimizer.requestUpdate()
+        }
+    }
+
+    SourceSizeOptimizer {
+        id: sourceSizeOptimizer
+        targetImage: image
+        imageInfo: targetImageInfo
+        delegateWidth: delegate.width
+        delegateHeight: delegate.height
+        maxDimension: 4096
+        maxTotalPixels: 0
     }
 
     ImageInputHandler {

--- a/src/qml/ImageDelegate/NormalImageDelegate.qml
+++ b/src/qml/ImageDelegate/NormalImageDelegate.qml
@@ -50,16 +50,50 @@ BaseImageDelegate {
         scale: 1.0
         smooth: true
         source: "image://ImageLoad/" + delegate.source + "#frame_" + delegate.frameIndex
-        // 限制加载分辨率为当前显示区域大小，避免将全尺寸大图上传为 GPU 纹理
-        sourceSize: Qt.size(delegate.width, delegate.height)
+        sourceSize: sourceSizeOptimizer.optimizedSourceSize
         width: delegate.width
-        // TODO: wait for Qt6.8 avoid flickering when image source change
-        // retainWhileLoading: true
+        // debounced (scroll wheel): retain old texture for smooth transition
+        // immediate (large jump): no retain, use snapshot instead
+        retainWhileLoading: !sourceSizeOptimizer.immediateUpgrade
+
+        onScaleChanged: {
+            sourceSizeOptimizer.requestUpdate()
+        }
 
         onStatusChanged: {
             if (Image.Ready === image.status && !rotationRunning) {
                 rotateAnimationLoader.active = false;
+                if (upgradeSnapshotLoader.active) {
+                    upgradeSnapshotLoader.active = false
+                }
             }
+        }
+    }
+
+    SourceSizeOptimizer {
+        id: sourceSizeOptimizer
+        targetImage: image
+        imageInfo: targetImageInfo
+        delegateWidth: delegate.width
+        delegateHeight: delegate.height
+    }
+
+    // Snapshot for immediate mode: shows old texture while new texture loads
+    Loader {
+        id: upgradeSnapshotLoader
+        active: sourceSizeOptimizer.showUpgradeSnapshot
+        anchors.fill: parent
+
+        sourceComponent: ShaderEffectSource {
+            anchors.centerIn: parent
+            width: image.width
+            height: image.height
+            sourceItem: image
+            live: false
+            hideSource: true
+            scale: image.scale
+            mipmap: true
+            smooth: true
         }
     }
 

--- a/src/qml/ImageDelegate/SourceSizeOptimizer.qml
+++ b/src/qml/ImageDelegate/SourceSizeOptimizer.qml
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: 2023~2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick
+
+// Dynamic sourceSize optimization during zoom.
+// Two upgrade modes:
+//   - Debounced (scroll wheel): Timer-delayed upgrade with retainWhileLoading
+//   - Immediate (imageInfo loaded while zoomed): instant upgrade with snapshot transition
+// Once upgraded, high-res sourceSize is kept until the image source changes.
+Item {
+    id: optimizer
+
+    property Image targetImage: null
+    property var imageInfo: null
+    property real delegateWidth: 0
+    property real delegateHeight: 0
+    property int maxDimension: 15000
+    // 225M pixels * 4 bytes = ~900MB GPU memory cap
+    property int maxTotalPixels: 225 * 1000 * 1000
+    // Skip upgrade if original pixel count is below this factor of display pixels.
+    property real upgradeThreshold: 2.0
+    // Debounce delay (ms) for scroll-wheel zoom before upgrading sourceSize.
+    property int debounceInterval: 400
+
+    property real zoomedWidth: 0
+    property real zoomedHeight: 0
+    readonly property bool isUpgraded: zoomedWidth > 0
+    // True when upgrade was triggered by imageInfo change; consumer should use
+    // snapshot transition instead of retainWhileLoading.
+    readonly property bool immediateUpgrade: immediateUpgradeFlag
+    property bool immediateUpgradeFlag: false
+    // Convenience: true during Loading after an immediate upgrade; consumer can
+    // bind this to a snapshot Loader's active property.
+    readonly property bool showUpgradeSnapshot: immediateUpgradeFlag && targetImage && targetImage.status === Image.Loading
+
+    property size optimizedSourceSize: zoomedWidth > 0 ? Qt.size(zoomedWidth, zoomedHeight) : Qt.size(delegateWidth, delegateHeight)
+
+    function requestUpdate() {
+        if (!optimizer.targetImage || optimizer.targetImage.scale <= 1.0) {
+            sourceSizeUpdateTimer.stop()
+            return
+        }
+
+        if (zoomedWidth > 0) {
+            return
+        }
+
+        sourceSizeUpdateTimer.restart()
+    }
+
+    function applyUpgrade() {
+        if (zoomedWidth > 0) {
+            return
+        }
+
+        var actualWidth = optimizer.imageInfo ? optimizer.imageInfo.width : 0
+        var actualHeight = optimizer.imageInfo ? optimizer.imageInfo.height : 0
+
+        if (actualWidth <= 0 || actualHeight <= 0) {
+            actualWidth = optimizer.targetImage.width
+            actualHeight = optimizer.targetImage.height
+        }
+
+        if (actualWidth <= 0 || actualHeight <= 0) {
+            return
+        }
+
+        if (actualWidth * actualHeight <= optimizer.delegateWidth * optimizer.delegateHeight * optimizer.upgradeThreshold) {
+            return
+        }
+
+        var w = actualWidth
+        var h = actualHeight
+        var ratio = actualWidth / actualHeight
+
+        if (w > optimizer.maxDimension || h > optimizer.maxDimension) {
+            if (w >= h) {
+                w = optimizer.maxDimension
+                h = Math.max(1, Math.round(optimizer.maxDimension / ratio))
+            } else {
+                h = optimizer.maxDimension
+                w = Math.max(1, Math.round(optimizer.maxDimension * ratio))
+            }
+        }
+
+        if (optimizer.maxTotalPixels > 0) {
+            var totalPixels = w * h
+            if (totalPixels > optimizer.maxTotalPixels) {
+                var shrinkFactor = Math.sqrt(optimizer.maxTotalPixels / totalPixels)
+                w = Math.max(1, Math.round(w * shrinkFactor))
+                h = Math.max(1, Math.round(h * shrinkFactor))
+            }
+        }
+
+        optimizer.zoomedWidth = w
+        optimizer.zoomedHeight = h
+    }
+
+    Connections {
+        target: optimizer.imageInfo
+        ignoreUnknownSignals: true
+
+        function onWidthChanged() { tryApplyImmediate() }
+        function onHeightChanged() { tryApplyImmediate() }
+
+        function tryApplyImmediate() {
+            if (optimizer.imageInfo.width > 0 && optimizer.imageInfo.height > 0
+                    && optimizer.targetImage && optimizer.targetImage.scale > 1.0) {
+                immediateUpgradeFlag = true
+                applyUpgrade()
+            }
+        }
+    }
+
+    Timer {
+        id: sourceSizeUpdateTimer
+        interval: optimizer.debounceInterval
+        repeat: false
+
+        onTriggered: {
+            if (!optimizer.targetImage || !optimizer.targetImage.source) {
+                optimizer.zoomedWidth = 0
+                optimizer.zoomedHeight = 0
+                return
+            }
+
+            if (optimizer.targetImage.scale <= 1.0) {
+                return
+            }
+
+            if (zoomedWidth <= 0) {
+                immediateUpgradeFlag = false
+                applyUpgrade()
+            }
+        }
+    }
+}

--- a/src/qml/ImageDelegate/SvgImageDelegate.qml
+++ b/src/qml/ImageDelegate/SvgImageDelegate.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -9,19 +9,6 @@ import "../Utils"
 
 BaseImageDelegate {
     id: delegate
-
-    // SVG 优化的实际分辨率，延迟更新以避免频繁重新栅格化
-    // 优先使用图片的实际分辨率，如果尚未加载则使用视图尺寸
-    property size optimizedSourceSize: {
-        var actualWidth = targetImageInfo.width
-        var actualHeight = targetImageInfo.height
-
-        if (actualWidth > 0 && actualHeight > 0) {
-            return Qt.size(Math.max(delegate.width, actualWidth), Math.max(delegate.height, actualHeight))
-        } else {
-            return Qt.size(Math.max(delegate.width, width), Math.max(delegate.height, height))
-        }
-    }
 
     status: image.status
     targetImage: image
@@ -40,91 +27,21 @@ BaseImageDelegate {
         smooth: true
         scale: 1.0
         source: delegate.source
-        // 使用延迟更新的优化分辨率，避免缩放过程中的卡顿
-        sourceSize: delegate.optimizedSourceSize
+        sourceSize: sourceSizeOptimizer.optimizedSourceSize
 
-        // 监听缩放变化，延迟更新分辨率
         onScaleChanged: {
-            sourceSizeUpdateTimer.restart()
+            sourceSizeOptimizer.requestUpdate()
         }
     }
 
-    // 监听图片信息变化，当实际分辨率可用时更新 sourceSize
-    Connections {
-        target: targetImageInfo
-
-        function onWidthChanged() {
-            if (targetImageInfo.width > 0) {
-                sourceSizeUpdateTimer.restart()
-            }
-        }
-
-        function onHeightChanged() {
-            if (targetImageInfo.height > 0) {
-                sourceSizeUpdateTimer.restart()
-            }
-        }
-    }
-
-    // 延迟更新 sourceSize 的定时器，避免频繁重新栅格化
-    Timer {
-        id: sourceSizeUpdateTimer
-        interval: 150 // 150ms 延迟，平衡响应性和性能
-        repeat: false
-
-        onTriggered: {
-            if (!delegate.source) {
-                delegate.optimizedSourceSize = Qt.size(0, 0)
-                return
-            }
-
-            // 使用图片的实际分辨率，而不是视图尺寸
-            var actualWidth = targetImageInfo.width
-            var actualHeight = targetImageInfo.height
-            var currentScale = image.scale
-
-            // 如果图片信息尚未加载完成，使用视图尺寸作为备选
-            if (actualWidth <= 0 || actualHeight <= 0) {
-                actualWidth = image.width
-                actualHeight = image.height
-            }
-
-            // 使用正确的缩放比例计算公式：(paintedWidth * scale) / originalWidth
-            // 这与 ImageViewer.qml 中的 readableScale 计算保持一致
-            var actualScaleRatio = 1.0
-            if (actualWidth > 0 && image.paintedWidth > 0) {
-                actualScaleRatio = (image.paintedWidth * currentScale) / actualWidth
-            }
-
-            // 计算基于正确缩放比例的期望渲染分辨率
-            var desiredWidth = actualWidth * actualScaleRatio
-            var desiredHeight = actualHeight * actualScaleRatio
-
-            // 保持宽高比的前提下应用最大分辨率限制，分辨率太高会导致渲染失败
-            var maxDimension = 8000
-            var aspectRatio = actualWidth / actualHeight
-
-            var targetWidth, targetHeight
-
-            if (desiredWidth <= maxDimension && desiredHeight <= maxDimension) {
-                // 期望分辨率都在限制范围内，直接使用
-                targetWidth = Math.max(1, desiredWidth)
-                targetHeight = Math.max(1, desiredHeight)
-            } else {
-                // 需要按比例缩放以适应最大限制
-                if (desiredWidth > desiredHeight) {
-                    // 宽度是限制因素
-                    targetWidth = maxDimension
-                    targetHeight = Math.max(1, maxDimension / aspectRatio)
-                } else {
-                    // 高度是限制因素
-                    targetHeight = maxDimension
-                    targetWidth = Math.max(1, maxDimension * aspectRatio)
-                }
-            }
-
-            delegate.optimizedSourceSize = Qt.size(Math.round(targetWidth), Math.round(targetHeight))
-        }
+    SourceSizeOptimizer {
+        id: sourceSizeOptimizer
+        targetImage: image
+        imageInfo: targetImageInfo
+        delegateWidth: delegate.width
+        delegateHeight: delegate.height
+        maxDimension: 8000
+        maxTotalPixels: 0
     }
 
     ImageInputHandler {

--- a/src/src/imagedata/imageprovider.cpp
+++ b/src/src/imagedata/imageprovider.cpp
@@ -114,6 +114,9 @@ public:
     QQuickTextureFactory *textureFactory() const override;
     void run() override;
 
+private:
+    QImage loadScaleAndCache(const QString &path, int frame, const QSize &targetSize);
+
     AsyncImageProvider *provider = nullptr;
     QString providerId;
     QSize requestedSize;
@@ -133,12 +136,31 @@ QQuickTextureFactory *AsyncImageResponse::textureFactory() const
     return QQuickTextureFactory::textureFactoryForImage(image);
 }
 
+QImage AsyncImageResponse::loadScaleAndCache(const QString &path, int frame, const QSize &targetSize)
+{
+    QImage img;
+    if (frame) {
+        img = readMultiImage(path, frame);
+    } else {
+        img = readNormalImageScaled(path, targetSize);
+    }
+
+    if (!img.isNull() && targetSize.isValid()
+        && (img.width() > targetSize.width() || img.height() > targetSize.height())) {
+        img = img.scaled(targetSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    }
+
+    if (!img.isNull()) {
+        provider->imageCache.add(path, frame, img);
+    }
+    return img;
+}
+
 /**
    @brief 线程中执行加载图像
  */
 void AsyncImageResponse::run()
 {
-    // 解析id，获取当前读取的文件和图片索引
     QString tempPath;
     int frameIndex;
     parseProviderID(providerId, tempPath, frameIndex);
@@ -146,7 +168,6 @@ void AsyncImageResponse::run()
     qCDebug(logImageViewer) << "Loading image:" << tempPath << "frame:" << frameIndex
                             << "requested size:" << requestedSize;
 
-    // 判断缓存中是否存在图片
     image = provider->imageCache.get(tempPath, frameIndex);
 
     if (!image.isNull()) {
@@ -154,28 +175,16 @@ void AsyncImageResponse::run()
     }
 
     if (image.isNull()) {
-        if (frameIndex) {
-            image = readMultiImage(tempPath, frameIndex);
-        } else {
-            // 优先以目标尺寸直接解码，避免先分配全尺寸大图再缩放造成内存峰值
-            image = readNormalImageScaled(tempPath, requestedSize);
-        }
-
-        // 若解码结果超出请求尺寸（如回退到全图路径），在入缓存前缩小，避免缓存过大图片
-        if (!image.isNull() && requestedSize.isValid()
-            && (image.width() > requestedSize.width() || image.height() > requestedSize.height())) {
-            image = image.scaled(requestedSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
-            qCDebug(logImageViewer) << "Scaled image to:" << image.size() << "before caching";
-        }
-
-        // 缓存图片信息，即使是异常图片
-        provider->imageCache.add(tempPath, frameIndex, image);
-    } else {
-        // 缓存命中但超出请求尺寸时（如从放大状态缩小），缩放至合适大小后返回
-        if (!image.isNull() && requestedSize.isValid()
-            && (image.width() > requestedSize.width() || image.height() > requestedSize.height())) {
+        image = loadScaleAndCache(tempPath, frameIndex, requestedSize);
+    } else if (requestedSize.isValid()) {
+        if (image.width() > requestedSize.width() || image.height() > requestedSize.height()) {
             image = image.scaled(requestedSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
             qCDebug(logImageViewer) << "Scaled cached image to:" << image.size();
+        } else if (image.width() < requestedSize.width() && image.height() < requestedSize.height()) {
+            qCDebug(logImageViewer) << "Cached image too small:" << image.size()
+                                    << "requested:" << requestedSize << ", re-reading from disk";
+            provider->imageCache.remove(tempPath, frameIndex);
+            image = loadScaleAndCache(tempPath, frameIndex, requestedSize);
         }
     }
 


### PR DESCRIPTION
Add SourceSizeOptimizer component that upgrades image decode resolution on zoom. Two modes: debounced (scroll wheel, retainWhileLoading) and immediate (large zoom jump, snapshot transition). Also fix C++ image cache to handle upscale requests by re-reading from disk.

添加 SourceSizeOptimizer 组件，在缩放时动态提升图片解码分辨率。
两种模式：防抖模式（滚轮，保留旧纹理平滑过渡）和立即模式（大
幅缩放，快照过渡）。同时修复 C++ 缓存不支持放大请求的问题。

Log: 缩放时动态提升图片解码分辨率，修复放大模糊问题
PMS: BUG-358671
Influence: 图片放大后显示清晰，滚轮平滑无闪烁。