### PR TITLE
fix(window): prevent window re-centering on image switch

### DIFF
--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -65,10 +65,6 @@ ApplicationWindow {
     Connections {
         function onCurrentSourceChanged() {
             window.title = IV.FileControl.slotGetFileName(IV.GControl.currentSource) + IV.FileControl.slotFileSuffix(IV.GControl.currentSource);
-            if (window.visibility !== Window.FullScreen && window.visibility !== Window.Maximized) {
-                setX(IV.FileControl.getPrimaryScreenCenterX(width));
-                setY(IV.FileControl.getPrimaryScreenCenterY(height));
-            }
         }
 
         target: IV.GControl


### PR DESCRIPTION
Only center window when opening new files via setImageFiles(), not on every currentSourceChanged during browsing.

仅在通过setImageFiles()打开新文件时居中窗口，
而非每次切换图片浏览时都重新居中。

Log: 修复切换图片时窗口位置重置到居中的问题
PMS: BUG-358647
Influence: 移动窗口后切换图片不再跳回屏幕居中，仅在首次打开图片文件时居中。