### PR TITLE
fix(info-dialog): auto-save filename on focus loss

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 *.a
 
 build*/
+obj-x86_64-linux-gnu/
 include*/
 
 *.txt.user*

--- a/src/qml/InformationDialog/PropertyActionItemDelegate.qml
+++ b/src/qml/InformationDialog/PropertyActionItemDelegate.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -39,6 +39,9 @@ Control {
     }
     property string title
 
+    // 允许组件接收焦点（用于转移焦点）
+    focus: true
+
     signal clicked
 
     function dealShowPicLabelClick() {
@@ -56,9 +59,25 @@ Control {
         }
     }
 
-    // 复位当前属性编辑组件，关闭编辑框
+    // 复位当前属性编辑组件，关闭编辑框（不保存）
     function reset() {
         showPicLabel.visible = true;
+    }
+
+    // 提交更改并关闭编辑框（保存文件名）
+    function commitAndClose() {
+        if (!showPicLabel.visible) {
+            var name = nameedit.text;
+            if (!IV.FileControl.isShowToolTip(IV.GControl.currentSource, name) && name.length > 0) {
+                IV.FileControl.slotFileReName(name, IV.GControl.currentSource);
+            }
+            showPicLabel.visible = true;
+        }
+    }
+
+    // 检查是否处于编辑状态
+    function isEditing() {
+        return !showPicLabel.visible;
     }
 
     bottomPadding: 4
@@ -113,6 +132,33 @@ Control {
                     }
                     if (event.key === Qt.Key_Escape) {
                         reset();
+                    }
+                }
+
+                // 焦点变化时处理 - 失去焦点时保存文件名
+                onActiveFocusChanged: {
+                    // 失去焦点且输入框可见时，保存文件名
+                    if (!activeFocus && visible && !showPicLabel.visible) {
+                        // 延迟执行，避免与其他焦点事件冲突
+                        commitAndCloseTimer.restart();
+                    }
+                }
+
+                // 失去焦点时保存文件名（备用方案）
+                onEditingFinished: {
+                    // 只有当输入框可见时才处理（避免在 reset 时触发）
+                    if (visible && !showPicLabel.visible) {
+                        dealShowPicLabelClick();
+                    }
+                }
+
+                Timer {
+                    id: commitAndCloseTimer
+                    interval: 10
+                    onTriggered: {
+                        if (!nameedit.activeFocus && nameedit.visible && !showPicLabel.visible) {
+                            dealShowPicLabelClick();
+                        }
                     }
                 }
 

--- a/src/qml/InformationDialog/PropertyItemDelegate.qml
+++ b/src/qml/InformationDialog/PropertyItemDelegate.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -41,6 +41,18 @@ Control {
     property string title
 
     signal clicked
+
+    // 允许接收焦点，点击时可以转移其他元素的焦点
+    focus: true
+
+    // 点击时获取焦点，使用 forceActiveFocus 确保能跨焦点作用域抢走焦点
+    MouseArea {
+        anchors.fill: parent
+        onClicked: {
+            control.forceActiveFocus();
+        }
+        cursorShape: Qt.ArrowCursor
+    }
 
     bottomPadding: 4
     implicitWidth: contrlImplicitWidth


### PR DESCRIPTION
Add focus handling to property delegates and auto-save filename when input loses focus, preventing data loss when clicking other items.

为属性委托添加焦点处理，输入框失去焦点时自动保存文件名，
防止点击其他项时数据丢失。

Log: 修复信息对话框文件名编辑失去焦点时自动保存
PMS: BUG-323761
Influence: 修复文件名编辑功能，用户在信息对话框中编辑文件名后点击其他区域时，会自动保存文件名，避免数据丢失。