### PR TITLE
fix(info-dialog): remove window stays on top hint

### DIFF
--- a/src/qml/InformationDialog/InformationDialog.qml
+++ b/src/qml/InformationDialog/InformationDialog.qml
@@ -20,7 +20,7 @@ DialogWindow {
     property int propRightWidth: 86
     property int topY: 70
 
-    flags: Qt.Dialog | Qt.WindowCloseButtonHint | Qt.MSWindowsFixedSizeDialogHint | Qt.WindowStaysOnTopHint
+    flags: Qt.Dialog | Qt.WindowCloseButtonHint | Qt.MSWindowsFixedSizeDialogHint
     maximumWidth: 280
     minimumWidth: 280
     visible: false


### PR DESCRIPTION
Remove Qt.WindowStaysOnTopHint flag from information dialog to allow normal window layering behavior.

移除信息对话框的窗口置顶标志，允许正常的窗口层级行为。

Log: 移除信息对话框窗口置顶标志
PMS: BUG-360103
Influence: 信息对话框不再强制置顶，用户可以正常操作其他窗口，提升用户体验。