### PR TITLE
fix(multi-image): fix blank page when switching multi-page TIFF frames

### DIFF
--- a/src/src/imagedata/imageinfo.cpp
+++ b/src/src/imagedata/imageinfo.cpp
@@ -357,7 +357,7 @@ void ImageInfoCache::loadFinished(const QString &path, int frameIndex, ImageInfo
 
     ThumbnailCache::Key key = ThumbnailCache::toFindKey(path, frameIndex);
 
-    if (data && waitSet.contains(key)) {
+    if (data) {
         cache.insert(key, data);
         qCDebug(logImageViewer) << "Image loaded successfully:" << path << "frame:" << frameIndex
                                 << "type:" << data->type << "size:" << data->size;

--- a/src/src/imagedata/pathviewproxymodel.cpp
+++ b/src/src/imagedata/pathviewproxymodel.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -594,6 +594,13 @@ void PathViewProxyModel::asyncUpdateLoadInfo(const QUrl &url, int sourceIndex, i
         ImageInfo *delayInfo = new ImageInfo(url, this);
         connect(delayInfo, &ImageInfo::statusChanged, this, [this, delayInfo, sourceIndex]() {
             qCDebug(logImageViewer) << "AsyncUpdateLoadInfo: ImageInfo status changed for:" << delayInfo->source().toString();
+            // Loading is a transient state; wait for a terminal state (Ready/Error).
+            // Requires loadFinished() to cache data unconditionally so that
+            // the subsequent Ready status change is guaranteed to fire.
+            if (ImageInfo::Loading == delayInfo->status()) {
+                return;
+            }
+
             // 仅更新加载成功的多页图数据，其它类型的数据无需关注，默认的 frameIndex 都是 0
             if (ImageInfo::Ready == delayInfo->status() && Types::MultiImage == delayInfo->type()) {
                 qCDebug(logImageViewer) << "Async update completed for multi-image:" << delayInfo->source().toString()


### PR DESCRIPTION
Cache loaded image data unconditionally in loadFinished() to prevent data loss from duplicate async load requests, and defer delayInfo cleanup until terminal status (Ready/Error) to ensure frame count update completes.

修复多页图切换第二页显示空白的问题，loadFinished() 无条件缓存
加载结果避免竞态丢数据，delayInfo 等待终态再清理确保帧数更新。

Log: 修复多页TIFF切换空白
PMS: BUG-359509
Influence: 修复后多页图（如多页TIFF）可正常逐页切换，不再出现空白或显示错误图片。