### PR TITLE
fix: show prev/next buttons for single multi-page TIF file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ vendor/lib/*
 .cursor
 .cursorindexingignore
 .specstory/
+.claude/
+.trellis/
+AGENTS.md
 
 *.log
 

--- a/src/qml/ThumbnailListView.qml
+++ b/src/qml/ThumbnailListView.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -133,7 +133,7 @@ Control {
         leftPadding: 10
         rightPadding: 20
         spacing: 10
-        visible: IV.GControl.imageCount > 1
+        visible: IV.GControl.hasPreviousImage || IV.GControl.hasNextImage
         width: visible ? implicitWidth : 0
 
         anchors {

--- a/src/src/globalcontrol.cpp
+++ b/src/src/globalcontrol.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -29,6 +29,11 @@ GlobalControl::GlobalControl(QObject *parent)
     sourceModel = new ImageSourceModel(this);
     viewSourceModel = new PathViewProxyModel(sourceModel, this);
     qCDebug(logImageViewer) << "ImageSourceModel and PathViewProxyModel initialized.";
+
+    // 图片信息异步加载完成后重新评估切换按钮状态
+    connect(&currentImage, &ImageInfo::infoChanged, this, [this]() {
+        checkSwitchEnable();
+    });
 
     // 图片旋转完成后触发信息变更
     connect(RotateImageHelper::instance(), &RotateImageHelper::rotateImageFinished, this, [this](const QString &path, bool ret) {

--- a/src/src/globalcontrol.cpp
+++ b/src/src/globalcontrol.cpp
@@ -30,9 +30,9 @@ GlobalControl::GlobalControl(QObject *parent)
     viewSourceModel = new PathViewProxyModel(sourceModel, this);
     qCDebug(logImageViewer) << "ImageSourceModel and PathViewProxyModel initialized.";
 
-    // 图片信息异步加载完成后重新评估切换按钮状态
+    // 图片信息异步加载完成后重新评估切换按钮状态（防抖，避免频繁触发）
     connect(&currentImage, &ImageInfo::infoChanged, this, [this]() {
-        checkSwitchEnable();
+        switchCheckTimer.start(50, this);
     });
 
     // 图片旋转完成后触发信息变更
@@ -510,6 +510,9 @@ void GlobalControl::timerEvent(QTimerEvent *event)
         submitTimer.stop();
         submitImageChangeImmediately();
         qCDebug(logImageViewer) << "Submit timer stopped and image changes submitted.";
+    } else if (switchCheckTimer.timerId() == event->timerId()) {
+        switchCheckTimer.stop();
+        checkSwitchEnable();
     }
 }
 
@@ -519,9 +522,16 @@ void GlobalControl::timerEvent(QTimerEvent *event)
 void GlobalControl::checkSwitchEnable()
 {
     qCDebug(logImageViewer) << "GlobalControl::checkSwitchEnable() called.";
-    Q_ASSERT(sourceModel);
+    if (!sourceModel || sourceModel->rowCount() <= 0) {
+        if (hasPrevious) { hasPrevious = false; Q_EMIT hasPreviousImageChanged(); }
+        if (hasNext) { hasNext = false; Q_EMIT hasNextImageChanged(); }
+        return;
+    }
+
     bool previous = (curIndex > 0 || curFrameIndex > 0);
-    bool next = (curIndex < (sourceModel->rowCount() - 1) || curFrameIndex < (currentImage.frameCount() - 1));
+    const int frameCount = currentImage.frameCount();
+    bool next = (curIndex < (sourceModel->rowCount() - 1)
+                 || (frameCount > 1 && curFrameIndex < (frameCount - 1)));
     qCDebug(logImageViewer) << "Can go previous: " << previous << ", Can go next: " << next;
 
     if (previous != hasPrevious) {

--- a/src/src/globalcontrol.h
+++ b/src/src/globalcontrol.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -100,6 +100,7 @@ private:
 
     int imageRotation = 0;    // 当前图片旋转角度
     QBasicTimer submitTimer;  // 图片变更提交定时器
+    QBasicTimer switchCheckTimer;  // 切换按钮状态检查防抖定时器
 };
 
 #endif  // GLOBALCONTROL_H


### PR DESCRIPTION
Fix visibility condition and async loading timing issue:
- QML: use hasPreviousImage/hasNextImage instead of imageCount > 1
- C++: connect infoChanged to checkSwitchEnable for async frame data

修复单文件多页TIF图片工具栏上一张/下一张按钮不显示的问题，
包含QML可见性条件修复和C++异步加载时序修复。

Log: 修复多页TIF工具栏按钮不显示
PMS: BUG-323847
Influence: 修复后打开单张多页TIF图片时，工具栏上一张/下一张按钮正常显示，
多文件场景和单张普通图片场景不受影响。