### PR TITLE
perf(dialog): disable enableInWindowBlendBlur for dialog title bars

### DIFF
--- a/src/qml/Dialog/RemoveDialog.qml
+++ b/src/qml/Dialog/RemoveDialog.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -26,7 +26,7 @@ DialogWindow {
     width: 400
 
     header: DialogTitleBar {
-        enableInWindowBlendBlur: true
+        enableInWindowBlendBlur: false
 
         // 仅保留默认状态，否则 hover 上会有变化效果
         icon {

--- a/src/qml/InformationDialog/InformationDialog.qml
+++ b/src/qml/InformationDialog/InformationDialog.qml
@@ -29,7 +29,7 @@ DialogWindow {
     header: DialogTitleBar {
         property string title: fileName
 
-        enableInWindowBlendBlur: true
+        enableInWindowBlendBlur: false
 
         content: Loader {
             sourceComponent: Label {


### PR DESCRIPTION
Disable in-window blend blur on RemoveDialog and InformationDialog to reduce GPU overhead.

关闭删除对话框和信息对话框的窗口内混合模糊效果，降低GPU开销。

Log: 关闭dialog的enableInWindowBlendBlur
PMS: BUG-362807
Influence: 删除确认对话框和图片信息对话框不再启用窗口内混合模糊，降低GPU渲染开销。