### PR TITLE
fix(delegate): add Ctrl+wheel navigation for NonexistImageDelegate

### DIFF
--- a/src/qml/ImageDelegate/NonexistImageDelegate.qml
+++ b/src/qml/ImageDelegate/NonexistImageDelegate.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -30,6 +30,19 @@ BaseImageDelegate {
         mipmap: true
         smooth: true
         width: 100
+    }
+
+    // 文件不存在时仍需支持 Ctrl+滚轮切换图片
+    MouseArea {
+        anchors.fill: parent
+        acceptedButtons: Qt.NoButton
+
+        onWheel: wheel => {
+            if (Qt.ControlModifier & wheel.modifiers) {
+                var detla = wheel.angleDelta.y / 120;
+                detla > 0 ? IV.GControl.previousImage() : IV.GControl.nextImage();
+            }
+        }
     }
 
     Label {


### PR DESCRIPTION
Add MouseArea to NonexistImageDelegate to handle Ctrl+wheel events, allowing image switching when the current image file is deleted.

修复图片文件被外部删除后，委托切换为 NonexistImageDelegate
导致无法通过 Ctrl+滚轮切换图片的问题。

Log: 修复文件删除后 Ctrl+滚轮无法切换图片
PMS: BUG-311063
Influence: 图片文件被外部删除后，用户仍可通过 Ctrl+滚轮切换到其他存在的图片。