### PR TITLE
fix(livetext): show IBeam cursor over recognized text blocks

### DIFF
--- a/src/qml/FullImageView.qml
+++ b/src/qml/FullImageView.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -304,6 +304,15 @@ Item {
         acceptedButtons: Qt.LeftButton
         enabled: !IV.GStatus.delayInit
         hoverEnabled: true
+
+        onPositionChanged: {
+            if (imageViewer.liveTextActive) {
+                var pos = mapToItem(imageViewer, mouseX, mouseY);
+                cursorShape = imageViewer.isMouseOverLiveBlock(pos.x, pos.y) ? Qt.IBeamCursor : Qt.ArrowCursor;
+            } else {
+                cursorShape = Qt.ArrowCursor;
+            }
+        }
 
         onEntered: {
             isEnterCurrentView = true;

--- a/src/qml/ImageViewer.qml
+++ b/src/qml/ImageViewer.qml
@@ -22,6 +22,14 @@ Item {
     property real lastDisplayScaleWidth: 0
     // current LiveText select text
     property bool liveTextSelected: false
+    // LiveText overlay 是否可见（识别完成并显示文字块）
+    property bool liveTextActive: false
+
+    function isMouseOverLiveBlock(x, y) {
+        if (!liveTextActive || !ltwLoader.item) return false;
+        var pos = ltwLoader.item.mapFromItem(imageViewer, x, y);
+        return ltwLoader.item.isOverBlock(pos.x, pos.y);
+    }
     // Image 类型的对象，空图片、错误图片、消失图片等异常为 null
     property alias targetImage: view.currentImage
 
@@ -562,6 +570,7 @@ Item {
                 liveTextAnalyzer.breakAnalyze();
                 ltw.clearLive();
                 liveTextTimer.stop();
+                imageViewer.liveTextActive = false;
             }
 
             //live text分析函数
@@ -582,6 +591,7 @@ Item {
                     console.debug("run live start");
                     ltw.drawRect(liveTextAnalyzer.liveBlock());
                     ltw.visible = true;
+                    imageViewer.liveTextActive = true;
                 }
             }
 

--- a/src/qml/LiveText/LiveTextWidget.qml
+++ b/src/qml/LiveText/LiveTextWidget.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -132,6 +132,17 @@ Item {
             }
         }
         return have;
+    }
+
+    function isOverBlock(x, y) {
+        for (var i = 0; i != blockArray.length; ++i) {
+            var block = blockArray[i];
+            if (x >= block.x && x <= block.x + block.width
+                    && y >= block.y && y <= block.y + block.height) {
+                return true;
+            }
+        }
+        return false;
     }
 
     visible: false


### PR DESCRIPTION
Root cause: imageViewerArea MouseArea overlays ImageViewer, blocking LiveBlock's cursorShape. Add position-based cursor switching via isOverBlock hit test.

根因：imageViewerArea MouseArea 覆盖在 ImageViewer 之上，
拦截了 LiveBlock 的光标设置。通过 isOverBlock 命中检测
动态切换光标形状。

Log: 修复实况文本区域光标未变为IBeam的问题
PMS: BUG-323751
Influence: 鼠标悬停在实况文字识别区域时正确显示文本选择光标