### PR TITLE
fix: remove redundant liveTextActive guard in onPositionChanged

### DIFF
--- a/src/qml/FullImageView.qml
+++ b/src/qml/FullImageView.qml
@@ -306,12 +306,9 @@ Item {
         hoverEnabled: true
 
         onPositionChanged: {
-            if (imageViewer.liveTextActive) {
-                var pos = mapToItem(imageViewer, mouseX, mouseY);
-                cursorShape = imageViewer.isMouseOverLiveBlock(pos.x, pos.y) ? Qt.IBeamCursor : Qt.ArrowCursor;
-            } else {
-                cursorShape = Qt.ArrowCursor;
-            }
+            if (!imageViewer.liveTextActive) return;
+            var pos = mapToItem(imageViewer, mouseX, mouseY);
+            cursorShape = imageViewer.isMouseOverLiveBlock(pos.x, pos.y) ? Qt.IBeamCursor : Qt.ArrowCursor;
         }
 
         onEntered: {


### PR DESCRIPTION
isMouseOverLiveBlock already returns false when liveTextActive is false, making the outer if/else unnecessary.

isMouseOverLiveBlock 在 liveTextActive 为 false 时已返回 false， 外层 if/else 冗余，直接用三元表达式即可。

Log: 简化光标切换逻辑
Influence: 无功能变更，纯代码简化

## Summary by Sourcery

Enhancements:
- Streamline the mouse position handler by relying on isMouseOverLiveBlock to determine cursor shape without an extra liveTextActive guard.