### PR TITLE
chore: Update version to 6.0.46

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-image-viewer (6.0.46) unstable; urgency=medium
+
+  * chore: Update version to 6.0.46
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Thu, 09 Jul 2026 13:05:34 +0800
+
 deepin-image-viewer (6.0.45) unstable; urgency=medium
 
   * fix: remove redundant liveTextActive guard in onPositionChanged

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.image.viewer
   name: deepin-image-viewer
-  version: 6.0.45.1
+  version: 6.0.46.1
   kind: app
   description: |
     view images for deepin os.
@@ -16,7 +16,7 @@ command:
   - deepin-image-viewer
 
 base: org.deepin.base/25.2.2
-runtime: org.deepin.runtime.dtk/25.2.2
+runtime: org.deepin.runtime.dtk/6.7.0
 
 build: |
   # 下载和安装依赖


### PR DESCRIPTION
- update version to 6.0.46

log: update version to 6.0.46

## Summary by Sourcery

Build:
- Update linglong packaging metadata with the new app version and runtime dependency.