### PR TITLE
fix(image): allow full-resolution decode for zoomed large images

### DIFF
--- a/src/src/imagedata/imageprovider.cpp
+++ b/src/src/imagedata/imageprovider.cpp
@@ -17,6 +17,10 @@
 Q_DECLARE_LOGGING_CATEGORY(logImageViewer)
 
 static const QString s_tagFrame = "#frame_";
+// 默认解码上限（保护内存）；与 QML SourceSizeOptimizer.maxDimension(15000) 对齐，
+// 放大场景下允许解码到原图全分辨率
+static const int s_defaultMaxDimension = 4096;
+static const int s_maxUpgradeDimension = 15000;
 
 /**
    @brief 解析图像处理器 \a id , 取得请求的文件路径 \a filePath 和 \a frameIndex
@@ -39,12 +43,13 @@ static void parseProviderID(const QString &id, QString &filePath, int &frameInde
 
 /**
    @return 读取 \a imagePath 的图像数据并返回
+   @param maxDimension 原图任一边超过该值时按比例缩放到该上限
  */
-static QImage readNormalImage(const QString &imagePath)
+static QImage readNormalImage(const QString &imagePath, int maxDimension = s_defaultMaxDimension)
 {
     QImage image;
     QString error;
-    if (!LibUnionImage_NameSpace::loadStaticImageFromFile(imagePath, image, error)) {
+    if (!LibUnionImage_NameSpace::loadStaticImageFromFile(imagePath, image, error, "", maxDimension)) {
         qCWarning(logImageViewer) << "Failed to load image:" << imagePath << "Error:" << error;
     } else {
         qCDebug(logImageViewer) << "Successfully loaded image:" << imagePath << "Size:" << image.size();
@@ -83,7 +88,8 @@ static QImage readNormalImageScaled(const QString &imagePath, const QSize &targe
         qCDebug(logImageViewer) << "QImageReader scaled read failed, falling back:" << imagePath;
     }
 
-    return readNormalImage(imagePath);
+    // targetSize >= 原图（放大升级）或按需缩放失败，用升级上限避免 4096 截断
+    return readNormalImage(imagePath, s_maxUpgradeDimension);
 }
 
 /**
@@ -399,7 +405,11 @@ QImage ImageProvider::requestImage(const QString &id, QSize *size, const QSize &
             image = readMultiImage(tempPath, frameIndex);
             qCDebug(logImageViewer) << "Read multi image for:" << tempPath << "frame:" << frameIndex;
         } else {
-            image = readNormalImage(tempPath);
+            // 按请求尺寸钳制解码上限：小请求用默认值保护内存，大请求随请求增长但不超过升级上限
+            int maxDim = qBound(s_defaultMaxDimension,
+                                qMax(requestedSize.width(), requestedSize.height()),
+                                s_maxUpgradeDimension);
+            image = readNormalImage(tempPath, maxDim);
             qCDebug(logImageViewer) << "Read normal image for:" << tempPath;
         }
 

--- a/src/src/unionimage/unionimage.cpp
+++ b/src/src/unionimage/unionimage.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -435,7 +435,7 @@ UNIONIMAGESHARED_EXPORT QString unionImageVersion()
     return ver;
 }
 
-UNIONIMAGESHARED_EXPORT bool loadStaticImageFromFile(const QString &path, QImage &res, QString &errorMsg, const QString &format_bar)
+UNIONIMAGESHARED_EXPORT bool loadStaticImageFromFile(const QString &path, QImage &res, QString &errorMsg, const QString &format_bar, int maxDimension)
 {
     qCDebug(logImageViewer) << "Loading static image from file:" << path;
     QFileInfo file_info(path);
@@ -473,7 +473,6 @@ UNIONIMAGESHARED_EXPORT bool loadStaticImageFromFile(const QString &path, QImage
         qCDebug(logImageViewer) << "Set QImageReader allocation limit to 2048MB";
         
         QSize originalSize = reader.size();
-        const int maxDimension = 4096;
         if (originalSize.width() > maxDimension || originalSize.height() > maxDimension) {
             qCDebug(logImageViewer) << "Large image detected (" << originalSize.width() << "x" << originalSize.height()
                                   << "), scaling down to max dimension:" << maxDimension;

--- a/src/src/unionimage/unionimage.h
+++ b/src/src/unionimage/unionimage.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -82,7 +82,7 @@ UNIONIMAGESHARED_EXPORT bool creatNewImage(QImage &res, int width = 0, int heigh
  * 载入失败返回false，如果需要可以读取errorMsg返回错误信息
  * 载入动态图片时，只会返回动态图片的第一帧，如果需要动图请使用UUnionMovieImage
  */
-UNIONIMAGESHARED_EXPORT bool loadStaticImageFromFile(const QString &path, QImage &res, QString &errorMsg, const QString &format_bar = "");
+UNIONIMAGESHARED_EXPORT bool loadStaticImageFromFile(const QString &path, QImage &res, QString &errorMsg, const QString &format_bar = "", int maxDimension = 4096);
 
 /**
  * @brief detectImageFormat


### PR DESCRIPTION
loadStaticImageFromFile hardcoded a 4096px cap, but QML SourceSizeOptimizer requests up to 15000px on zoom, so the zoom fallback decoded large images at 4096 and appeared blurry. Add a configurable maxDimension param aligned with the QML limit.

loadStaticImageFromFile 原硬编码 4096 上限，与 QML
SourceSizeOptimizer 放大时请求的不一致，导致放大回退
路径将大图截断到 4096 而模糊。新增可配置 maxDimension 参数，
与 QML 上限对齐。

Log: 修复大图放大模糊问题
PMS: BUG-369639
Influence: 放大超过4096px的大图时按原图分辨率解码，不再截断模糊；小尺寸请求和内存保护(setAllocationLimit/maxTotalPixels)不受影响。