### PR TITLE
docs(image-viewer): merge rotation buttons into single Rotate entry

### DIFF
--- a/src/assets/deepin-image-viewer/image-viewer/en_US/d_image-viewer.md
+++ b/src/assets/deepin-image-viewer/image-viewer/en_US/d_image-viewer.md
@@ -57,8 +57,7 @@ Following Image formats are supported: BMP, ICO, JPG/JPE/JPEG, PNG, TGA, TIF/TIF
 | ![adapt_image](../common/adaptimage.svg)               | 1:1 Size                | The image will show in 1:1 size.                          |
 | ![fit_hover](../common/adaptscreen.svg)                | Fit to window           | The image will be resized to adapt to the current window. |
 | ![ocr](../common/ocr.svg)                | Extract text          | Texts on the image will be recognized. |
-| ![clockwise_rotation](../common/clockwiserotation.svg) | Rotate clockwise        | Rotate the image 90 degrees clockwise.                    |
-| ![contrarotate](../common/contrarotate.svg)            | Rotate counterclockwise | Rotate the image 90 degrees counterclockwise.             |
+| ![contrarotate](../common/contrarotate.svg)            | Rotate | Rotate the image 90 degrees counterclockwise.             |
 | ![delete](../common/delete.svg)                        | Delete                  | Delete the current image.                                 |
 
 > ![notes](../common/notes.svg) Notes: You are unavailable to rename, rotate and delete system images.

--- a/src/assets/deepin-image-viewer/image-viewer/en_US/p_image-viewer.md
+++ b/src/assets/deepin-image-viewer/image-viewer/en_US/p_image-viewer.md
@@ -57,8 +57,7 @@ Following Image formats are supported: BMP, ICO, JPG/JPE/JPEG, PNG, TGA, TIF/TIF
 | ![adapt_image](../common/adaptimage.svg)               | 1:1 Size                | The image will show in 1:1 size.                          |
 | ![fit_hover](../common/adaptscreen.svg)                | Fit to window           | The image will be resized to adapt to the current window. |
 | ![ocr](../common/ocr.svg)                | Extract text          | Texts on the image will be recognized. |
-| ![clockwise_rotation](../common/clockwiserotation.svg) | Rotate clockwise        | Rotate the image 90 degrees clockwise.                    |
-| ![contrarotate](../common/contrarotate.svg)            | Rotate counterclockwise | Rotate the image 90 degrees counterclockwise.             |
+| ![contrarotate](../common/contrarotate.svg)            | Rotate | Rotate the image 90 degrees counterclockwise.             |
 | ![delete](../common/delete.svg)                        | Delete                  | Delete the current image.                                 |
 
 > ![notes](../common/notes.svg) Notes: You are unavailable to rename, rotate and delete system images.

--- a/src/assets/deepin-image-viewer/image-viewer/zh_CN/d_image-viewer.md
+++ b/src/assets/deepin-image-viewer/image-viewer/zh_CN/d_image-viewer.md
@@ -59,8 +59,7 @@
 | ![adaptimage](../common/adaptimage.svg)               | 1:1视图    | 图片按照实际尺寸显示。 |
 | ![adaptscreen](../common/adaptscreen.svg)             | 适应窗口   | 图片适应窗口尺寸显示。 |
 | ![ocr](../common/ocr.svg)             | 识别文字 | 识别图片中的文字。 |
-| ![clockwiserotation](../common/clockwiserotation.svg) | 顺时针旋转 | 图片顺时针旋转90度。   |
-| ![contrarotate](../common/contrarotate.svg)           | 逆时针旋转 | 图片逆时针旋转90度。   |
+| ![contrarotate](../common/contrarotate.svg)           | 旋转 | 图片逆时针旋转90度。   |
 | ![delete](../common/delete.svg)                       | 删除       | 删除当前图片。         |
 
 

--- a/src/assets/deepin-image-viewer/image-viewer/zh_CN/p_image-viewer.md
+++ b/src/assets/deepin-image-viewer/image-viewer/zh_CN/p_image-viewer.md
@@ -59,8 +59,7 @@
 | ![adaptimage](../common/adaptimage.svg)               | 1:1视图    | 图片按照实际尺寸显示。 |
 | ![adaptscreen](../common/adaptscreen.svg)             | 适应窗口   | 图片适应窗口尺寸显示。 |
 | ![ocr](../common/ocr.svg)             | 识别文字 | 识别图片中的文字。 |
-| ![clockwiserotation](../common/clockwiserotation.svg) | 顺时针旋转 | 图片顺时针旋转90度。   |
-| ![contrarotate](../common/contrarotate.svg)           | 逆时针旋转 | 图片逆时针旋转90度。   |
+| ![contrarotate](../common/contrarotate.svg)           | 旋转 | 图片逆时针旋转90度。   |
 | ![delete](../common/delete.svg)                       | 删除       | 删除当前图片。         |
 
 

--- a/src/assets/deepin-image-viewer/image-viewer/zh_HK/d_image-viewer.md
+++ b/src/assets/deepin-image-viewer/image-viewer/zh_HK/d_image-viewer.md
@@ -58,8 +58,7 @@
 | ![adapt_image](../common/adaptimage.svg)               | 1:1視圖    | 圖片按照實際尺寸顯示。 |
 | ![adapt_screen](../common/adaptscreen.svg)             | 適應窗口   | 圖片適應窗口尺寸顯示。 |
 | ![ocr](../common/ocr.svg)             | 識別文字 | 識別圖片中的文字。 |
-| ![clockwise_rotation](../common/clockwiserotation.svg) | 順時針旋轉 | 圖片順時針旋轉90度。   |
-| ![contrarotate](../common/contrarotate.svg)            | 逆時針旋轉 | 圖片逆時針旋轉90度。   |
+| ![contrarotate](../common/contrarotate.svg)            | 旋轉 | 圖片逆時針旋轉90度。   |
 | ![delete](../common/delete.svg)                        | 刪除       | 刪除當前圖片。         |
 
 > ![notess](../common/notes.svg) 說明：系統圖片不支持重命名、旋轉和刪除的操作。

--- a/src/assets/deepin-image-viewer/image-viewer/zh_HK/p_image-viewer.md
+++ b/src/assets/deepin-image-viewer/image-viewer/zh_HK/p_image-viewer.md
@@ -58,8 +58,7 @@
 | ![adapt_image](../common/adaptimage.svg)               | 1:1視圖    | 圖片按照實際尺寸顯示。 |
 | ![adapt_screen](../common/adaptscreen.svg)             | 適應窗口   | 圖片適應窗口尺寸顯示。 |
 | ![ocr](../common/ocr.svg)             | 識別文字 | 識別圖片中的文字。 |
-| ![clockwise_rotation](../common/clockwiserotation.svg) | 順時針旋轉 | 圖片順時針旋轉90度。   |
-| ![contrarotate](../common/contrarotate.svg)            | 逆時針旋轉 | 圖片逆時針旋轉90度。   |
+| ![contrarotate](../common/contrarotate.svg)            | 旋轉 | 圖片逆時針旋轉90度。   |
 | ![delete](../common/delete.svg)                        | 刪除       | 刪除當前圖片。         |
 
 > ![notess](../common/notes.svg) 說明：系統圖片不支持重命名、旋轉和刪除的操作。

--- a/src/assets/deepin-image-viewer/image-viewer/zh_TW/d_image-viewer.md
+++ b/src/assets/deepin-image-viewer/image-viewer/zh_TW/d_image-viewer.md
@@ -56,8 +56,7 @@
 | ![adapt_image](../common/adaptimage.svg)               | 1:1檢視    | 圖片按照實際尺寸顯示。 |
 | ![adapt_screen](../common/adaptscreen.svg)             | 適應視窗   | 圖片適應視窗尺寸顯示。 |
 | ![ocr](../common/ocr.svg)             | 識別文字 | 識別圖片中的文字。 |
-| ![clockwise_rotation](../common/clockwiserotation.svg) | 順時針旋轉 | 圖片順時針旋轉90度。   |
-| ![contrarotate](../common/contrarotate.svg)            | 逆時針旋轉 | 圖片逆時針旋轉90度。   |
+| ![contrarotate](../common/contrarotate.svg)            | 旋轉 | 圖片逆時針旋轉90度。   |
 | ![delete](../common/delete.svg)                        | 刪除       | 刪除目前圖片。         |
 
 

--- a/src/assets/deepin-image-viewer/image-viewer/zh_TW/p_image-viewer.md
+++ b/src/assets/deepin-image-viewer/image-viewer/zh_TW/p_image-viewer.md
@@ -56,8 +56,7 @@
 | ![adapt_image](../common/adaptimage.svg)               | 1:1檢視    | 圖片按照實際尺寸顯示。 |
 | ![adapt_screen](../common/adaptscreen.svg)             | 適應視窗   | 圖片適應視窗尺寸顯示。 |
 | ![ocr](../common/ocr.svg)             | 識別文字 | 識別圖片中的文字。 |
-| ![clockwise_rotation](../common/clockwiserotation.svg) | 順時針旋轉 | 圖片順時針旋轉90度。   |
-| ![contrarotate](../common/contrarotate.svg)            | 逆時針旋轉 | 圖片逆時針旋轉90度。   |
+| ![contrarotate](../common/contrarotate.svg)            | 旋轉 | 圖片逆時針旋轉90度。   |
 | ![delete](../common/delete.svg)                        | 刪除       | 刪除目前圖片。         |
 
 


### PR DESCRIPTION
Merge clockwise and counterclockwise rotation entries into one "Rotate" entry to match the updated toolbar UI.

将顺时针旋转和逆时针旋转两个说明条目合并为一个「旋转」条目，与最新工具栏 UI 保持一致。

Log: 更新旋转按钮说明文档，合并为单个旋转条目
PMS: BUG-344695
Influence: 仅影响图片查看器使用说明文档的工具栏图标说明，不涉及功能代码改动。