### PR TITLE
fix(image): wait for image info before setting dynamic source size

### DIFF
--- a/src/qml/ImageDelegate/DynamicImageDelegate.qml
+++ b/src/qml/ImageDelegate/DynamicImageDelegate.qml
@@ -3,12 +3,31 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import QtQuick
+import org.deepin.image.viewer 1.0 as IV
 import "../Utils"
 
 BaseImageDelegate {
     id: delegate
 
     property bool needInit: true
+    readonly property bool imageInfoReady: targetImageInfo.status === IV.ImageInfo.Ready
+
+    function scaledSourceSize() {
+        var sourceWidth = targetImageInfo.width
+        var sourceHeight = targetImageInfo.height
+        var requestedSize = sourceSizeOptimizer.optimizedSourceSize
+
+        if (sourceWidth <= 0 || sourceHeight <= 0
+                || requestedSize.width <= 0 || requestedSize.height <= 0) {
+            return Qt.size(0, 0)
+        }
+
+        var scale = Math.min(1,
+                             requestedSize.width / sourceWidth,
+                             requestedSize.height / sourceHeight)
+        return Qt.size(Math.max(1, Math.round(sourceWidth * scale)),
+                       Math.max(1, Math.round(sourceHeight * scale)))
+    }
 
     inputHandler: imageInput
     status: image.status
@@ -24,14 +43,20 @@ BaseImageDelegate {
         height: delegate.height
         scale: 1.0
         smooth: true
-        source: delegate.source
-        // 限制每帧解码分辨率为显示区域大小，动图帧数多时可显著降低内存峰值
-        sourceSize: sourceSizeOptimizer.optimizedSourceSize
+        // 等待原始尺寸就绪，避免将显示区域的宽高直接传给动图解码器而拉伸帧内容。
+        source: delegate.imageInfoReady ? delegate.source : ""
+        // 限制每帧解码分辨率，同时保持原图比例且不在解码阶段放大。
+        sourceSize: delegate.imageInfoReady ? delegate.scaledSourceSize() : Qt.size(0, 0)
         width: delegate.width
 
         onScaleChanged: {
             sourceSizeOptimizer.requestUpdate()
         }
+    }
+
+    onSourceChanged: {
+        needInit = true
+        sourceSizeOptimizer.resetSourceSize()
     }
 
     SourceSizeOptimizer {

--- a/src/qml/ImageDelegate/SourceSizeOptimizer.qml
+++ b/src/qml/ImageDelegate/SourceSizeOptimizer.qml
@@ -37,6 +37,13 @@ Item {
 
     property size optimizedSourceSize: zoomedWidth > 0 ? Qt.size(zoomedWidth, zoomedHeight) : Qt.size(delegateWidth, delegateHeight)
 
+    function resetSourceSize() {
+        sourceSizeUpdateTimer.stop()
+        zoomedWidth = 0
+        zoomedHeight = 0
+        immediateUpgradeFlag = false
+    }
+
     function requestUpdate() {
         if (!optimizer.targetImage || optimizer.targetImage.scale <= 1.0) {
             sourceSizeUpdateTimer.stop()


### PR DESCRIPTION
Gate source/sourceSize on imageInfoReady and scale by original dimensions to avoid stretching animated frames during decode.

等原图尺寸就绪后再设置 source/sourceSize，按原图比例缩放，
避免动图帧解码被拉伸，切换图片时重置状态。

Log: 修复动图帧解码被拉伸的问题
PMS: BUG-370383
Influence: 动图帧按原图比例解码，避免帧内容被拉伸，切换图片时正确重置 SourceSizeOptimizer 状态。