### PR TITLE
ci(cppcheck): update checkout action for pull request scans

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -14,10 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: export
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
       - uses: linuxdeepin/action-cppcheck@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use actions/checkout v7 and enable unsafe PR checkout support.

升级 actions/checkout 至 v7。

Log: 更新 cppcheck 工作流的检出配置
Influence: PR 的 cppcheck 检查将使用新版 checkout 操作执行。

## Summary by Sourcery

CI:
- Bump actions/checkout in the cppcheck workflow from v4 to v7 and enable unsafe PR checkout for head SHA scans.