### PR TITLE
fix(image): preserve aspect ratio when scaling requested images

### DIFF
--- a/src/src/imagedata/imageprovider.cpp
+++ b/src/src/imagedata/imageprovider.cpp
@@ -427,8 +427,8 @@ QImage ImageProvider::requestImage(const QString &id, QSize *size, const QSize &
 
     // 调整图像大小
     if (!image.isNull() && image.size() != requestedSize && requestedSize.isValid()) {
-        image = image.scaled(requestedSize);
-        qCDebug(logImageViewer) << "Scaled image to:" << requestedSize;
+        image = image.scaled(requestedSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+        qCDebug(logImageViewer) << "Scaled image to:" << image.size();
     }
 
     qCDebug(logImageViewer) << "ImageProvider::requestImage finished for id:" << id;


### PR DESCRIPTION
Keep requested image scaling proportional and apply smooth transformation.

按请求尺寸缩放图像时保持原始宽高比，并使用平滑变换。

Log: 修复请求图像缩放比例失真问题
Influence: 图像按请求尺寸缩放时不再拉伸，日志输出实际缩放后的图像尺寸。

## Summary by Sourcery

Preserve image aspect ratio and improve quality when scaling requested images.

Bug Fixes:
- Fix distorted aspect ratios when scaling images to requested sizes by keeping the original proportions.

Enhancements:
- Use smooth image transformation when scaling and log the actual resulting image size instead of the requested size.