### PR TITLE
test: add unit test framework with coverage report

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,4 +40,6 @@ add_subdirectory(src)
 add_subdirectory(qimage-plugins)
 
 # Unit Tests
-#add_subdirectory(tests)
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    add_subdirectory(tests)
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,2 +1,121 @@
-# gtest: 使用 DAppLoader 加载本项目生成的 LIB
-add_subdirectory(dapploader)
+# SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+cmake_minimum_required(VERSION 3.16)
+
+if (NOT DEFINED VERSION)
+    set(VERSION "1.0.0")
+endif ()
+
+# 开启 Qt MOC/UIC/RCC，与 src/CMakeLists.txt 保持一致
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+
+ADD_COMPILE_OPTIONS(-fno-access-control)
+
+set(CMAKE_SAFETYTEST "${CMAKE_SAFETYTEST_ARG}")
+
+if(CMAKE_SAFETYTEST STREQUAL "")
+    set(CMAKE_SAFETYTEST "CMAKE_SAFETYTEST_ARG_OFF")
+endif()
+
+# 安全编译参数（统一管理，去除冗余，修正 _FORTIFY_SOURCE 拼写）
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-all -D_FORTIFY_SOURCE=2 -fPIC")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fstack-protector-all -D_FORTIFY_SOURCE=2 -fPIC")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D${CMAKE_SAFETYTEST}")
+
+# 安全链接参数（链接器专属选项移至 CMAKE_EXE_LINKER_FLAGS）
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack -pie -Wl,-z,lazy")
+
+if(CMAKE_SAFETYTEST STREQUAL "CMAKE_SAFETYTEST_ARG_ON")
+  # 安全测试选项（ASAN 需配合 -O2 使 _FORTIFY_SOURCE 生效）
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -fsanitize=undefined,address -O2")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fsanitize=undefined,address -O2")
+endif()
+
+# 代码覆盖率编译参数
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fprofile-arcs -ftest-coverage")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -fprofile-arcs -ftest-coverage")
+
+# 本项目固定使用 Qt6 + DTK6
+message(STATUS "Testing with Qt6")
+find_package(Qt6 6.6 REQUIRED COMPONENTS Core Gui Widgets DBus Concurrent Svg PrintSupport Test Quick Qml)
+find_package(Dtk6 REQUIRED COMPONENTS Core Widget Gui Declarative)
+find_package(GTest REQUIRED)
+find_package(PkgConfig REQUIRED)
+
+# OCR 相关依赖
+pkg_search_module(OCR_PLUGIN REQUIRED deepin-ocr-plugin-manager)
+pkg_check_modules(InferenceEngine REQUIRED ncnn opencv_mobile)
+include_directories(${OCR_PLUGIN_INCLUDE_DIRS})
+
+include_directories(${GTEST_INCLUDE_DIRS})
+
+# 保证 src 目录及其子目录的头文件全局可见，与 src/CMakeLists.txt 保持一致
+include_directories(${CMAKE_SOURCE_DIR}/src)
+include_directories(${CMAKE_SOURCE_DIR}/src/src)
+include_directories(${CMAKE_SOURCE_DIR}/src/src/unionimage)
+include_directories(${CMAKE_SOURCE_DIR}/src/src/imagedata)
+include_directories(${CMAKE_SOURCE_DIR}/src/src/dbus)
+include_directories(${CMAKE_SOURCE_DIR}/src/src/declarative)
+include_directories(${CMAKE_SOURCE_DIR}/src/src/ocr)
+include_directories(${CMAKE_SOURCE_DIR}/src/src/printdialog)
+include_directories(${CMAKE_SOURCE_DIR}/src/src/utils)
+include_directories(${CMAKE_SOURCE_DIR}/src/src/misc)
+include_directories(src)
+
+set(PROJECT_NAME_TEST
+    ${PROJECT_NAME}-test)
+
+# 收集源码文件，仅扫描 src/src/ 子目录（程序入口 src/main.cpp 不在其中）
+file(GLOB_RECURSE IMAGEVIEWER_SRC_TEST ${CMAKE_SOURCE_DIR}/src/src/*.cpp)
+# 防御性排除 main.cpp，避免 glob 规则变更后产生 main 函数重定义冲突
+list(REMOVE_ITEM IMAGEVIEWER_SRC_TEST
+    "${CMAKE_SOURCE_DIR}/src/main.cpp"
+    "${CMAKE_SOURCE_DIR}/src/src/main.cpp"
+)
+
+# 收集测试源文件
+file(GLOB_RECURSE IMAGEVIEWER_UT_SRC ${CMAKE_CURRENT_LIST_DIR}/src/*.cpp)
+
+# 生成测试可执行程序
+add_executable(${PROJECT_NAME_TEST}
+    ${IMAGEVIEWER_SRC_TEST}
+    ${IMAGEVIEWER_UT_SRC}
+    )
+
+# 生成测试可执行程序的依赖库
+target_link_libraries(${PROJECT_NAME_TEST} gtest gtest_main -pthread)
+
+target_link_libraries(${PROJECT_NAME_TEST}
+    Dtk6::Core
+    Dtk6::Gui
+    Dtk6::Widget
+    Dtk6::Declarative
+    Qt6::Core
+    Qt6::Gui
+    Qt6::Widgets
+    Qt6::DBus
+    Qt6::Concurrent
+    Qt6::Svg
+    Qt6::PrintSupport
+    Qt6::Test
+    Qt6::Quick
+    Qt6::Qml
+    ${InferenceEngine_LIBRARIES}
+    ${OCR_PLUGIN_LIBRARIES}
+    GL
+    pthread
+)
+
+##------------------------------ 创建'make test'指令---------------------------------------
+add_custom_target(test
+    COMMAND echo " =================== TEST BEGIN ==================== "
+    COMMAND ${CMAKE_BINARY_DIR}/tests/${PROJECT_NAME_TEST}
+    COMMAND echo " =================== TEST END ==================== "
+)
+
+##'make test'命令依赖与我们的测试程序
+add_dependencies(test ${PROJECT_NAME_TEST})

--- a/tests/cmake-lcov-test.sh
+++ b/tests/cmake-lcov-test.sh
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -e
+
+utdir=build-ut
+rm -rf $utdir
+rm -rf ../$utdir
+mkdir ../$utdir
+cd ../$utdir
+
+cmake -DCMAKE_BUILD_TYPE=Debug ..
+make -j16
+
+workdir=$(cd ../$(dirname $0)/$utdir; pwd)
+
+mkdir -p report
+
+./tests/deepin-image-viewer-test --gtest_output=xml:./report/report.xml || exit 1
+
+lcov -d $workdir -c -o ./report/coverage.info
+
+lcov --extract ./report/coverage.info '*/src/*' -o ./report/coverage.info
+
+lcov --remove ./report/coverage.info '*/tests/*' -o ./report/coverage.info
+
+genhtml -o ./report ./report/coverage.info
+
+exit 0

--- a/tests/src/addr_pri.h
+++ b/tests/src/addr_pri.h
@@ -1,0 +1,181 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef __ADDR_PRI_H__
+#define __ADDR_PRI_H__
+
+
+#include <utility>
+#include <type_traits>
+
+
+
+//base on C++11
+
+/**********************************************************
+             access private function
+**********************************************************/
+
+
+namespace std {
+  template <bool B, class T = void>
+  using enable_if_t = typename enable_if<B, T>::type;
+  template <class T>
+  using remove_reference_t = typename remove_reference<T>::type;
+} // std
+
+// Unnamed namespace is used to avoid duplicate symbols if the macros are used
+namespace {
+  namespace private_access_detail {
+
+    // @tparam TagType, used to declare different "get" funciton overloads for
+    // different members/statics
+    template <typename PtrType, PtrType PtrValue, typename TagType>
+    struct private_access {
+      // Normal lookup cannot find in-class defined (inline) friend functions.
+      friend PtrType get(TagType) { return PtrValue; }
+    };
+
+  } // namespace private_access_detail
+} // namespace
+
+// Used macro naming conventions:
+// The "namespace" of this macro library is PRIVATE_ACCESS, i.e. all
+// macro here has this prefix.
+// All implementation macro, which are not meant to be used directly have the
+// PRIVATE_ACCESS_DETAIL prefix.
+// Some macros have the ABCD_IMPL form, which means they contain the
+// implementation details for the specific ABCD macro.
+
+#define PRIVATE_ACCESS_DETAIL_CONCATENATE_IMPL(x, y) x##y
+#define PRIVATE_ACCESS_DETAIL_CONCATENATE(x, y)                                \
+  PRIVATE_ACCESS_DETAIL_CONCATENATE_IMPL(x, y)
+
+// @param PtrTypeKind E.g if we have "class A", then it can be "A::*" in case of
+// members, or it can be "*" in case of statics.
+#define PRIVATE_ACCESS_DETAIL_ACCESS_PRIVATE(Tag, Class, Type, Name,           \
+                                             PtrTypeKind)                      \
+  namespace {                                                                  \
+    namespace private_access_detail {                                          \
+      /* Tag type, used to declare different get funcitons for different       \
+       * members                                                               \
+       */                                                                      \
+      struct Tag {};                                                           \
+      /* Explicit instantiation */                                             \
+      template struct private_access<decltype(&Class::Name), &Class::Name,     \
+                                     Tag>;                                     \
+      /* We can build the PtrType only with two aliases */                     \
+      /* E.g. using PtrType = int(int) *; would be illformed */                \
+      using PRIVATE_ACCESS_DETAIL_CONCATENATE(Alias_, Tag) = Type;             \
+      using PRIVATE_ACCESS_DETAIL_CONCATENATE(PtrType_, Tag) =                 \
+          PRIVATE_ACCESS_DETAIL_CONCATENATE(Alias_, Tag) PtrTypeKind;          \
+      /* Declare the friend function, now it is visible in namespace scope.    \
+       * Note,                                                                 \
+       * we could declare it inside the Tag type too, in that case ADL would   \
+       * find                                                                  \
+       * the declaration. By choosing to declare it here, the Tag type remains \
+       * a                                                                     \
+       * simple tag type, it has no other responsibilities. */                 \
+      PRIVATE_ACCESS_DETAIL_CONCATENATE(PtrType_, Tag) get(Tag);               \
+    }                                                                          \
+  }
+
+#define PRIVATE_ACCESS_DETAIL_ACCESS_PRIVATE_FIELD(Tag, Class, Type, Name)     \
+  PRIVATE_ACCESS_DETAIL_ACCESS_PRIVATE(Tag, Class, Type, Name, Class::*)       \
+  namespace {                                                                  \
+    namespace access_private_field {                                                  \
+      Type &Class##Name(Class &&t) { return t.*get(private_access_detail::Tag{}); }   \
+      Type &Class##Name(Class &t) { return t.*get(private_access_detail::Tag{}); }    \
+      /* The following usings are here to avoid duplicate const qualifier      \
+       * warnings                                                              \
+       */                                                                      \
+      using PRIVATE_ACCESS_DETAIL_CONCATENATE(X, Tag) = Type;                  \
+      using PRIVATE_ACCESS_DETAIL_CONCATENATE(Y, Tag) =                        \
+          const PRIVATE_ACCESS_DETAIL_CONCATENATE(X, Tag);                     \
+      PRIVATE_ACCESS_DETAIL_CONCATENATE(Y, Tag) & Class##Name(const Class &t) {\
+        return t.*get(private_access_detail::Tag{});                           \
+      }                                                                        \
+    }                                                                          \
+  }
+
+#define PRIVATE_ACCESS_DETAIL_ACCESS_PRIVATE_FUN(Tag, Class, Type, Name)       \
+  PRIVATE_ACCESS_DETAIL_ACCESS_PRIVATE(Tag, Class, Type, Name, Class::*)       \
+  namespace {                                                                  \
+    namespace call_private_fun {                                               \
+      /* We do perfect forwarding, but we want to restrict the overload set    \
+       * only for objects which have the type Class. */                        \
+      template <typename Obj,                                                  \
+                std::enable_if_t<std::is_same<std::remove_reference_t<Obj>,    \
+                                              Class>::value> * = nullptr,      \
+                typename... Args>                                              \
+      auto Class##Name(Obj &&o, Args &&... args) -> decltype(                  \
+          (std::forward<Obj>(o).*                                              \
+           get(private_access_detail::Tag{}))(std::forward<Args>(args)...)) {  \
+        return (std::forward<Obj>(o).*get(private_access_detail::Tag{}))(      \
+            std::forward<Args>(args)...);                                      \
+      }                                                                        \
+    }                                                                          \
+    namespace get_private_fun {                                                \
+      auto Class##Name()  -> decltype(                                         \
+          get(private_access_detail::Tag{})) {                                 \
+        return (get(private_access_detail::Tag{}));                            \
+      }                                                                        \
+    }                                                                          \
+  }
+
+#define PRIVATE_ACCESS_DETAIL_ACCESS_PRIVATE_STATIC_FIELD(Tag, Class, Type,    \
+                                                          Name)                \
+  PRIVATE_ACCESS_DETAIL_ACCESS_PRIVATE(Tag, Class, Type, Name, *)              \
+  namespace {                                                                  \
+    namespace access_private_static_field {                                    \
+      namespace Class {                                                        \
+        Type &Class##Name() { return *get(private_access_detail::Tag{}); }     \
+      }                                                                        \
+    }                                                                          \
+  }
+
+#define PRIVATE_ACCESS_DETAIL_ACCESS_PRIVATE_STATIC_FUN(Tag, Class, Type,      \
+                                                        Name)                  \
+  PRIVATE_ACCESS_DETAIL_ACCESS_PRIVATE(Tag, Class, Type, Name, *)              \
+  namespace {                                                                  \
+    namespace call_private_static_fun {                                        \
+      namespace Class {                                                        \
+        template <typename... Args>                                            \
+        auto Class##Name(Args &&... args) -> decltype(                         \
+            get(private_access_detail::Tag{})(std::forward<Args>(args)...)) {  \
+          return get(private_access_detail::Tag{})(                            \
+              std::forward<Args>(args)...);                                    \
+        }                                                                      \
+      }                                                                        \
+    }                                                                          \
+    namespace get_private_static_fun {                                         \
+      namespace Class {                                                        \
+        auto Class##Name() -> decltype(get(private_access_detail::Tag{})) {    \
+          return get(private_access_detail::Tag{});                            \
+        }                                                                      \
+      }                                                                        \
+    }                                                                          \
+  }
+
+#define PRIVATE_ACCESS_DETAIL_UNIQUE_TAG                                       \
+  PRIVATE_ACCESS_DETAIL_CONCATENATE(PrivateAccessTag, __COUNTER__)
+
+#define ACCESS_PRIVATE_FIELD(Class, Type, Name)                                \
+  PRIVATE_ACCESS_DETAIL_ACCESS_PRIVATE_FIELD(PRIVATE_ACCESS_DETAIL_UNIQUE_TAG, \
+                                             Class, Type, Name)
+
+#define ACCESS_PRIVATE_FUN(Class, Type, Name)                                  \
+  PRIVATE_ACCESS_DETAIL_ACCESS_PRIVATE_FUN(PRIVATE_ACCESS_DETAIL_UNIQUE_TAG,   \
+                                           Class, Type, Name)
+
+#define ACCESS_PRIVATE_STATIC_FIELD(Class, Type, Name)                         \
+    Type Class::Name;                                                          \
+  PRIVATE_ACCESS_DETAIL_ACCESS_PRIVATE_STATIC_FIELD(                           \
+      PRIVATE_ACCESS_DETAIL_UNIQUE_TAG, Class, Type, Name)
+
+#define ACCESS_PRIVATE_STATIC_FUN(Class, Type, Name)                           \
+  PRIVATE_ACCESS_DETAIL_ACCESS_PRIVATE_STATIC_FUN(                             \
+      PRIVATE_ACCESS_DETAIL_UNIQUE_TAG, Class, Type, Name)
+
+#endif

--- a/tests/src/stub.h
+++ b/tests/src/stub.h
@@ -1,0 +1,365 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef __STUB_H__
+#define __STUB_H__
+
+#ifdef _WIN32
+//windows
+#include <windows.h>
+#include <processthreadsapi.h>
+#else
+//linux
+#include <unistd.h>
+#include <bits/stdint-uintn.h>
+#include <sys/mman.h>
+#endif
+//c
+#include <cstddef>
+#include <cstring>
+#include <stdexcept>
+//c++
+#include <map>
+
+
+#define ADDR(CLASS_NAME,MEMBER_NAME) (&CLASS_NAME::MEMBER_NAME)
+
+/**********************************************************
+                  replace function
+**********************************************************/
+#ifdef _WIN32
+#define CACHEFLUSH(addr, size) FlushInstructionCache(GetCurrentProcess(), addr, size)
+#else
+#define CACHEFLUSH(addr, size) __builtin___clear_cache(addr, addr + size)
+#endif
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+    #define CODESIZE 16U
+    #define CODESIZE_MIN 16U
+    #define CODESIZE_MAX CODESIZE
+    // ldr x9, +8
+    // br x9
+    // addr
+    #define REPLACE_FAR(t, fn, fn_stub)\
+        ((uint32_t*)fn)[0] = 0x58000040 | 9;\
+        ((uint32_t*)fn)[1] = 0xd61f0120 | (9 << 5);\
+        *(long long *)(fn + 8) = (long long )fn_stub;\
+        CACHEFLUSH((char *)fn, CODESIZE);
+    #define REPLACE_NEAR(t, fn, fn_stub) REPLACE_FAR(t, fn, fn_stub)
+#elif defined(__arm__) || defined(_M_ARM)
+    #define CODESIZE 8U
+    #define CODESIZE_MIN 8U
+    #define CODESIZE_MAX CODESIZE
+    // ldr pc, [pc, #-4]
+    #define REPLACE_FAR(t, fn, fn_stub)\
+        ((uint32_t*)fn)[0] = 0xe51ff004;\
+        ((uint32_t*)fn)[1] = (uint32_t)fn_stub;\
+        CACHEFLUSH((char *)fn, CODESIZE);
+    #define REPLACE_NEAR(t, fn, fn_stub) REPLACE_FAR(t, fn, fn_stub)
+#elif defined(__mips64)
+    #define CACHEFLUSH(addr, size) __builtin___clear_cache(addr, addr + size)
+    #define CODESIZE 80U
+    #define CODESIZE_MIN 80U
+    #define CODESIZE_MAX CODESIZE
+    //mips没有PC指针，所以需要手动入栈出栈
+    //120000ce0:  67bdffe0    daddiu  sp, sp, -32  //入栈
+    //120000ce4:  ffbf0018    sd  ra, 24(sp)
+    //120000ce8:  ffbe0010    sd  s8, 16(sp)
+    //120000cec:  ffbc0008    sd  gp, 8(sp)
+    //120000cf0:  03a0f025    move    s8, sp
+
+    //120000d2c:  03c0e825    move    sp, s8  //出栈
+    //120000d30:  dfbf0018    ld  ra, 24(sp)
+    //120000d34:  dfbe0010    ld  s8, 16(sp)
+    //120000d38:  dfbc0008    ld  gp, 8(sp)
+    //120000d3c:  67bd0020    daddiu  sp, sp, 32
+    //120000d40:  03e00008    jr  ra
+
+    #define REPLACE_FAR(t, fn, fn_stub)\
+        ((uint32_t *)fn)[0] = 0x67bdffe0;\
+        ((uint32_t *)fn)[1] = 0xffbf0018;\
+        ((uint32_t *)fn)[2] = 0xffbe0010;\
+        ((uint32_t *)fn)[3] = 0xffbc0008;\
+        ((uint32_t *)fn)[4] = 0x03a0f025;\
+        *(uint16_t *)(fn + 20) = (long long)fn_stub >> 32;\
+        *(fn + 22) = 0x19;\
+        *(fn + 23) = 0x24;\
+        ((uint32_t *)fn)[6] = 0x0019cc38;\
+        *(uint16_t *)(fn + 28) = (long long)fn_stub >> 16;\
+        *(fn + 30) = 0x39;\
+        *(fn + 31) = 0x37;\
+        ((uint32_t *)fn)[8] = 0x0019cc38;\
+        *(uint16_t *)(fn + 36) = (long long)fn_stub;\
+        *(fn + 38) = 0x39;\
+        *(fn + 39) = 0x37;\
+        ((uint32_t *)fn)[10] = 0x0320f809;\
+        ((uint32_t *)fn)[11] = 0x00000000;\
+        ((uint32_t *)fn)[12] = 0x00000000;\
+        ((uint32_t *)fn)[13] = 0x03c0e825;\
+        ((uint32_t *)fn)[14] = 0xdfbf0018;\
+        ((uint32_t *)fn)[15] = 0xdfbe0010;\
+        ((uint32_t *)fn)[16] = 0xdfbc0008;\
+        ((uint32_t *)fn)[17] = 0x67bd0020;\
+        ((uint32_t *)fn)[18] = 0x03e00008;\
+        ((uint32_t *)fn)[19] = 0x00000000;\
+        CACHEFLUSH((char *)fn, CODESIZE);
+    #define REPLACE_NEAR(t, fn, fn_stub) REPLACE_FAR(t, fn, fn_stub)
+#elif defined(__thumb__) || defined(_M_THUMB)
+    #error "Thumb is not supported"
+#else //__i386__ _x86_64__
+    #define CODESIZE 13U
+    #define CODESIZE_MIN 5U
+    #define CODESIZE_MAX CODESIZE
+    //13 byte(jmp m16:64)
+    //movabs $0x102030405060708,%r11
+    //jmpq   *%r11
+    static void REPLACE_FAR(void *t, char *fn, char *fn_stub)
+    {
+        *fn = 0x49;
+        *(fn + 1) = 0xbb;
+        *(long long *)(fn + 2) = (long long)fn_stub;
+        *(fn + 10) = 0x41;
+        *(fn + 11) = 0xff;
+        *(fn + 12) = 0xe3;
+        CACHEFLUSH((char *)fn, CODESIZE);
+    }
+    //5 byte(jmp rel32)
+    #define REPLACE_NEAR(t, fn, fn_stub)\
+        *fn = 0xE9;\
+        *(int *)(fn + 1) = (int)(fn_stub - fn - CODESIZE_MIN);\
+        CACHEFLUSH((char *)fn, CODESIZE);
+#endif
+
+struct func_stub
+{
+    char *fn;
+    unsigned char code_buf[CODESIZE];
+    bool far_jmp;
+};
+
+class Stub
+{
+public:
+    Stub()
+    {
+#ifdef _WIN32
+        SYSTEM_INFO sys_info;
+        GetSystemInfo(&sys_info);
+        m_pagesize = sys_info.dwPageSize;
+#else
+        m_pagesize = sysconf(_SC_PAGE_SIZE);
+#endif
+
+        if (m_pagesize < 0)
+        {
+            m_pagesize = 4096;
+        }
+    }
+    ~Stub()
+    {
+        clear();
+    }
+
+    virtual void clear()
+    {
+        std::map<char*,func_stub*>::iterator iter;
+        struct func_stub *pstub;
+        for(iter=m_result.begin(); iter != m_result.end(); iter++)
+        {
+            pstub = iter->second;
+#ifdef _WIN32
+            DWORD lpflOldProtect;
+            if(0 != VirtualProtect(pageof(pstub->fn), m_pagesize * 2, PAGE_EXECUTE_READWRITE, &lpflOldProtect))
+#else
+            if (0 == mprotect(pageof(pstub->fn), m_pagesize * 2, PROT_READ | PROT_WRITE | PROT_EXEC))
+#endif
+            {
+
+                if(pstub->far_jmp)
+                {
+                    std::memcpy(pstub->fn, pstub->code_buf, CODESIZE_MAX);
+                }
+                else
+                {
+                    std::memcpy(pstub->fn, pstub->code_buf, CODESIZE_MIN);
+                }
+
+#ifdef _WIN32
+                VirtualProtect(pageof(pstub->fn), m_pagesize * 2, PAGE_EXECUTE_READ, &lpflOldProtect);
+#else
+                CACHEFLUSH(pstub->fn,CODESIZE);
+                mprotect(pageof(pstub->fn), m_pagesize * 2, PROT_READ | PROT_EXEC);
+#endif
+            }
+
+            iter->second  = NULL;
+            delete pstub;
+        }
+
+        m_result.clear();
+        return;
+    }
+    template<typename T,typename S>
+    bool set(T addr, S addr_stub)
+    {
+        char * fn;
+        char * fn_stub;
+        fn = addrof(addr);
+        fn_stub = addrof(addr_stub);
+        struct func_stub *pstub;
+        std::map<char*,func_stub*>::iterator iter = m_result.find(fn);
+
+        if (iter == m_result.end())
+        {
+            pstub = new func_stub;
+            //start
+            pstub->fn = fn;
+
+            if(distanceof(fn, fn_stub))
+            {
+                pstub->far_jmp = true;
+                std::memcpy(pstub->code_buf, fn, CODESIZE_MAX);
+            }
+            else
+            {
+                pstub->far_jmp = false;
+                std::memcpy(pstub->code_buf, fn, CODESIZE_MIN);
+            }
+        }
+        else {
+            pstub = iter->second;
+            pstub->far_jmp = distanceof(fn, fn_stub);
+        }
+
+
+
+#ifdef _WIN32
+        DWORD lpflOldProtect;
+        if(0 == VirtualProtect(pageof(pstub->fn), m_pagesize * 2, PAGE_EXECUTE_READWRITE, &lpflOldProtect))
+#else
+        if (-1 == mprotect(pageof(pstub->fn), static_cast<size_t>(m_pagesize * 2), PROT_READ | PROT_WRITE | PROT_EXEC))
+#endif
+        {
+            throw std::runtime_error("stub set memory protect to w+r+x faild");
+            return  false;
+        }
+
+        if(pstub->far_jmp)
+        {
+            REPLACE_FAR(this, fn, fn_stub);
+        }
+        else
+        {
+            REPLACE_NEAR(this, fn, fn_stub);
+        }
+
+
+#ifdef _WIN32
+        if(0 == VirtualProtect(pageof(pstub->fn), m_pagesize * 2, PAGE_EXECUTE_READ, &lpflOldProtect))
+#else
+        if (-1 == mprotect(pageof(pstub->fn), m_pagesize * 2, PROT_READ | PROT_EXEC))
+#endif
+        {
+            throw std::runtime_error("stub set memory protect to r+x failed");
+            return false;
+        }
+        m_result.insert(std::pair<char*,func_stub*>(fn,pstub));
+        return true;
+    }
+
+    template<typename T>
+    bool reset(T addr)
+    {
+        char * fn;
+        fn = addrof(addr);
+
+        std::map<char*,func_stub*>::iterator iter = m_result.find(fn);
+
+        if (iter == m_result.end())
+        {
+            return true;
+        }
+        struct func_stub *pstub;
+        pstub = iter->second;
+
+#ifdef _WIN32
+        DWORD lpflOldProtect;
+        if(0 == VirtualProtect(pageof(pstub->fn), m_pagesize * 2, PAGE_EXECUTE_READWRITE, &lpflOldProtect))
+#else
+        if (-1 == mprotect(pageof(pstub->fn), m_pagesize * 2, PROT_READ | PROT_WRITE | PROT_EXEC))
+#endif
+        {
+            throw std::runtime_error("stub reset memory protect to w+r+x faild");
+            return false;
+        }
+
+        if(pstub->far_jmp)
+        {
+            std::memcpy(pstub->fn, pstub->code_buf, CODESIZE_MAX);
+        }
+        else
+        {
+            std::memcpy(pstub->fn, pstub->code_buf, CODESIZE_MIN);
+        }
+
+#ifdef _WIN32
+        if(0 == VirtualProtect(pageof(pstub->fn), m_pagesize * 2, PAGE_EXECUTE_READ, &lpflOldProtect))
+#else
+        CACHEFLUSH(pstub->fn,CODESIZE);
+        if (-1 == mprotect(pageof(pstub->fn), m_pagesize * 2, PROT_READ | PROT_EXEC))
+#endif
+        {
+            throw std::runtime_error("stub reset memory protect to r+x failed");
+            return false;
+        }
+
+        m_result.erase(iter);
+        delete pstub;
+
+        return true;
+    }
+protected:
+    char *pageof(char* addr)
+    {
+#ifdef _WIN32
+        return (char *)((unsigned long long)addr & ~(m_pagesize - 1));
+#else
+        return (char *)((unsigned long)addr & ~(m_pagesize - 1));
+#endif
+    }
+
+    template<typename T>
+    char* addrof(T addr)
+    {
+        union
+        {
+          T _s;
+          char* _d;
+        }ut;
+        ut._s = addr;
+        return ut._d;
+    }
+
+    bool distanceof(char* addr, char* addr_stub)
+    {
+        std::ptrdiff_t diff = addr_stub >= addr ? addr_stub - addr : addr - addr_stub;
+        if((sizeof(addr) > 4) && (((diff >> 31) - 1) > 0))
+        {
+            return true;
+        }
+        return false;
+    }
+
+protected:
+#ifdef _WIN32
+    //LLP64
+    long long m_pagesize;
+#else
+    //LP64
+    long m_pagesize;
+#endif
+    std::map<char*, func_stub*> m_result;
+};
+
+#endif

--- a/tests/src/ut_commandparser.cpp
+++ b/tests/src/ut_commandparser.cpp
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "ut_commandparser.h"
+#include "commandparser.h"
+
+#include <QCoreApplication>
+#include <QStringList>
+
+void ut_commandparser::SetUp()
+{
+}
+
+void ut_commandparser::TearDown()
+{
+}
+
+// 测试单例实例获取
+TEST_F(ut_commandparser, Instance)
+{
+    CommandParser *instance = CommandParser::instance();
+    ASSERT_TRUE(instance != nullptr);
+
+    // 再次获取应返回同一实例
+    CommandParser *instance2 = CommandParser::instance();
+    EXPECT_EQ(instance, instance2);
+}
+
+// 测试 process 方法解析参数
+TEST_F(ut_commandparser, ProcessArguments)
+{
+    CommandParser *parser = CommandParser::instance();
+
+    QStringList args;
+    args << QCoreApplication::applicationFilePath() << "test_image.jpg";
+
+    parser->process(args);
+
+    // positionalArguments 应包含非选项参数
+    QStringList positional = parser->positionalArguments();
+    EXPECT_FALSE(positional.isEmpty());
+}
+
+// 测试 isSet 方法对未设置选项的返回值
+TEST_F(ut_commandparser, IsSetOptionNotSet)
+{
+    CommandParser *parser = CommandParser::instance();
+
+    // 未设置的选项应返回 false
+    EXPECT_FALSE(parser->isSet("nonexistent_option"));
+}
+
+// 测试 value 方法获取选项值
+TEST_F(ut_commandparser, ValueOfOption)
+{
+    CommandParser *parser = CommandParser::instance();
+
+    // 不存在的选项值应为空
+    QString val = parser->value("nonexistent_option");
+    EXPECT_TRUE(val.isEmpty());
+}

--- a/tests/src/ut_commandparser.h
+++ b/tests/src/ut_commandparser.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef UT_COMMANDPARSER_H
+#define UT_COMMANDPARSER_H
+
+#include <gtest/gtest.h>
+
+class CommandParser;
+
+class ut_commandparser : public testing::Test
+{
+protected:
+    virtual void SetUp() override;
+    virtual void TearDown() override;
+};
+
+#endif  // UT_COMMANDPARSER_H

--- a/tests/src/ut_configsetter.cpp
+++ b/tests/src/ut_configsetter.cpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "ut_configsetter.h"
+#include "configsetter.h"
+
+#include <QVariant>
+#include <QSignalSpy>
+#include <QTemporaryDir>
+
+void ut_configsetter::SetUp()
+{
+}
+
+void ut_configsetter::TearDown()
+{
+}
+
+// 测试单例实例获取
+TEST_F(ut_configsetter, Instance)
+{
+    LibConfigSetter *instance = LibConfigSetter::instance();
+    ASSERT_TRUE(instance != nullptr);
+
+    LibConfigSetter *instance2 = LibConfigSetter::instance();
+    EXPECT_EQ(instance, instance2);
+}
+
+// 测试设置和读取配置值
+TEST_F(ut_configsetter, SetValueAndGetValue)
+{
+    LibConfigSetter *setter = LibConfigSetter::instance();
+
+    QString group = "test_group";
+    QString key = "test_key";
+    QVariant value = QString("test_value");
+
+    setter->setValue(group, key, value);
+
+    QVariant readValue = setter->value(group, key);
+    EXPECT_EQ(readValue.toString(), value.toString());
+}
+
+// 测试读取不存在的键返回默认值
+TEST_F(ut_configsetter, GetValueWithDefault)
+{
+    LibConfigSetter *setter = LibConfigSetter::instance();
+
+    QVariant defaultValue = QString("default");
+    QVariant readValue = setter->value("nonexistent_group", "nonexistent_key", defaultValue);
+    EXPECT_EQ(readValue.toString(), defaultValue.toString());
+}
+
+// 测试 valueChanged 信号
+TEST_F(ut_configsetter, ValueChangedSignal)
+{
+    LibConfigSetter *setter = LibConfigSetter::instance();
+
+    QSignalSpy spy(setter, &LibConfigSetter::valueChanged);
+    setter->setValue("signal_group", "signal_key", QString("signal_value"));
+    EXPECT_EQ(spy.count(), 1);
+}

--- a/tests/src/ut_configsetter.h
+++ b/tests/src/ut_configsetter.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef UT_CONFIGSETTER_H
+#define UT_CONFIGSETTER_H
+
+#include <gtest/gtest.h>
+
+class LibConfigSetter;
+
+class ut_configsetter : public testing::Test
+{
+protected:
+    virtual void SetUp() override;
+    virtual void TearDown() override;
+};
+
+#endif  // UT_CONFIGSETTER_H

--- a/tests/src/ut_cursortool.cpp
+++ b/tests/src/ut_cursortool.cpp
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "ut_cursortool.h"
+#include "cursortool.h"
+
+#include <QCursor>
+#include <QPoint>
+#include <QSignalSpy>
+
+void ut_cursortool::SetUp()
+{
+}
+
+void ut_cursortool::TearDown()
+{
+}
+
+// 测试构造与析构
+TEST_F(ut_cursortool, Construct)
+{
+    CursorTool *tool = new CursorTool();
+    ASSERT_TRUE(tool != nullptr);
+    delete tool;
+}
+
+// 测试 currentCursorPos 返回当前光标位置
+TEST_F(ut_cursortool, CurrentCursorPos)
+{
+    CursorTool tool;
+    QPoint pos = tool.currentCursorPos();
+    // 应与 QCursor::pos() 返回一致
+    EXPECT_EQ(pos, QCursor::pos());
+}
+
+// 测试 setCaptureCursor 启动/停止采样
+TEST_F(ut_cursortool, SetCaptureCursor)
+{
+    CursorTool tool;
+    // 启动采样不应崩溃
+    tool.setCaptureCursor(true);
+    tool.setCaptureCursor(false);
+}
+
+// 测试 activeColor 返回有效颜色
+TEST_F(ut_cursortool, ActiveColor)
+{
+    CursorTool tool;
+    QColor color = tool.activeColor();
+    EXPECT_TRUE(color.isValid());
+}

--- a/tests/src/ut_cursortool.h
+++ b/tests/src/ut_cursortool.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef UT_CURSORTOOL_H
+#define UT_CURSORTOOL_H
+
+#include <gtest/gtest.h>
+
+class CursorTool;
+
+class ut_cursortool : public testing::Test
+{
+protected:
+    virtual void SetUp() override;
+    virtual void TearDown() override;
+};
+
+#endif  // UT_CURSORTOOL_H

--- a/tests/src/ut_filecontrol.cpp
+++ b/tests/src/ut_filecontrol.cpp
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "ut_filecontrol.h"
+#include "filecontrol.h"
+
+#include <QUrl>
+#include <QTemporaryFile>
+#include <QImage>
+#include <QStandardPaths>
+
+void ut_filecontrol::SetUp()
+{
+}
+
+void ut_filecontrol::TearDown()
+{
+}
+
+// 测试构造与析构
+TEST_F(ut_filecontrol, Construct)
+{
+    FileControl *control = new FileControl();
+    ASSERT_TRUE(control != nullptr);
+    delete control;
+}
+
+// 测试获取标准图片路径
+TEST_F(ut_filecontrol, StandardPicturesPath)
+{
+    FileControl control;
+    QString path = control.standardPicturesPath();
+    EXPECT_FALSE(path.isEmpty());
+}
+
+// 测试获取文件名（不要求文件存在）
+TEST_F(ut_filecontrol, SlotGetFileName)
+{
+    FileControl control;
+    QString name = control.slotGetFileName("/tmp/test/image.png");
+    EXPECT_FALSE(name.isEmpty());
+}
+
+// 测试获取文件后缀（需要文件存在，slotFileSuffix 内部使用 QUrl::toLocalFile）
+TEST_F(ut_filecontrol, SlotFileSuffix)
+{
+    FileControl control;
+
+    // 创建临时文件以测试后缀获取
+    QTemporaryFile tmpFile("ut_test_suffix_XXXXXX.png");
+    tmpFile.setAutoRemove(true);
+    ASSERT_TRUE(tmpFile.open());
+
+    QImage img(2, 2, QImage::Format_ARGB32);
+    img.save(&tmpFile, "PNG");
+    tmpFile.close();
+
+    // slotFileSuffix 内部使用 QUrl(path).toLocalFile()，需传入 file:// URL
+    QString fileUrl = QUrl::fromLocalFile(tmpFile.fileName()).toString();
+    QString suffix = control.slotFileSuffix(fileUrl);
+    EXPECT_FALSE(suffix.isEmpty());
+}
+
+// 测试判断是否为图片
+TEST_F(ut_filecontrol, IsImage)
+{
+    FileControl control;
+    EXPECT_TRUE(control.isImage("/tmp/test/image.jpg"));
+    EXPECT_TRUE(control.isImage("/tmp/test/image.png"));
+    EXPECT_FALSE(control.isImage("/tmp/test/document.txt"));
+}
+
+// 测试配置读写
+TEST_F(ut_filecontrol, ConfigValue)
+{
+    FileControl control;
+    control.setConfigValue("ut_group", "ut_key", QString("ut_value"));
+    QVariant val = control.getConfigValue("ut_group", "ut_key");
+    EXPECT_EQ(val.toString(), QString("ut_value"));
+}

--- a/tests/src/ut_filecontrol.h
+++ b/tests/src/ut_filecontrol.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef UT_FILECONTROL_H
+#define UT_FILECONTROL_H
+
+#include <gtest/gtest.h>
+
+class FileControl;
+
+class ut_filecontrol : public testing::Test
+{
+protected:
+    virtual void SetUp() override;
+    virtual void TearDown() override;
+};
+
+#endif  // UT_FILECONTROL_H

--- a/tests/src/ut_globalcontrol.cpp
+++ b/tests/src/ut_globalcontrol.cpp
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "ut_globalcontrol.h"
+#include "globalcontrol.h"
+
+#include <QSignalSpy>
+#include <QTemporaryDir>
+#include <QImage>
+#include <QFile>
+#include <QStandardPaths>
+
+void ut_globalcontrol::SetUp()
+{
+}
+
+void ut_globalcontrol::TearDown()
+{
+}
+
+// 测试构造与析构
+TEST_F(ut_globalcontrol, Construct)
+{
+    GlobalControl *control = new GlobalControl();
+    ASSERT_TRUE(control != nullptr);
+    delete control;
+}
+
+// 测试默认索引值
+TEST_F(ut_globalcontrol, DefaultIndex)
+{
+    GlobalControl control;
+    EXPECT_EQ(control.currentIndex(), 0);
+    EXPECT_EQ(control.currentFrameIndex(), 0);
+    EXPECT_EQ(control.imageCount(), 0);
+}
+
+// 在临时目录中创建指定数量的测试图片文件，由 QTemporaryDir 自动清理
+static QStringList createTestImageFiles(const QTemporaryDir &dir, int count)
+{
+    QStringList files;
+    for (int i = 0; i < count; ++i) {
+        QString path = dir.filePath(QString("ut_test_img_%1.png").arg(i));
+        QImage img(10, 10, QImage::Format_ARGB32);
+        img.fill(Qt::red);
+        if (img.save(path, "PNG")) {
+            files << path;
+        }
+    }
+    return files;
+}
+
+// 测试设置图片文件列表
+TEST_F(ut_globalcontrol, SetImageFiles)
+{
+    QTemporaryDir tmpDir;
+    ASSERT_TRUE(tmpDir.isValid());
+
+    GlobalControl control;
+    QStringList files = createTestImageFiles(tmpDir, 3);
+    ASSERT_EQ(files.size(), 3);
+
+    control.setImageFiles(files, files.value(1));
+    EXPECT_EQ(control.imageCount(), 3);
+}
+
+// 测试设置当前索引
+TEST_F(ut_globalcontrol, CurrentIndex)
+{
+    QTemporaryDir tmpDir;
+    ASSERT_TRUE(tmpDir.isValid());
+
+    GlobalControl control;
+    QStringList files = createTestImageFiles(tmpDir, 3);
+    ASSERT_EQ(files.size(), 3);
+
+    control.setImageFiles(files, files.value(0));
+    EXPECT_EQ(control.imageCount(), 3);
+
+    QSignalSpy spy(&control, &GlobalControl::currentIndexChanged);
+    control.setCurrentIndex(2);
+    EXPECT_EQ(control.currentIndex(), 2);
+    EXPECT_EQ(spy.count(), 1);
+}
+
+// 测试旋转角度设置
+TEST_F(ut_globalcontrol, CurrentRotation)
+{
+    GlobalControl control;
+    EXPECT_EQ(control.currentRotation(), 0);
+
+    QSignalSpy spy(&control, &GlobalControl::currentRotationChanged);
+    control.setCurrentRotation(90);
+    EXPECT_EQ(control.currentRotation(), 90);
+    EXPECT_EQ(spy.count(), 1);
+}

--- a/tests/src/ut_globalcontrol.h
+++ b/tests/src/ut_globalcontrol.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef UT_GLOBALCONTROL_H
+#define UT_GLOBALCONTROL_H
+
+#include <gtest/gtest.h>
+
+class GlobalControl;
+
+class ut_globalcontrol : public testing::Test
+{
+protected:
+    virtual void SetUp() override;
+    virtual void TearDown() override;
+};
+
+#endif  // UT_GLOBALCONTROL_H

--- a/tests/src/ut_globalstatus.cpp
+++ b/tests/src/ut_globalstatus.cpp
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "ut_globalstatus.h"
+#include "globalstatus.h"
+#include "types.h"
+
+#include <QSignalSpy>
+
+void ut_globalstatus::SetUp()
+{
+}
+
+void ut_globalstatus::TearDown()
+{
+}
+
+// 测试常量属性返回值
+TEST_F(ut_globalstatus, ConstantProperties)
+{
+    GlobalStatus status;
+
+    EXPECT_EQ(status.minHeight(), 300);
+    EXPECT_EQ(status.minWidth(), 628);
+    EXPECT_EQ(status.minHideHeight(), 425);
+    EXPECT_EQ(status.floatMargin(), 65);
+    EXPECT_EQ(status.titleHeight(), 50);
+    EXPECT_EQ(status.thumbnailViewHeight(), 70);
+    EXPECT_EQ(status.showBottomY(), 80);
+    EXPECT_EQ(status.switchImageHotspotWidth(), 100);
+    EXPECT_EQ(status.actionMargin(), 9);
+    EXPECT_EQ(status.rightMenuItemHeight(), 32);
+    EXPECT_DOUBLE_EQ(status.animationDefaultDuration(), 366.0);
+    EXPECT_EQ(status.pathViewItemCount(), 3);
+}
+
+// 测试 showFullScreen 属性设置与信号
+TEST_F(ut_globalstatus, ShowFullScreenProperty)
+{
+    GlobalStatus status;
+    EXPECT_FALSE(status.showFullScreen());
+
+    QSignalSpy spy(&status, &GlobalStatus::showFullScreenChanged);
+    status.setShowFullScreen(true);
+    EXPECT_TRUE(status.showFullScreen());
+    EXPECT_EQ(spy.count(), 1);
+
+    // 设置相同值不应触发信号
+    status.setShowFullScreen(true);
+    EXPECT_EQ(spy.count(), 1);
+}
+
+// 测试 enableNavigation 属性默认值与设置
+TEST_F(ut_globalstatus, EnableNavigationProperty)
+{
+    GlobalStatus status;
+    EXPECT_TRUE(status.enableNavigation());
+
+    QSignalSpy spy(&status, &GlobalStatus::enableNavigationChanged);
+    status.setEnableNavigation(false);
+    EXPECT_FALSE(status.enableNavigation());
+    EXPECT_EQ(spy.count(), 1);
+}
+
+// 测试 stackPage 属性设置
+TEST_F(ut_globalstatus, StackPageProperty)
+{
+    GlobalStatus status;
+    EXPECT_EQ(status.stackPage(), Types::OpenImagePage);
+
+    QSignalSpy spy(&status, &GlobalStatus::stackPageChanged);
+    status.setStackPage(Types::ImageViewPage);
+    EXPECT_EQ(status.stackPage(), Types::ImageViewPage);
+    EXPECT_EQ(spy.count(), 1);
+}
+
+// 测试 thumbnailVaildWidth 属性设置
+TEST_F(ut_globalstatus, ThumbnailVaildWidthProperty)
+{
+    GlobalStatus status;
+    EXPECT_EQ(status.thumbnailVaildWidth(), 0);
+
+    QSignalSpy spy(&status, &GlobalStatus::thumbnailVaildWidthChanged);
+    status.setThumbnailVaildWidth(200);
+    EXPECT_EQ(status.thumbnailVaildWidth(), 200);
+    EXPECT_EQ(spy.count(), 1);
+}
+
+// 测试 delayInit 属性设置
+TEST_F(ut_globalstatus, DelayInitProperty)
+{
+    GlobalStatus status;
+    EXPECT_TRUE(status.delayInit());
+
+    QSignalSpy spy(&status, &GlobalStatus::delayInitChanged);
+    status.setDelayInit(false);
+    EXPECT_FALSE(status.delayInit());
+    EXPECT_EQ(spy.count(), 1);
+}

--- a/tests/src/ut_globalstatus.h
+++ b/tests/src/ut_globalstatus.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef UT_GLOBALSTATUS_H
+#define UT_GLOBALSTATUS_H
+
+#include <gtest/gtest.h>
+
+class GlobalStatus;
+
+class ut_globalstatus : public testing::Test
+{
+protected:
+    virtual void SetUp() override;
+    virtual void TearDown() override;
+};
+
+#endif  // UT_GLOBALSTATUS_H

--- a/tests/src/ut_imageinfo.cpp
+++ b/tests/src/ut_imageinfo.cpp
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "ut_imageinfo.h"
+#include "imageinfo.h"
+
+#include <QUrl>
+#include <QSignalSpy>
+
+void ut_imageinfo::SetUp()
+{
+}
+
+void ut_imageinfo::TearDown()
+{
+}
+
+// 测试默认构造
+TEST_F(ut_imageinfo, DefaultConstruct)
+{
+    ImageInfo info;
+    EXPECT_EQ(info.status(), ImageInfo::Null);
+    EXPECT_EQ(info.frameIndex(), 0);
+    // 默认 frameCount 为 1（空图片按单帧处理）
+    EXPECT_EQ(info.frameCount(), 1);
+    // 默认 width/height 为 -1（未加载）
+    EXPECT_EQ(info.width(), -1);
+    EXPECT_EQ(info.height(), -1);
+}
+
+// 测试设置 source
+TEST_F(ut_imageinfo, SetSource)
+{
+    ImageInfo info;
+    QSignalSpy spy(&info, &ImageInfo::sourceChanged);
+
+    QUrl testUrl("file:///tmp/nonexistent_test_image.jpg");
+    info.setSource(testUrl);
+
+    EXPECT_EQ(info.source(), testUrl);
+}
+
+// 测试设置 frameIndex
+TEST_F(ut_imageinfo, SetFrameIndex)
+{
+    ImageInfo info;
+    QSignalSpy spy(&info, &ImageInfo::frameIndexChanged);
+
+    info.setFrameIndex(0);
+    EXPECT_EQ(info.frameIndex(), 0);
+}
+
+// 测试运行时属性默认值
+TEST_F(ut_imageinfo, RuntimeProperties)
+{
+    ImageInfo info;
+
+    // 运行时属性默认值
+    EXPECT_EQ(info.x(), 0);
+    EXPECT_EQ(info.y(), 0);
+}

--- a/tests/src/ut_imageinfo.h
+++ b/tests/src/ut_imageinfo.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef UT_IMAGEINFO_H
+#define UT_IMAGEINFO_H
+
+#include <gtest/gtest.h>
+
+class ImageInfo;
+
+class ut_imageinfo : public testing::Test
+{
+protected:
+    virtual void SetUp() override;
+    virtual void TearDown() override;
+};
+
+#endif  // UT_IMAGEINFO_H

--- a/tests/src/ut_main.cpp
+++ b/tests/src/ut_main.cpp
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include <QGuiApplication>
+#include <QCoreApplication>
+#include <DLog>
+
+// 定义日志分类，与 src/main.cpp 中的定义保持一致
+// 由于测试不编译 main.cpp，需要在此处定义
+Q_LOGGING_CATEGORY(logImageViewer, "org.deepin.dde.imageviewer")
+
+int main(int argc, char *argv[])
+{
+    QGuiApplication app(argc, argv);
+    QCoreApplication::setOrganizationName("deepin");
+    QCoreApplication::setApplicationName("deepin-image-viewer");
+
+    Dtk::Core::DLogManager::registerConsoleAppender();
+
+    testing::InitGoogleTest(&argc, argv);
+
+    return RUN_ALL_TESTS();
+}

--- a/tests/src/ut_types.cpp
+++ b/tests/src/ut_types.cpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "ut_types.h"
+#include "types.h"
+
+void ut_types::SetUp()
+{
+}
+
+void ut_types::TearDown()
+{
+}
+
+// 验证枚举值与预期一致
+TEST_F(ut_types, ImageTypeEnumValues)
+{
+    EXPECT_EQ(static_cast<int>(Types::NullImage), 0);
+    EXPECT_EQ(static_cast<int>(Types::NormalImage), 1);
+    EXPECT_EQ(static_cast<int>(Types::DynamicImage), 2);
+    EXPECT_EQ(static_cast<int>(Types::SvgImage), 3);
+    EXPECT_EQ(static_cast<int>(Types::MultiImage), 4);
+    EXPECT_EQ(static_cast<int>(Types::DamagedImage), 5);
+    EXPECT_EQ(static_cast<int>(Types::NonexistImage), 6);
+}
+
+TEST_F(ut_types, StackPageEnumValues)
+{
+    EXPECT_EQ(static_cast<int>(Types::OpenImagePage), 0);
+    EXPECT_EQ(static_cast<int>(Types::ImageViewPage), 1);
+    EXPECT_EQ(static_cast<int>(Types::SliderShowPage), 2);
+}
+
+TEST_F(ut_types, ItemRoleEnumValues)
+{
+    EXPECT_EQ(static_cast<int>(Types::ImageUrlRole), Qt::UserRole + 1);
+    EXPECT_EQ(static_cast<int>(Types::FrameIndexRole), Qt::UserRole + 2);
+    EXPECT_EQ(static_cast<int>(Types::ImageAngleRole), Qt::UserRole + 3);
+}

--- a/tests/src/ut_types.h
+++ b/tests/src/ut_types.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef UT_TYPES_H
+#define UT_TYPES_H
+
+#include <gtest/gtest.h>
+
+class Types;
+
+class ut_types : public testing::Test
+{
+protected:
+    virtual void SetUp() override;
+    virtual void TearDown() override;
+};
+
+#endif  // UT_TYPES_H

--- a/tests/test-prj-running.sh
+++ b/tests/test-prj-running.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -e
+
+builddir=build
+reportdir=build-ut
+rm -rf $builddir
+rm -rf ../$builddir
+rm -rf $reportdir
+rm -rf ../$reportdir
+mkdir ../$builddir
+mkdir ../$reportdir
+cd ../$builddir
+#编译
+cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_SAFETYTEST_ARG="CMAKE_SAFETYTEST_ARG_ON" ..
+make -j8
+#生成asan日志和ut测试xml结果
+./tests/deepin-image-viewer-test --gtest_output=xml:./report/report_deepin-image-viewer.xml || exit 1
+
+workdir=$(cd ../$(dirname $0)/$builddir; pwd)
+
+mkdir -p report
+#统计代码覆盖率并生成html报告
+lcov -d $workdir -c -o ./coverage.info
+
+lcov --extract ./coverage.info '*/src/*' -o ./coverage.info
+
+lcov --remove ./coverage.info '*/tests/*' -o ./coverage.info
+
+genhtml -o ./html ./coverage.info
+
+mv ./html/index.html ./html/cov_deepin-image-viewer.html
+#对asan、ut、代码覆盖率结果收集至指定文件夹
+cp -r html ../$reportdir/
+cp -r report ../$reportdir/
+cp -r asan*.log* ../$reportdir/asan_deepin-image-viewer.log
+
+exit 0


### PR DESCRIPTION
Add GTest-based unit test infrastructure following deepin-voice-note pattern, including 8 test modules with 36 test cases, lcov coverage report generation and ASAN support scripts.

新增基于 GTest 的单元测试框架，参照 deepin-voice-note 项目实现，包含 8 个测试模块共 36 个测试用例，支持 lcov 覆盖率报告和 ASAN 安全测试脚本。

Log: 补充单元测试框架及覆盖率报告生成

Influence: 新增 tests 目录单元测试代码，Debug 模式下编译运行，不影响 Release 正常构建。