### PR TITLE
test(imagedata): add unit tests for imagedata module

### DIFF
--- a/tests/src/ut_imagefilewatcher.cpp
+++ b/tests/src/ut_imagefilewatcher.cpp
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "ut_imagefilewatcher.h"
+#include "imagefilewatcher.h"
+
+#include <QUrl>
+#include <QFile>
+#include <QDir>
+#include <QFileInfo>
+#include <QSignalSpy>
+#include <QCoreApplication>
+#include <QEventLoop>
+#include <QTimer>
+#include <QImage>
+
+// 生成一个临时文件用于测试，返回绝对路径
+static QString makeWatcherTempFile(const QString &name)
+{
+    QString dir = QDir::tempPath() + "/ut_filewatcher_" +
+                  QString::number(QCoreApplication::applicationPid());
+    QDir().mkpath(dir);
+    QString path = dir + "/" + name;
+    QImage img(8, 8, QImage::Format_ARGB32);
+    img.fill(Qt::blue);
+    img.save(path, "PNG");
+    return path;
+}
+
+void ut_imagefilewatcher::SetUp()
+{
+    // 每个用例前重置单例状态，保证隔离
+    ImageFileWatcher::instance()->resetImageFiles({});
+}
+
+void ut_imagefilewatcher::TearDown()
+{
+    ImageFileWatcher::instance()->resetImageFiles({});
+}
+
+// 测试 instance() 返回同一单例
+TEST_F(ut_imagefilewatcher, InstanceReturnsSameSingleton)
+{
+    ImageFileWatcher *p1 = ImageFileWatcher::instance();
+    ImageFileWatcher *p2 = ImageFileWatcher::instance();
+    EXPECT_NE(p1, nullptr);
+    EXPECT_EQ(p1, p2);
+}
+
+// 测试 resetImageFiles 空列表不崩溃
+TEST_F(ut_imagefilewatcher, ResetImageFilesEmpty)
+{
+    ImageFileWatcher::instance()->resetImageFiles({});
+    SUCCEED();
+}
+
+// 测试 resetImageFiles 设置存在的文件
+TEST_F(ut_imagefilewatcher, ResetImageFilesWithExistingFiles)
+{
+    QString f1 = makeWatcherTempFile("a.png");
+    QString f2 = makeWatcherTempFile("b.png");
+    ASSERT_TRUE(QFileInfo::exists(f1));
+
+    // resetImageFiles 内部用 QUrl(filePath).toLocalFile() 解析，故传入 file:// URL
+    ImageFileWatcher::instance()->resetImageFiles(
+        {QUrl::fromLocalFile(f1).toString(), QUrl::fromLocalFile(f2).toString()});
+    // 重复重置同一目录应被忽略（isCurrentDir 分支）
+    ImageFileWatcher::instance()->resetImageFiles(
+        {QUrl::fromLocalFile(f1).toString(), QUrl::fromLocalFile(f2).toString()});
+    SUCCEED();
+}
+
+// 测试 resetImageFiles 包含不存在文件（被忽略）
+TEST_F(ut_imagefilewatcher, ResetImageFilesWithNonexisting)
+{
+    ImageFileWatcher::instance()->resetImageFiles({QUrl::fromLocalFile("/tmp/ut_nonexist_file.png").toString()});
+    SUCCEED();
+}
+
+// 测试 isCurrentDir
+TEST_F(ut_imagefilewatcher, IsCurrentDir)
+{
+    QString f1 = makeWatcherTempFile("c.png");
+    ImageFileWatcher::instance()->resetImageFiles({QUrl::fromLocalFile(f1).toString()});
+
+    // f1 所在目录应被监控（isCurrentDir 接收本地路径）
+    EXPECT_TRUE(ImageFileWatcher::instance()->isCurrentDir(f1));
+    // 另一目录不被监控
+    EXPECT_FALSE(ImageFileWatcher::instance()->isCurrentDir("/usr/bin"));
+}
+
+// 测试 fileRename 缓存命中与未命中分支
+TEST_F(ut_imagefilewatcher, FileRenameHitAndMiss)
+{
+    QString f1 = makeWatcherTempFile("d.png");
+    QString f1Renamed = QFileInfo(f1).absolutePath() + "/d_renamed.png";
+    QFile::rename(f1, f1Renamed);  // 真实重命名以便新路径存在
+
+    ImageFileWatcher::instance()->resetImageFiles({QUrl::fromLocalFile(f1Renamed).toString()});
+    // 未命中分支（oldPath 不在缓存中，预期不崩溃且无副作用）
+    ImageFileWatcher::instance()->fileRename("/tmp/ut_not_in_cache.png", f1Renamed);
+
+    // 对当前缓存路径做 rename（命中分支，cacheFileInfo 以本地路径为 key）
+    ImageFileWatcher::instance()->fileRename(f1Renamed, f1);
+    SUCCEED();
+}
+
+// 测试 recordRotateImage 与 clearRotateStatus
+TEST_F(ut_imagefilewatcher, RecordAndClearRotateStatus)
+{
+    QString target = "/tmp/ut_rotate_target.png";
+    ImageFileWatcher::instance()->recordRotateImage(target);
+    // 再次清除存在的记录
+    ImageFileWatcher::instance()->clearRotateStatus(target);
+    // 清除不存在的记录不崩溃
+    ImageFileWatcher::instance()->clearRotateStatus("/tmp/ut_rotate_other.png");
+    SUCCEED();
+}
+
+// 测试 imageFileChanged 信号在文件变更时触发
+TEST_F(ut_imagefilewatcher, ImageFileChangedSignal)
+{
+    QString f1 = makeWatcherTempFile("e.png");
+    ImageFileWatcher::instance()->resetImageFiles({QUrl::fromLocalFile(f1).toString()});
+
+    QSignalSpy spy(ImageFileWatcher::instance(), &ImageFileWatcher::imageFileChanged);
+
+    // 触发文件内容变更：覆盖写入
+    {
+        QImage img(4, 4, QImage::Format_ARGB32);
+        img.fill(Qt::red);
+        img.save(f1, "PNG");
+    }
+
+    // 处理事件循环，等待 QFileSystemWatcher 回调
+    QEventLoop loop;
+    QTimer::singleShot(500, &loop, &QEventLoop::quit);
+    loop.exec();
+
+    // 至少有可能触发；不强求必定 >=1（QFileSystemWatcher 行为依赖平台），
+    // 这里只验证接口可调用且不崩溃。
+    EXPECT_TRUE(spy.isValid());
+}
+
+// ---------- 私有槽测试（依赖 -fno-access-control） ----------
+
+// 测试 onImageFileChanged 对缓存中的文件
+TEST_F(ut_imagefilewatcher, PrivateOnImageFileChangedCached)
+{
+    QString f1 = makeWatcherTempFile("f.png");
+    ImageFileWatcher::instance()->resetImageFiles({QUrl::fromLocalFile(f1).toString()});
+
+    // 先记录旋转状态，使 onImageFileChanged 走"忽略"分支
+    ImageFileWatcher::instance()->recordRotateImage(f1);
+    ImageFileWatcher::instance()->onImageFileChanged(f1);
+    SUCCEED();
+}
+
+// 测试 onImageFileChanged 对非缓存文件（不处理）
+TEST_F(ut_imagefilewatcher, PrivateOnImageFileChangedNotCached)
+{
+    ImageFileWatcher::instance()->onImageFileChanged("/tmp/ut_not_cached_file.png");
+    SUCCEED();
+}
+
+// 测试 onImageDirChanged 不崩溃
+TEST_F(ut_imagefilewatcher, PrivateOnImageDirChanged)
+{
+    QString dir = QDir::tempPath() + "/ut_filewatcher_" +
+                  QString::number(QCoreApplication::applicationPid());
+    ImageFileWatcher::instance()->onImageDirChanged(dir);
+    SUCCEED();
+}

--- a/tests/src/ut_imagefilewatcher.h
+++ b/tests/src/ut_imagefilewatcher.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef UT_IMAGEFILEWATCHER_H
+#define UT_IMAGEFILEWATCHER_H
+
+#include <gtest/gtest.h>
+
+class ImageFileWatcher;
+
+class ut_imagefilewatcher : public testing::Test
+{
+protected:
+    virtual void SetUp() override;
+    virtual void TearDown() override;
+};
+
+#endif  // UT_IMAGEFILEWATCHER_H

--- a/tests/src/ut_imageprovider.cpp
+++ b/tests/src/ut_imageprovider.cpp
@@ -1,0 +1,274 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "ut_imageprovider.h"
+#include "imageprovider.h"
+
+#include <QImage>
+#include <QUrl>
+#include <QDir>
+#include <QSize>
+#include <QPixmap>
+#include <QEventLoop>
+#include <QTimer>
+#include <QCoreApplication>
+#include <QQuickImageResponse>
+#include <QSignalSpy>
+
+// 生成临时 PNG 文件，返回绝对路径
+static QString makeProviderTempImage(const QString &name, int side = 64)
+{
+    QString dir = QDir::tempPath() + "/ut_imageprovider_" +
+                  QString::number(QCoreApplication::applicationPid());
+    QDir().mkpath(dir);
+    QString path = dir + "/" + name;
+    QImage img(side, side, QImage::Format_ARGB32);
+    img.fill(Qt::green);
+    img.save(path, "PNG");
+    return path;
+}
+
+void ut_imageprovider::SetUp()
+{
+}
+
+void ut_imageprovider::TearDown()
+{
+}
+
+// ==================== ProviderCache ====================
+
+// 测试 ProviderCache 构造与析构
+TEST_F(ut_imageprovider, ProviderCacheConstruct)
+{
+    ProviderCache cache;
+    cache.clearCache();  // 确认可调用
+    SUCCEED();
+}
+
+// 测试 rotateImageCached 角度为 0 提前返回
+TEST_F(ut_imageprovider, RotateImageCachedZeroAngle)
+{
+    ProviderCache cache;
+    cache.rotateImageCached(0, "/tmp/ut_zero_angle.png");
+    SUCCEED();
+}
+
+// 测试 rotateImageCached 缓存中无图像（image 为 null 走警告分支）
+TEST_F(ut_imageprovider, RotateImageCachedNoCachedImage)
+{
+    ProviderCache cache;
+    cache.rotateImageCached(90, "/tmp/ut_no_cached_image.png", 0);
+    SUCCEED();
+}
+
+// 测试 rotateImageCached 对已缓存图像执行旋转
+TEST_F(ut_imageprovider, RotateImageCachedWithCachedImage)
+{
+    ProviderCache cache;
+    QString path = makeProviderTempImage("rot.png");
+    QImage img(path);
+    ASSERT_FALSE(img.isNull());
+
+    // 先把图像放入缓存（imageCache 为 protected 成员，借由 -fno-access-control 直接访问）
+    cache.imageCache.add(path, 0, img);
+    cache.rotateImageCached(90, path, 0);
+
+    // 同一路径连续旋转（走 lastRotatePath 分支）
+    cache.rotateImageCached(90, path, 0);
+    // 360 度不旋转分支
+    cache.rotateImageCached(180, path, 0);
+    SUCCEED();
+}
+
+// 测试 removeImageCache
+TEST_F(ut_imageprovider, RemoveImageCache)
+{
+    ProviderCache cache;
+    QString path = makeProviderTempImage("rm.png");
+    QImage img(path);
+    cache.imageCache.add(path, 0, img);
+    cache.imageCache.add(path, 1, img);
+    cache.removeImageCache(path);
+    EXPECT_FALSE(cache.imageCache.contains(path, 0));
+
+    // 移除不存在的项不崩溃
+    cache.removeImageCache("/tmp/ut_not_in_cache.png");
+}
+
+// 测试 renameImageCache
+TEST_F(ut_imageprovider, RenameImageCache)
+{
+    ProviderCache cache;
+    QString oldPath = makeProviderTempImage("old.png");
+    QString newPath = QFileInfo(oldPath).absolutePath() + "/new.png";
+    QImage img(oldPath);
+    cache.imageCache.add(oldPath, 0, img);
+    cache.renameImageCache(oldPath, newPath);
+    EXPECT_TRUE(cache.imageCache.contains(newPath, 0));
+    EXPECT_FALSE(cache.imageCache.contains(oldPath, 0));
+
+    // 重命名不存在的项不崩溃
+    cache.renameImageCache("/tmp/ut_no_old.png", "/tmp/ut_no_new.png");
+}
+
+// 测试 clearCache 清空状态
+TEST_F(ut_imageprovider, ClearCache)
+{
+    ProviderCache cache;
+    QString path = makeProviderTempImage("clr.png");
+    QImage img(path);
+    cache.imageCache.add(path, 0, img);
+    cache.rotateImageCached(90, path, 0);
+
+    cache.clearCache();
+    EXPECT_FALSE(cache.imageCache.contains(path, 0));
+    EXPECT_TRUE(cache.lastRotatePath.isEmpty());
+}
+
+// 测试 preloadImage 默认实现（空操作）
+TEST_F(ut_imageprovider, PreloadImageDefault)
+{
+    ProviderCache cache;
+    cache.preloadImage("/tmp/ut_preload.png");
+    SUCCEED();
+}
+
+// ==================== ImageProvider ====================
+
+// 测试 ImageProvider 构造与析构
+TEST_F(ut_imageprovider, ImageProviderConstruct)
+{
+    ImageProvider provider;
+    SUCCEED();
+}
+
+// 测试 ImageProvider::requestImage 读取真实文件(frame 0)
+TEST_F(ut_imageprovider, ImageProviderRequestImage)
+{
+    ImageProvider provider;
+    QString path = makeProviderTempImage("req.png", 80);
+    QString id = QUrl::fromLocalFile(path).toString();  // id 需为 file:// URL
+    QSize outSize;
+    QImage img = provider.requestImage(id, &outSize, QSize(40, 40));
+    EXPECT_FALSE(img.isNull());
+}
+
+// 测试 ImageProvider::requestImage 缓存命中
+TEST_F(ut_imageprovider, ImageProviderRequestImageCached)
+{
+    ImageProvider provider;
+    QString path = makeProviderTempImage("cached.png");
+    QString id = QUrl::fromLocalFile(path).toString();
+    QSize outSize1;
+    provider.requestImage(id, &outSize1, QSize());  // 首次加载并缓存
+    QSize outSize2;
+    QImage img = provider.requestImage(id, &outSize2, QSize());  // 走缓存
+    EXPECT_FALSE(img.isNull());
+}
+
+// 测试 ImageProvider::requestImage 不存在文件返回空图像
+TEST_F(ut_imageprovider, ImageProviderRequestImageNonexist)
+{
+    ImageProvider provider;
+    QImage img = provider.requestImage("/tmp/ut_not_exist.png", nullptr, QSize());
+    EXPECT_TRUE(img.isNull());
+}
+
+// 测试 ImageProvider::requestImage 带 frame 索引（多页图，非 0 帧）
+TEST_F(ut_imageprovider, ImageProviderRequestImageWithFrame)
+{
+    ImageProvider provider;
+    // 单页 PNG 指定非 0 帧，readMultiImage 返回空
+    QImage img = provider.requestImage("file:///tmp/ut_frame.png#frame_1", nullptr, QSize());
+    // 非存在文件，frame != 0，返回空
+    EXPECT_TRUE(img.isNull());
+}
+
+// ==================== ThumbnailProvider ====================
+
+// 测试 ThumbnailProvider 构造
+TEST_F(ut_imageprovider, ThumbnailProviderConstruct)
+{
+    ThumbnailProvider provider;
+    SUCCEED();
+}
+
+// 测试 ThumbnailProvider::requestImage 读取真实文件
+TEST_F(ut_imageprovider, ThumbnailProviderRequestImage)
+{
+    ThumbnailProvider provider;
+    QString path = makeProviderTempImage("thumb.png", 100);
+    QString id = QUrl::fromLocalFile(path).toString();
+    QSize outSize;
+    QImage img = provider.requestImage(id, &outSize, QSize(50, 50));
+    EXPECT_FALSE(img.isNull());
+}
+
+// 测试 ThumbnailProvider::requestImage 缓存命中
+TEST_F(ut_imageprovider, ThumbnailProviderRequestImageCached)
+{
+    ThumbnailProvider provider;
+    QString path = makeProviderTempImage("thumb_cached.png", 100);
+    QString id = QUrl::fromLocalFile(path).toString();
+    QSize outSize1;
+    provider.requestImage(id, &outSize1, QSize());  // 首次，写入缩略图缓存
+    QImage img = provider.requestImage(id, nullptr, QSize());  // 走 ThumbnailCache
+    EXPECT_FALSE(img.isNull());
+}
+
+// 测试 ThumbnailProvider::requestPixmap
+TEST_F(ut_imageprovider, ThumbnailProviderRequestPixmap)
+{
+    ThumbnailProvider provider;
+    QString path = makeProviderTempImage("pixmap.png", 100);
+    QString id = QUrl::fromLocalFile(path).toString();
+    QSize outSize;
+    QPixmap pix = provider.requestPixmap(id, &outSize, QSize(50, 50));
+    EXPECT_FALSE(pix.isNull());
+}
+
+// ==================== AsyncImageProvider ====================
+
+// 测试 AsyncImageProvider 构造
+TEST_F(ut_imageprovider, AsyncImageProviderConstruct)
+{
+    AsyncImageProvider provider;
+    SUCCEED();
+}
+
+// 测试 AsyncImageProvider::requestImageResponse 返回应答并完成
+TEST_F(ut_imageprovider, AsyncImageProviderRequestImageResponse)
+{
+    AsyncImageProvider provider;
+    QString path = makeProviderTempImage("async.png", 100);
+    QString id = QUrl::fromLocalFile(path).toString();
+
+    QQuickImageResponse *response = provider.requestImageResponse(id, QSize(50, 50));
+    ASSERT_NE(response, nullptr);
+
+    QSignalSpy spy(response, &QQuickImageResponse::finished);
+    // 等待加载完成（线程池异步）
+    QEventLoop loop;
+    QObject::connect(response, &QQuickImageResponse::finished, &loop, &QEventLoop::quit);
+    QTimer::singleShot(3000, &loop, &QEventLoop::quit);
+    loop.exec();
+
+    EXPECT_GE(spy.count(), 1);
+    delete response;
+}
+
+// 测试 AsyncImageProvider::preloadImage 不崩溃
+TEST_F(ut_imageprovider, AsyncImageProviderPreloadImage)
+{
+    AsyncImageProvider provider;
+    QString path = makeProviderTempImage("preload.png", 100);
+    provider.preloadImage(QUrl::fromLocalFile(path).toString());
+
+    // 等待后台线程完成，避免访问已释放资源
+    QEventLoop loop;
+    QTimer::singleShot(1000, &loop, &QEventLoop::quit);
+    loop.exec();
+    SUCCEED();
+}

--- a/tests/src/ut_imageprovider.h
+++ b/tests/src/ut_imageprovider.h
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef UT_IMAGEPROVIDER_H
+#define UT_IMAGEPROVIDER_H
+
+#include <gtest/gtest.h>
+
+class ProviderCache;
+class ImageProvider;
+class ThumbnailProvider;
+class AsyncImageProvider;
+
+class ut_imageprovider : public testing::Test
+{
+protected:
+    virtual void SetUp() override;
+    virtual void TearDown() override;
+};
+
+#endif  // UT_IMAGEPROVIDER_H

--- a/tests/src/ut_imagesourcemodel.cpp
+++ b/tests/src/ut_imagesourcemodel.cpp
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "ut_imagesourcemodel.h"
+#include "imagesourcemodel.h"
+
+#include <QUrl>
+#include <QList>
+#include <QModelIndex>
+#include <QSignalSpy>
+#include "types.h"
+
+void ut_imagesourcemodel::SetUp()
+{
+}
+
+void ut_imagesourcemodel::TearDown()
+{
+}
+
+// 测试默认构造与空模型
+TEST_F(ut_imagesourcemodel, DefaultConstruct)
+{
+    ImageSourceModel model;
+    EXPECT_EQ(model.rowCount(), 0);
+}
+
+// 测试 roleNames 包含 imageUrl
+TEST_F(ut_imagesourcemodel, RoleNames)
+{
+    ImageSourceModel model;
+    QHash<int, QByteArray> names = model.roleNames();
+    EXPECT_TRUE(names.contains(Types::ImageUrlRole));
+    EXPECT_EQ(names.value(Types::ImageUrlRole), QByteArray("imageUrl"));
+}
+
+// 测试 setImageFiles 后 rowCount 与 data
+TEST_F(ut_imagesourcemodel, SetImageFilesAndUpdateRowCount)
+{
+    ImageSourceModel model;
+    QList<QUrl> files;
+    files << QUrl("file:///a.jpg") << QUrl("file:///b.jpg") << QUrl("file:///c.jpg");
+
+    model.setImageFiles(files);
+    EXPECT_EQ(model.rowCount(), 3);
+
+    QModelIndex idx = model.index(1);
+    EXPECT_EQ(model.data(idx, Types::ImageUrlRole).toUrl(), QUrl("file:///b.jpg"));
+}
+
+// 测试 data 传入非法索引返回空
+TEST_F(ut_imagesourcemodel, DataInvalidIndexReturnsEmpty)
+{
+    ImageSourceModel model;
+    QList<QUrl> files;
+    files << QUrl("file:///a.jpg");
+    model.setImageFiles(files);
+
+    QVariant v = model.data(QModelIndex(), Types::ImageUrlRole);
+    EXPECT_FALSE(v.isValid());
+
+    QModelIndex bad = model.index(99);
+    QVariant v2 = model.data(bad, Types::ImageUrlRole);
+    EXPECT_FALSE(v2.isValid());
+}
+
+// 测试 data 传入未知 role 返回空
+TEST_F(ut_imagesourcemodel, DataUnknownRoleReturnsEmpty)
+{
+    ImageSourceModel model;
+    QList<QUrl> files;
+    files << QUrl("file:///a.jpg");
+    model.setImageFiles(files);
+
+    QVariant v = model.data(model.index(0), Qt::UserRole + 100);
+    EXPECT_FALSE(v.isValid());
+}
+
+// 测试 setData 成功并发信号
+TEST_F(ut_imagesourcemodel, SetDataValidEmitsSignal)
+{
+    ImageSourceModel model;
+    QList<QUrl> files;
+    files << QUrl("file:///a.jpg") << QUrl("file:///b.jpg");
+    model.setImageFiles(files);
+
+    QSignalSpy spy(&model, &ImageSourceModel::dataChanged);
+    QModelIndex idx = model.index(0);
+    bool ok = model.setData(idx, QVariant::fromValue(QUrl("file:///changed.jpg")), Types::ImageUrlRole);
+    EXPECT_TRUE(ok);
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_EQ(model.data(idx, Types::ImageUrlRole).toUrl(), QUrl("file:///changed.jpg"));
+}
+
+// 测试 setData 非法索引返回 false
+TEST_F(ut_imagesourcemodel, SetDataInvalidIndexReturnsFalse)
+{
+    ImageSourceModel model;
+    bool ok = model.setData(QModelIndex(), QVariant::fromValue(QUrl("file:///x.jpg")), Types::ImageUrlRole);
+    EXPECT_FALSE(ok);
+}
+
+// 测试 setData 未知 role 返回 false
+TEST_F(ut_imagesourcemodel, SetDataUnknownRoleReturnsFalse)
+{
+    ImageSourceModel model;
+    QList<QUrl> files;
+    files << QUrl("file:///a.jpg");
+    model.setImageFiles(files);
+
+    bool ok = model.setData(model.index(0), QVariant::fromValue(QUrl("file:///y.jpg")), Qt::UserRole + 100);
+    EXPECT_FALSE(ok);
+}
+
+// 测试 indexForImagePath 命中/未命中/空
+TEST_F(ut_imagesourcemodel, IndexForImagePath)
+{
+    ImageSourceModel model;
+    QList<QUrl> files;
+    files << QUrl("file:///a.jpg") << QUrl("file:///b.jpg");
+    model.setImageFiles(files);
+
+    EXPECT_EQ(model.indexForImagePath(QUrl("file:///b.jpg")), 1);
+    EXPECT_EQ(model.indexForImagePath(QUrl("file:///notexist.jpg")), -1);
+    EXPECT_EQ(model.indexForImagePath(QUrl()), -1);
+}
+
+// 测试 removeImage 移除存在的项
+TEST_F(ut_imagesourcemodel, RemoveExistingImage)
+{
+    ImageSourceModel model;
+    QList<QUrl> files;
+    files << QUrl("file:///a.jpg") << QUrl("file:///b.jpg") << QUrl("file:///c.jpg");
+    model.setImageFiles(files);
+
+    model.removeImage(QUrl("file:///b.jpg"));
+    EXPECT_EQ(model.rowCount(), 2);
+    EXPECT_EQ(model.data(model.index(1), Types::ImageUrlRole).toUrl(), QUrl("file:///c.jpg"));
+}
+
+// 测试 removeImage 移除不存在的项不报错
+TEST_F(ut_imagesourcemodel, RemoveNonexistingImage)
+{
+    ImageSourceModel model;
+    QList<QUrl> files;
+    files << QUrl("file:///a.jpg");
+    model.setImageFiles(files);
+
+    model.removeImage(QUrl("file:///nope.jpg"));
+    EXPECT_EQ(model.rowCount(), 1);
+}
+
+// 测试 rowCount 带父索引参数
+TEST_F(ut_imagesourcemodel, RowCountWithParent)
+{
+    ImageSourceModel model;
+    QList<QUrl> files;
+    files << QUrl("file:///a.jpg") << QUrl("file:///b.jpg");
+    model.setImageFiles(files);
+    EXPECT_EQ(model.rowCount(QModelIndex()), 2);
+}

--- a/tests/src/ut_imagesourcemodel.h
+++ b/tests/src/ut_imagesourcemodel.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef UT_IMAGESOURCEMODEL_H
+#define UT_IMAGESOURCEMODEL_H
+
+#include <gtest/gtest.h>
+
+class ImageSourceModel;
+
+class ut_imagesourcemodel : public testing::Test
+{
+protected:
+    virtual void SetUp() override;
+    virtual void TearDown() override;
+};
+
+#endif  // UT_IMAGESOURCEMODEL_H

--- a/tests/src/ut_pathviewproxymodel.cpp
+++ b/tests/src/ut_pathviewproxymodel.cpp
@@ -1,0 +1,422 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "ut_pathviewproxymodel.h"
+#include "pathviewproxymodel.h"
+#include "imagesourcemodel.h"
+
+#include <QUrl>
+#include <QList>
+#include <QModelIndex>
+#include <QSignalSpy>
+#include <QImage>
+#include <QDir>
+#include <QCoreApplication>
+#include "types.h"
+
+// 创建若干临时 PNG 文件供 ImageSourceModel 使用，确保 ImageInfo 能同步加载。
+static QStringList g_pathviewTmpPaths;
+static QList<QUrl> g_pathviewTmpUrls;
+
+static void ensurePathViewTempImages()
+{
+    if (!g_pathviewTmpPaths.isEmpty()) {
+        return;
+    }
+    QString dir = QDir::tempPath() + "/ut_pathview_" +
+                  QString::number(QCoreApplication::applicationPid());
+    QDir().mkpath(dir);
+    for (int i = 0; i < 5; ++i) {
+        QImage img(20 + i, 20, QImage::Format_ARGB32);
+        img.fill(QColor(i * 50, 100, 100));
+        QString path = dir + "/img" + QString::number(i) + ".png";
+        img.save(path, "PNG");
+        g_pathviewTmpPaths << path;
+        g_pathviewTmpUrls << QUrl::fromLocalFile(path);
+    }
+}
+
+void ut_pathviewproxymodel::SetUp()
+{
+    ensurePathViewTempImages();
+}
+
+void ut_pathviewproxymodel::TearDown()
+{
+}
+
+// 测试构造与默认状态
+TEST_F(ut_pathviewproxymodel, Construct)
+{
+    ImageSourceModel src;
+    PathViewProxyModel model(&src);
+    EXPECT_EQ(model.rowCount(), 0);
+    EXPECT_EQ(model.currentIndex(), 0);
+}
+
+// 测试 roleNames
+TEST_F(ut_pathviewproxymodel, RoleNames)
+{
+    ImageSourceModel src;
+    PathViewProxyModel model(&src);
+    QHash<int, QByteArray> names = model.roleNames();
+    EXPECT_TRUE(names.contains(Types::ImageUrlRole));
+    EXPECT_TRUE(names.contains(Types::FrameIndexRole));
+}
+
+// 测试 setCurrentIndex 与信号
+TEST_F(ut_pathviewproxymodel, SetCurrentIndexAndSignal)
+{
+    ImageSourceModel src;
+    PathViewProxyModel model(&src);
+
+    QSignalSpy spy(&model, &PathViewProxyModel::currentIndexChanged);
+    model.setCurrentIndex(2);
+    EXPECT_EQ(model.currentIndex(), 2);
+    EXPECT_EQ(spy.count(), 1);
+
+    // 相同值不触发信号
+    model.setCurrentIndex(2);
+    EXPECT_EQ(spy.count(), 1);
+}
+
+// 测试 setQueueCount 合法值（奇数 >=3）
+TEST_F(ut_pathviewproxymodel, SetQueueCountValid)
+{
+    ImageSourceModel src;
+    PathViewProxyModel model(&src);
+    model.setQueueCount(7);
+    // 无直接 getter，通过 resetModel 后的 rowCount 间接验证
+    src.setImageFiles(g_pathviewTmpUrls);
+    model.resetModel(0, 0);
+    EXPECT_EQ(model.rowCount(), 7);
+}
+
+// 测试 resetModel 填充队列
+TEST_F(ut_pathviewproxymodel, ResetModelFillsQueue)
+{
+    ImageSourceModel src;
+    src.setImageFiles(g_pathviewTmpUrls);
+    PathViewProxyModel model(&src);
+
+    QSignalSpy resetSpy(&model, &QAbstractListModel::modelReset);
+    ASSERT_TRUE(resetSpy.isValid());
+    model.resetModel(2, 0);
+    EXPECT_EQ(model.rowCount(), 5);  // default queue count
+    EXPECT_EQ(model.currentIndex(), 0);
+    EXPECT_GE(resetSpy.count(), 1);
+}
+
+// 测试 data 合法与非法索引
+TEST_F(ut_pathviewproxymodel, DataValidAndInvalid)
+{
+    ImageSourceModel src;
+    src.setImageFiles(g_pathviewTmpUrls);
+    PathViewProxyModel model(&src);
+    model.resetModel(2, 0);
+
+    QModelIndex idx = model.index(0);
+    QVariant urlVar = model.data(idx, Types::ImageUrlRole);
+    EXPECT_TRUE(urlVar.isValid());
+
+    QVariant frameVar = model.data(idx, Types::FrameIndexRole);
+    EXPECT_EQ(frameVar.toInt(), 0);
+
+    // 未知 role
+    QVariant unknown = model.data(idx, Qt::UserRole + 100);
+    EXPECT_FALSE(unknown.isValid());
+
+    // 非法索引
+    EXPECT_FALSE(model.data(QModelIndex(), Types::ImageUrlRole).isValid());
+}
+
+// 测试 setData 更新 url
+TEST_F(ut_pathviewproxymodel, SetDataUpdatesUrl)
+{
+    ImageSourceModel src;
+    src.setImageFiles(g_pathviewTmpUrls);
+    PathViewProxyModel model(&src);
+    model.resetModel(2, 0);
+
+    QSignalSpy spy(&model, &PathViewProxyModel::dataChanged);
+    QModelIndex idx = model.index(0);
+    QUrl newUrl("file:///changed.png");
+    bool ok = model.setData(idx, QVariant::fromValue(newUrl), Types::ImageUrlRole);
+    EXPECT_TRUE(ok);
+    EXPECT_GE(spy.count(), 1);
+    EXPECT_EQ(model.data(idx, Types::ImageUrlRole).toUrl(), newUrl);
+}
+
+// 测试 setData 非法索引与未知 role
+TEST_F(ut_pathviewproxymodel, SetDataInvalidAndUnknownRole)
+{
+    ImageSourceModel src;
+    src.setImageFiles(g_pathviewTmpUrls);
+    PathViewProxyModel model(&src);
+    model.resetModel(2, 0);
+
+    EXPECT_FALSE(model.setData(QModelIndex(), QVariant::fromValue(QUrl("file:///x.png")), Types::ImageUrlRole));
+    EXPECT_FALSE(model.setData(model.index(0), QVariant::fromValue(QUrl("file:///y.png")), Qt::UserRole + 100));
+}
+
+// 测试 moveNext/movePrevoius 不崩溃并更新 currentIndex
+TEST_F(ut_pathviewproxymodel, MoveNextAndPrevious)
+{
+    ImageSourceModel src;
+    src.setImageFiles(g_pathviewTmpUrls);
+    PathViewProxyModel model(&src);
+    model.resetModel(2, 0);
+
+    int oldIdx = model.currentIndex();
+    model.moveNext();
+    EXPECT_EQ(model.rowCount(), 5);
+
+    model.movePrevoius();
+    EXPECT_EQ(model.rowCount(), 5);
+    // 多次移动
+    for (int i = 0; i < 10; ++i) {
+        model.moveNext();
+    }
+    EXPECT_EQ(model.rowCount(), 5);
+}
+
+// 测试 dumpInfo 不崩溃
+TEST_F(ut_pathviewproxymodel, DumpInfo)
+{
+    ImageSourceModel src;
+    src.setImageFiles(g_pathviewTmpUrls);
+    PathViewProxyModel model(&src);
+    model.resetModel(2, 0);
+    model.dumpInfo();
+    SUCCEED();
+}
+
+// 测试 syncState 在 jumpFlag==Current 时为空操作
+TEST_F(ut_pathviewproxymodel, SyncStateNoOpWhenCurrent)
+{
+    ImageSourceModel src;
+    src.setImageFiles(g_pathviewTmpUrls);
+    PathViewProxyModel model(&src);
+    model.resetModel(2, 0);
+    model.syncState();  // jumpFlag == Current, 无副作用
+    SUCCEED();
+}
+
+// 测试 syncState 在跳转后刷新两侧数据
+TEST_F(ut_pathviewproxymodel, SyncStateAfterJump)
+{
+    ImageSourceModel src;
+    src.setImageFiles(g_pathviewTmpUrls);
+    PathViewProxyModel model(&src);
+    model.resetModel(2, 0);
+    // OutOfRange 跳转会设置 jumpFlag
+    model.setCurrentSourceIndex(0, 0);
+    model.syncState();
+    SUCCEED();
+}
+
+// 测试 setCurrentSourceIndex 各距离分支
+TEST_F(ut_pathviewproxymodel, SetCurrentSourceIndexBranches)
+{
+    ImageSourceModel src;
+    src.setImageFiles(g_pathviewTmpUrls);
+    PathViewProxyModel model(&src);
+    model.resetModel(2, 0);
+
+    // Current - 不动作
+    model.setCurrentSourceIndex(2, 0);
+    // Previous
+    model.setCurrentSourceIndex(1, 0);
+    // Next
+    model.setCurrentSourceIndex(2, 0);
+    model.movePrevoius();
+    model.setCurrentSourceIndex(2, 0);
+    // OutOfRange
+    model.resetModel(2, 0);
+    model.setCurrentSourceIndex(0, 0);
+    SUCCEED();
+}
+
+// 测试 setCurrentSourceIndex 空队列提前返回
+TEST_F(ut_pathviewproxymodel, SetCurrentSourceIndexEmptyQueue)
+{
+    ImageSourceModel src;
+    src.setImageFiles(g_pathviewTmpUrls);
+    PathViewProxyModel model(&src);
+    // 队列为空，不崩溃
+    model.setCurrentSourceIndex(0, 0);
+    SUCCEED();
+}
+
+// 测试 deleteCurrent 各分支
+TEST_F(ut_pathviewproxymodel, DeleteCurrentBranches)
+{
+    // 1. 空队列
+    {
+        ImageSourceModel src;
+        src.setImageFiles(g_pathviewTmpUrls);
+        PathViewProxyModel model(&src);
+        model.deleteCurrent();  // 空队列提前返回
+    }
+    // 2. 源模型行数为 0
+    {
+        ImageSourceModel src;
+        PathViewProxyModel model(&src);
+        model.resetModel(0, 0);  // 队列非空但源模型 rowCount=0
+        src.setImageFiles(g_pathviewTmpUrls);
+        model.deleteCurrent();
+    }
+    // 3. 正常删除（非尾部）
+    {
+        ImageSourceModel src;
+        src.setImageFiles(g_pathviewTmpUrls);
+        PathViewProxyModel model(&src);
+        model.resetModel(2, 0);
+        model.deleteCurrent();
+        EXPECT_EQ(model.rowCount(), 5);
+    }
+}
+
+// ---------- 私有函数测试（依赖 -fno-access-control） ----------
+
+// 测试 sourcePath 合法与越界
+TEST_F(ut_pathviewproxymodel, PrivateSourcePath)
+{
+    ImageSourceModel src;
+    src.setImageFiles(g_pathviewTmpUrls);
+    PathViewProxyModel model(&src);
+    model.resetModel(2, 0);
+
+    QUrl p = model.sourcePath(0);
+    EXPECT_FALSE(p.isEmpty());
+    EXPECT_TRUE(model.sourcePath(-1).isEmpty());
+    EXPECT_TRUE(model.sourcePath(999).isEmpty());
+}
+
+// 测试 previousPorxyIdx / nextProxyIdx 环形
+TEST_F(ut_pathviewproxymodel, PrivateProxyIdxRing)
+{
+    ImageSourceModel src;
+    src.setImageFiles(g_pathviewTmpUrls);
+    PathViewProxyModel model(&src);
+    model.resetModel(2, 0);
+    int size = model.rowCount();
+    ASSERT_EQ(size, 5);
+
+    EXPECT_EQ(model.previousPorxyIdx(0), size - 1);
+    EXPECT_EQ(model.nextProxyIdx(size - 1), 0);
+    EXPECT_EQ(model.nextProxyIdx(0), 1);
+    EXPECT_EQ(model.previousPorxyIdx(1), 0);
+}
+
+// 测试 distance 各分支
+TEST_F(ut_pathviewproxymodel, PrivateDistance)
+{
+    ImageSourceModel src;
+    src.setImageFiles(g_pathviewTmpUrls);
+    PathViewProxyModel model(&src);
+    model.resetModel(2, 0);
+
+    EXPECT_EQ(model.distance(2, 0), PathViewProxyModel::Current);    // 0
+    EXPECT_EQ(model.distance(3, 0), PathViewProxyModel::Next);       // 1
+    EXPECT_EQ(model.distance(1, 0), PathViewProxyModel::Previous);   // -1
+    EXPECT_EQ(model.distance(0, 0), PathViewProxyModel::OutOfRange); // 0x80
+    EXPECT_EQ(model.distance(-1, 0), PathViewProxyModel::Invalid);   // 0x100
+    EXPECT_EQ(model.distance(999, 0), PathViewProxyModel::Invalid);
+}
+
+// 测试 infoFromIndex 合法与越界
+TEST_F(ut_pathviewproxymodel, PrivateInfoFromIndex)
+{
+    ImageSourceModel src;
+    src.setImageFiles(g_pathviewTmpUrls);
+    PathViewProxyModel model(&src);
+    model.resetModel(2, 0);
+
+    auto info = model.infoFromIndex(0, 0);
+    ASSERT_TRUE(!info.isNull());
+    EXPECT_EQ(info->index, 0);
+    EXPECT_FALSE(info->url.isEmpty());
+
+    // 越界返回空
+    auto bad = model.infoFromIndex(999, 0);
+    EXPECT_TRUE(bad.isNull());
+}
+
+// 测试 createPreviousIndexInfo / createNextIndexInfo
+TEST_F(ut_pathviewproxymodel, PrivateCreatePrevNextIndexInfo)
+{
+    ImageSourceModel src;
+    src.setImageFiles(g_pathviewTmpUrls);
+    PathViewProxyModel model(&src);
+    model.resetModel(2, 0);
+
+    auto base = model.infoFromIndex(2, 0);
+    ASSERT_TRUE(!base.isNull());
+
+    auto prev = model.createPreviousIndexInfo(base);
+    EXPECT_FALSE(prev.isNull());  // src1
+    auto next = model.createNextIndexInfo(base);
+    EXPECT_FALSE(next.isNull());  // src3
+
+    // 空入参返回空
+    PathViewProxyModel::IndexInfoPtr nullInfo;
+    EXPECT_TRUE(model.createPreviousIndexInfo(nullInfo).isNull());
+    EXPECT_TRUE(model.createNextIndexInfo(nullInfo).isNull());
+}
+
+// 测试 createPreviousIndexInfo 在边界(index 0)返回空
+TEST_F(ut_pathviewproxymodel, PrivateCreatePrevAtBoundary)
+{
+    ImageSourceModel src;
+    src.setImageFiles(g_pathviewTmpUrls);
+    PathViewProxyModel model(&src);
+    model.resetModel(0, 0);  // current = src0
+
+    auto base = model.infoFromIndex(0, 0);
+    auto prev = model.createPreviousIndexInfo(base);
+    // src0 前面无图片
+    EXPECT_TRUE(prev.isNull());
+}
+
+// 测试 updateIndexInfo 更新并发信号
+TEST_F(ut_pathviewproxymodel, PrivateUpdateIndexInfo)
+{
+    ImageSourceModel src;
+    src.setImageFiles(g_pathviewTmpUrls);
+    PathViewProxyModel model(&src);
+    model.resetModel(2, 0);
+
+    QSignalSpy spy(&model, &PathViewProxyModel::dataChanged);
+    auto info = model.infoFromIndex(4, 0);
+    model.updateIndexInfo(0, info);
+    EXPECT_GE(spy.count(), 1);
+    EXPECT_EQ(model.data(model.index(0), Types::ImageUrlRole).toUrl(), info->url);
+}
+
+// 测试 jumpToIndex 与 refreshBothSideData
+TEST_F(ut_pathviewproxymodel, PrivateJumpAndRefresh)
+{
+    ImageSourceModel src;
+    src.setImageFiles(g_pathviewTmpUrls);
+    PathViewProxyModel model(&src);
+    model.resetModel(2, 0);
+
+    model.jumpToIndex(4, 0);
+    model.refreshBothSideData();
+    SUCCEED();
+}
+
+// 测试 asyncUpdateLoadInfo 不崩溃（frameIndex 0 与非 0）
+TEST_F(ut_pathviewproxymodel, PrivateAsyncUpdateLoadInfo)
+{
+    ImageSourceModel src;
+    src.setImageFiles(g_pathviewTmpUrls);
+    PathViewProxyModel model(&src);
+    model.resetModel(2, 0);
+
+    model.asyncUpdateLoadInfo(g_pathviewTmpUrls.first(), 0, 0);
+    model.asyncUpdateLoadInfo(g_pathviewTmpUrls.first(), 0, 1);  // frameIndex != 0 直接跳过
+    SUCCEED();
+}

--- a/tests/src/ut_pathviewproxymodel.h
+++ b/tests/src/ut_pathviewproxymodel.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef UT_PATHVIEWPROXYMODEL_H
+#define UT_PATHVIEWPROXYMODEL_H
+
+#include <gtest/gtest.h>
+
+class PathViewProxyModel;
+
+class ut_pathviewproxymodel : public testing::Test
+{
+protected:
+    virtual void SetUp() override;
+    virtual void TearDown() override;
+};
+
+#endif  // UT_PATHVIEWPROXYMODEL_H

--- a/tests/src/ut_thumbnailcache.cpp
+++ b/tests/src/ut_thumbnailcache.cpp
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "ut_thumbnailcache.h"
+#include "thumbnailcache.h"
+
+#include <QImage>
+#include <QList>
+
+void ut_thumbnailcache::SetUp()
+{
+}
+
+void ut_thumbnailcache::TearDown()
+{
+}
+
+// 测试默认构造与析构
+TEST_F(ut_thumbnailcache, DefaultConstruct)
+{
+    ThumbnailCache cache;
+    EXPECT_TRUE(cache.keys().isEmpty());
+}
+
+// 测试 instance() 返回同一单例
+TEST_F(ut_thumbnailcache, InstanceReturnsSameSingleton)
+{
+    ThumbnailCache *p1 = ThumbnailCache::instance();
+    ThumbnailCache *p2 = ThumbnailCache::instance();
+    EXPECT_NE(p1, nullptr);
+    EXPECT_EQ(p1, p2);
+}
+
+// 测试 add/contains/get 协同
+TEST_F(ut_thumbnailcache, AddContainsAndGet)
+{
+    ThumbnailCache cache;
+    QImage img(10, 10, QImage::Format_ARGB32);
+    img.fill(Qt::red);
+
+    EXPECT_FALSE(cache.contains("path1"));
+    cache.add("path1", 0, img);
+    EXPECT_TRUE(cache.contains("path1", 0));
+
+    QImage got = cache.get("path1", 0);
+    EXPECT_FALSE(got.isNull());
+    EXPECT_EQ(got.size(), QSize(10, 10));
+}
+
+// 测试 get 未命中返回空图像
+TEST_F(ut_thumbnailcache, GetNonexistentReturnsNull)
+{
+    ThumbnailCache cache;
+    QImage got = cache.get("nonexistent", 0);
+    EXPECT_TRUE(got.isNull());
+}
+
+// 测试不同帧索引独立缓存
+TEST_F(ut_thumbnailcache, FrameIndexIndependence)
+{
+    ThumbnailCache cache;
+    QImage img1(2, 2, QImage::Format_ARGB32);
+    img1.fill(Qt::blue);
+    QImage img2(4, 4, QImage::Format_ARGB32);
+    img2.fill(Qt::green);
+
+    cache.add("file", 0, img1);
+    cache.add("file", 1, img2);
+
+    EXPECT_TRUE(cache.contains("file", 0));
+    EXPECT_TRUE(cache.contains("file", 1));
+    EXPECT_EQ(cache.get("file", 0).size(), QSize(2, 2));
+    EXPECT_EQ(cache.get("file", 1).size(), QSize(4, 4));
+}
+
+// 测试 take 取出后从缓存移除
+TEST_F(ut_thumbnailcache, TakeRemovesEntry)
+{
+    ThumbnailCache cache;
+    QImage img(8, 8, QImage::Format_ARGB32);
+    img.fill(Qt::black);
+
+    cache.add("takepath", 3, img);
+    EXPECT_TRUE(cache.contains("takepath", 3));
+
+    QImage taken = cache.take("takepath", 3);
+    EXPECT_FALSE(taken.isNull());
+    EXPECT_FALSE(cache.contains("takepath", 3));
+}
+
+// 测试 take 未命中返回空图像
+TEST_F(ut_thumbnailcache, TakeNonexistentReturnsNull)
+{
+    ThumbnailCache cache;
+    QImage taken = cache.take("nope", 0);
+    EXPECT_TRUE(taken.isNull());
+}
+
+// 测试 remove
+TEST_F(ut_thumbnailcache, RemoveEntry)
+{
+    ThumbnailCache cache;
+    QImage img(1, 1, QImage::Format_ARGB32);
+    cache.add("rm", 0, img);
+    EXPECT_TRUE(cache.contains("rm", 0));
+
+    cache.remove("rm", 0);
+    EXPECT_FALSE(cache.contains("rm", 0));
+
+    // remove 不存在的项不应崩溃
+    cache.remove("rm", 0);
+}
+
+// 测试 setMaxCost 驱逐策略
+TEST_F(ut_thumbnailcache, SetMaxCostEvictsOldEntries)
+{
+    ThumbnailCache cache;
+    cache.setMaxCost(1);
+
+    QImage img1(3, 3, QImage::Format_ARGB32);
+    QImage img2(5, 5, QImage::Format_ARGB32);
+
+    cache.add("a", 0, img1);
+    EXPECT_TRUE(cache.contains("a", 0));
+
+    // 新插入项(cost=1)超过总容量 1，应驱逐旧项
+    cache.add("b", 0, img2);
+    EXPECT_FALSE(cache.contains("a", 0));
+    EXPECT_TRUE(cache.contains("b", 0));
+}
+
+// 测试 clear 清空全部
+TEST_F(ut_thumbnailcache, ClearAll)
+{
+    ThumbnailCache cache;
+    QImage img(2, 2, QImage::Format_ARGB32);
+    cache.add("c1", 0, img);
+    cache.add("c2", 0, img);
+    EXPECT_EQ(cache.keys().size(), 2);
+
+    cache.clear();
+    EXPECT_TRUE(cache.keys().isEmpty());
+    EXPECT_FALSE(cache.contains("c1", 0));
+}
+
+// 测试 keys 返回所有键
+TEST_F(ut_thumbnailcache, KeysReturnsAllEntries)
+{
+    ThumbnailCache cache;
+    QImage img(1, 1, QImage::Format_ARGB32);
+    cache.add("k1", 0, img);
+    cache.add("k2", 2, img);
+
+    QList<ThumbnailCache::Key> ks = cache.keys();
+    EXPECT_EQ(ks.size(), 2);
+}
+
+// 测试静态 toFindKey 组合路径与帧号
+TEST_F(ut_thumbnailcache, ToFindKeyCombinesPathAndFrame)
+{
+    ThumbnailCache::Key k = ThumbnailCache::toFindKey("abc", 5);
+    EXPECT_EQ(k.first, QString("abc"));
+    EXPECT_EQ(k.second, 5);
+
+    // 默认帧号
+    ThumbnailCache::Key k2 = ThumbnailCache::toFindKey("xyz");
+    EXPECT_EQ(k2.second, 0);
+}

--- a/tests/src/ut_thumbnailcache.h
+++ b/tests/src/ut_thumbnailcache.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef UT_THUMBNAILCACHE_H
+#define UT_THUMBNAILCACHE_H
+
+#include <gtest/gtest.h>
+
+class ThumbnailCache;
+
+class ut_thumbnailcache : public testing::Test
+{
+protected:
+    virtual void SetUp() override;
+    virtual void TearDown() override;
+};
+
+#endif  // UT_THUMBNAILCACHE_H


### PR DESCRIPTION
Add GTest unit tests for ThumbnailCache, PathViewProxyModel, ImageFileWatcher, ImageProvider and ImageSourceModel with full function coverage.

为 imagedata 模块的 5 个类补充 GTest 单元测试，覆盖全部 public 与
protected 函数，共 79 个测试用例。

Log: 补充 imagedata 模块单元测试
Influence: 仅新增 tests/src 下测试文件，Debug 模式生效，不影响 Release 构建.