### PR TITLE
fix(open): validate image paths and keep open state consistent

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 ~ 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -184,9 +184,8 @@ int main(int argc, char *argv[])
     if (!cliParam.isEmpty()) {
         qCDebug(logImageViewer) << "Commandline parameter is not empty, processing initial image.";
         QStringList filePaths = fileControl.getDirImagePath(cliParam);
-        if (!filePaths.isEmpty()) {
+        if (!filePaths.isEmpty() && control.setImageFiles(filePaths, cliParam)) {
             qCDebug(logImageViewer) << "Found image files: " << filePaths.count();
-            control.setImageFiles(filePaths, cliParam);
             fileControl.resetImageFiles(filePaths);
 
             status.setStackPage(Types::ImageViewPage);

--- a/src/qml/MainStack.qml
+++ b/src/qml/MainStack.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -28,7 +28,10 @@ Item {
         } else {
             var sourcePaths = IV.FileControl.getDirImagePath(path);
             if (sourcePaths.length > 0) {
-                IV.GControl.setImageFiles(sourcePaths, path);
+                if (!IV.GControl.setImageFiles(sourcePaths, path)) {
+                    console.warn("Rejected image path not in image list", path);
+                    return;
+                }
                 // 记录当前读取的图片信息
                 IV.FileControl.resetImageFiles(sourcePaths);
                 console.log("Load image info", path);
@@ -100,7 +103,8 @@ Item {
         anchors.fill: parent
 
         onDropped: {
-            if (drop.hasUrls && drop.urls.length !== 0) {
+            if (drop.hasUrls && drop.urls.length !== 0
+                    && IV.FileControl.isImage(drop.urls[0].toString())) {
                 setSourcePath(drop.urls[0]);
             }
         }

--- a/src/src/dbus/applicationadpator.cpp
+++ b/src/src/dbus/applicationadpator.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -20,8 +20,10 @@ ApplicationAdaptor::ApplicationAdaptor(FileControl *controller)
 bool ApplicationAdaptor::openImageFile(const QString &fileName)
 {
     if (fileControl) {
-        QString urlPath = QUrl::fromLocalFile(fileName).toString();
-        if (fileControl->isCanReadable(urlPath)) {
+        const QUrl inputUrl(fileName);
+        const QString localPath = inputUrl.isLocalFile() ? inputUrl.toLocalFile() : fileName;
+        const QString urlPath = QUrl::fromLocalFile(localPath).toString();
+        if (fileControl->isCanReadable(urlPath) && fileControl->isImage(urlPath)) {
             Q_EMIT fileControl->openImageFile(urlPath);
             return true;
         }

--- a/src/src/filecontrol.cpp
+++ b/src/src/filecontrol.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -201,10 +201,12 @@ QString FileControl::getNamePath(const QString &oldPath, const QString &newName)
 bool FileControl::isImage(const QString &path)
 {
     qCDebug(logImageViewer) << "Checking if path is an image:" << path;
+    const QUrl url(path);
+    const QString localPath = url.isLocalFile() ? url.toLocalFile() : path;
     bool bRet = false;
     QMimeDatabase db;
-    QMimeType mt = db.mimeTypeForFile(path, QMimeDatabase::MatchContent);
-    QMimeType mt1 = db.mimeTypeForFile(path, QMimeDatabase::MatchExtension);
+    QMimeType mt = db.mimeTypeForFile(localPath, QMimeDatabase::MatchContent);
+    QMimeType mt1 = db.mimeTypeForFile(localPath, QMimeDatabase::MatchExtension);
     qCDebug(logImageViewer) << "Mime type by content:" << mt.name() << ", by extension:" << mt1.name();
     if (mt.name().startsWith("image/") || mt.name().startsWith("video/x-mng") || mt1.name().startsWith("image/") || mt1.name().startsWith("video/x-mng")) {
         bRet = true;

--- a/src/src/globalcontrol.cpp
+++ b/src/src/globalcontrol.cpp
@@ -339,26 +339,32 @@ void GlobalControl::forceExit()
    @brief 设置打开图片列表 \a filePaths ， 其中 \a openFile 是首个展示的图片路径，
     将更新全局数据源并发送状态变更信号
  */
-void GlobalControl::setImageFiles(const QStringList &filePaths, const QString &openFile)
+bool GlobalControl::setImageFiles(const QStringList &filePaths, const QString &openFile)
 {
     qCDebug(logImageViewer) << "Setting image files, count:" << filePaths.size() << "initial file:" << openFile;
+    if (filePaths.isEmpty()) {
+        qCWarning(logImageViewer) << "Cannot set empty image files.";
+        return false;
+    }
+
+    const int index = filePaths.indexOf(openFile);
+    if (-1 == index) {
+        qCWarning(logImageViewer) << "Open file is not in image files:" << openFile;
+        return false;
+    }
+
     Q_ASSERT(sourceModel);
     // 优先更新数据源
     sourceModel->setImageFiles(QUrl::fromStringList(filePaths));
     qCDebug(logImageViewer) << "Source model image files set.";
 
-    int index = filePaths.indexOf(openFile);
-    if (-1 == index || filePaths.isEmpty()) {
-        index = 0;
-        qCDebug(logImageViewer) << "Using default index 0";
-    }
-
     setIndexAndFrameIndex(index, 0);
 
-    // 更新图像信息，无论变更均更新
-    if (currentImage.source() != openFile) {
-        qCDebug(logImageViewer) << "Updating current image source to:" << openFile;
-        currentImage.setSource(openFile);
+    // 当前图片源必须来自已设置的数据模型，避免传入路径不在列表时状态失配。
+    const QUrl currentSource = sourceModel->data(sourceModel->index(index), Types::ImageUrlRole).toUrl();
+    if (currentImage.source() != currentSource) {
+        qCDebug(logImageViewer) << "Updating current image source to:" << currentSource;
+        currentImage.setSource(currentSource);
     }
     Q_EMIT currentSourceChanged();
     qCDebug(logImageViewer) << "Emitted currentSourceChanged signal.";
@@ -370,6 +376,7 @@ void GlobalControl::setImageFiles(const QStringList &filePaths, const QString &o
     // 更新视图展示模型
     viewSourceModel->resetModel(index, 0);
     qCDebug(logImageViewer) << "Image files set complete";
+    return true;
 }
 
 /**

--- a/src/src/globalcontrol.h
+++ b/src/src/globalcontrol.h
@@ -72,7 +72,7 @@ public:
     Q_INVOKABLE void forceExit();
 
     // 图像文件变更操作
-    Q_SLOT void setImageFiles(const QStringList &imageFiles, const QString &openFile);
+    Q_SLOT bool setImageFiles(const QStringList &imageFiles, const QString &openFile);
     Q_SLOT void removeImage(const QUrl &removeImage);
     Q_SLOT void renameImage(const QUrl &oldName, const QUrl &newName);
 


### PR DESCRIPTION
Validate local paths and file URLs before opening an image.

打开图片前校验本地路径和 file URL。

Log: 修复非图片路径导致的打开状态不一致问题
Influence: DBus、拖拽等入口将拒绝非图片，当前图片源始终与模型一致。

## Summary by Sourcery

Validate image paths before opening them and keep the open state aligned with the underlying image model across all entry points.

Bug Fixes:
- Reject non-image paths across DBus, drag-and-drop and CLI openings to avoid inconsistent open state.

Enhancements:
- Ensure the current image source always comes from the validated image list and make setImageFiles report failures via a boolean return value.

Documentation:
- Update SPDX copyright years across main entry, QML main stack and DBus adaptor files.