### PR TITLE
test(unionimage): add unit tests for unionimage module

### DIFF
--- a/tests/src/ut_baseutils.cpp
+++ b/tests/src/ut_baseutils.cpp
@@ -1,0 +1,243 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "ut_baseutils.h"
+#include "baseutils.h"
+
+#include <QFont>
+#include <QDateTime>
+#include <QTemporaryFile>
+#include <QTemporaryDir>
+#include <QFileInfo>
+#include <QFile>
+#include <QDir>
+#include <QPixmap>
+
+using namespace Libutils::base;
+
+void ut_baseutils::SetUp() {}
+void ut_baseutils::TearDown() {}
+
+// ---------------- hash ----------------
+TEST_F(ut_baseutils, Hash_WhenSameInput_ReturnsSameMd5Hex)
+{
+    const QString h1 = hash("hello");
+    const QString h2 = hash("hello");
+    EXPECT_EQ(h1, h2);
+    EXPECT_FALSE(h1.isEmpty());
+}
+
+TEST_F(ut_baseutils, Hash_WhenDifferentInput_ReturnsDifferentMd5)
+{
+    EXPECT_NE(hash("hello"), hash("world"));
+}
+
+TEST_F(ut_baseutils, Hash_WhenEmptyString_ReturnsMd5OfEmpty)
+{
+    // MD5 of empty string
+    EXPECT_EQ(hash(""), QString("d41d8cd98f00b204e9800998ecf8427e"));
+}
+
+// ---------------- stringWidth / stringHeight ----------------
+TEST_F(ut_baseutils, StringWidth_WhenNonEmptyString_ReturnsPositiveValue)
+{
+    QFont font;
+    const int w = stringWidth(font, "test string");
+    EXPECT_GT(w, 0);
+}
+
+TEST_F(ut_baseutils, StringWidth_WhenEmptyString_ReturnsNonNegative)
+{
+    QFont font;
+    const int w = stringWidth(font, "");
+    EXPECT_GE(w, 0);
+}
+
+TEST_F(ut_baseutils, StringHeight_WhenNonEmptyString_ReturnsPositiveValue)
+{
+    QFont font;
+    const int h = stringHeight(font, "test string");
+    EXPECT_GT(h, 0);
+}
+
+// ---------------- timeToString ----------------
+TEST_F(ut_baseutils, TimeToString_WhenNormalFormat_ReturnsNormalFormattedString)
+{
+    QDateTime dt = QDateTime::fromString("2024.01.15", "yyyy.MM.dd");
+    const QString s = timeToString(dt, true);
+    EXPECT_EQ(s, QString("2024.01.15"));
+}
+
+TEST_F(ut_baseutils, TimeToString_WhenExifFormat_ReturnsExifFormattedString)
+{
+    QDateTime dt = QDateTime::fromString("2024:01:15 10:20:30", "yyyy:MM:dd HH:mm:ss");
+    const QString s = timeToString(dt, false);
+    EXPECT_EQ(s, QString("2024:01:15 10:20:30"));
+}
+
+// ---------------- stringToDateTime ----------------
+TEST_F(ut_baseutils, StringToDateTime_WhenExifFormat_ReturnsValidDateTime)
+{
+    const QDateTime dt = stringToDateTime("2024:01:15 10:20:30");
+    EXPECT_TRUE(dt.isValid());
+    EXPECT_EQ(dt.date().year(), 2024);
+}
+
+TEST_F(ut_baseutils, StringToDateTime_WhenNormalFormat_ReturnsValidDateTime)
+{
+    const QDateTime dt = stringToDateTime("2024.01.15");
+    EXPECT_TRUE(dt.isValid());
+    EXPECT_EQ(dt.date().year(), 2024);
+}
+
+TEST_F(ut_baseutils, StringToDateTime_WhenInvalidString_ReturnsInvalidDateTime)
+{
+    const QDateTime dt = stringToDateTime("not a date");
+    EXPECT_FALSE(dt.isValid());
+}
+
+// ---------------- getFileContent ----------------
+TEST_F(ut_baseutils, GetFileContent_WhenFileReadable_ReturnsContent)
+{
+    QTemporaryFile tmp;
+    tmp.open();
+    tmp.write("hello content");
+    tmp.close();
+    EXPECT_EQ(getFileContent(tmp.fileName()), QString("hello content"));
+}
+
+TEST_F(ut_baseutils, GetFileContent_WhenFileNotReadable_ReturnsEmpty)
+{
+    EXPECT_EQ(getFileContent("/nonexistent/path/file.txt"), QString(""));
+}
+
+// ---------------- SpliteText ----------------
+TEST_F(ut_baseutils, SpliteText_WhenTextFitsLabel_ReturnsOriginalText)
+{
+    QFont font;
+    const int wide = 1000;  // 远大于文本宽度
+    EXPECT_EQ(SpliteText("short", font, wide, false), QString("short"));
+}
+
+TEST_F(ut_baseutils, SpliteText_WhenTextExceedsLabel_ReturnsSplitTextWithNewline)
+{
+    QFont font;
+    const int narrow = 20;  // 比文本窄
+    const QString result = SpliteText("aaaa bbbb", font, narrow, false);
+    EXPECT_TRUE(result.contains("\n"));
+}
+
+TEST_F(ut_baseutils, SpliteText_WhenBReturnTrue_ReplacesSpacesWithNewlines)
+{
+    QFont font;
+    const int narrow = 20;
+    const QString result = SpliteText("aaaa bbbb", font, narrow, true);
+    // 在 bReturn=true 路径中,空格会被替换成换行
+    EXPECT_FALSE(result.contains(' '));
+}
+
+// ---------------- onMountDevice ----------------
+TEST_F(ut_baseutils, OnMountDevice_WhenMediaPath_ReturnsTrue)
+{
+    EXPECT_TRUE(onMountDevice("/media/user/usb/file.png"));
+}
+
+TEST_F(ut_baseutils, OnMountDevice_WhenRunMediaPath_ReturnsTrue)
+{
+    EXPECT_TRUE(onMountDevice("/run/media/user/usb/file.png"));
+}
+
+TEST_F(ut_baseutils, OnMountDevice_WhenHomePath_ReturnsFalse)
+{
+    EXPECT_FALSE(onMountDevice("/home/user/file.png"));
+}
+
+// ---------------- mountDeviceExist ----------------
+TEST_F(ut_baseutils, MountDeviceExist_WhenPathUnderExistingDir_ReturnsTrue)
+{
+    // /media 路径会提取出 mountPoint,这里用一个一定存在的目录模拟
+    // mountPoint 为 "/med" 之类前缀,通常存在
+    // 仅验证函数可被调用且返回 bool
+    bool result = mountDeviceExist("/media/someuser/device/file.png");
+    // 不对结果做强断言(取决于真实环境),只验证不崩溃
+    EXPECT_TRUE(true);
+}
+
+TEST_F(ut_baseutils, MountDeviceExist_WhenNonMediaPath_ReturnsExistenceOfEmptyMountPoint)
+{
+    // 非 /media 与 /run/media 路径,mountPoint 为空,QFileInfo("").exists() == false
+    EXPECT_FALSE(mountDeviceExist("/home/user/file.png"));
+}
+
+// ---------------- renderSVG ----------------
+TEST_F(ut_baseutils, RenderSVG_WhenFileNotReadable_ReturnsNullPixmap)
+{
+    const QPixmap pix = renderSVG("/nonexistent/file.svg", QSize(32, 32));
+    EXPECT_TRUE(pix.isNull());
+}
+
+TEST_F(ut_baseutils, RenderSVG_WhenValidSvg_ReturnsNonNullPixmap)
+{
+    QTemporaryFile tmp("XXXXXX.svg");
+    tmp.open();
+    // 一个最小可被 QImageReader 读取的 SVG
+    tmp.write("<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"10\" height=\"10\"><rect width=\"10\" height=\"10\" fill=\"red\"/></svg>");
+    tmp.close();
+    const QPixmap pix = renderSVG(tmp.fileName(), QSize(16, 16));
+    EXPECT_FALSE(pix.isNull());
+}
+
+// ---------------- showInFileManager ----------------
+TEST_F(ut_baseutils, ShowInFileManager_WhenPathEmpty_ReturnsImmediately)
+{
+    // 覆盖空路径早返回分支,无副作用
+    showInFileManager("");
+    SUCCEED();
+}
+
+TEST_F(ut_baseutils, ShowInFileManager_WhenPathNotExists_ReturnsImmediately)
+{
+    showInFileManager("/nonexistent/path/file.png");
+    SUCCEED();
+}
+
+// ---------------- copyImageToClipboard ----------------
+TEST_F(ut_baseutils, CopyImageToClipboard_WhenSinglePath_SetsClipboardWithoutCrash)
+{
+    // 需要真实临时文件路径(不必存在),验证剪贴板写入路径
+    QTemporaryFile tmp;
+    tmp.open();
+    QStringList paths;
+    paths << tmp.fileName();
+    copyImageToClipboard(paths);
+    SUCCEED();
+}
+
+TEST_F(ut_baseutils, CopyImageToClipboard_WhenMultiplePaths_SetsClipboardWithoutCrash)
+{
+    QStringList paths;
+    paths << "/tmp/a.png"
+          << ""
+          << "/tmp/b.jpg";
+    copyImageToClipboard(paths);
+    SUCCEED();
+}
+
+// ---------------- trashFile ----------------
+TEST_F(ut_baseutils, TrashFile_WhenFileNotExists_ReturnsFalse)
+{
+    EXPECT_FALSE(trashFile("/nonexistent/file_to_trash.png"));
+}
+
+TEST_F(ut_baseutils, TrashFile_WhenFileExists_MovesToTrashAndReturnsTrue)
+{
+    // 创建真实临时文件,删除会污染真实回收站,但这是 trashFile 的契约
+    QTemporaryDir dir;
+    const QString path = dir.path() + "/to_trash.png";
+    QImage img(2, 2, QImage::Format_RGB32);
+    img.fill(Qt::red);
+    ASSERT_TRUE(img.save(path, "PNG"));
+    EXPECT_TRUE(trashFile(path));
+    EXPECT_FALSE(QFileInfo(path).exists());  // 原文件应已被移走
+}

--- a/tests/src/ut_baseutils.h
+++ b/tests/src/ut_baseutils.h
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef UT_BASEUTILS_H
+#define UT_BASEUTILS_H
+
+#include <gtest/gtest.h>
+
+class ut_baseutils : public testing::Test
+{
+protected:
+    virtual void SetUp() override;
+    virtual void TearDown() override;
+};
+
+#endif  // UT_BASEUTILS_H

--- a/tests/src/ut_imageutils.cpp
+++ b/tests/src/ut_imageutils.cpp
@@ -1,0 +1,338 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "ut_imageutils.h"
+#include "imageutils.h"
+#include "unionimage.h"
+
+#include <QImage>
+#include <QPixmap>
+#include <QPixmapCache>
+#include <QTemporaryFile>
+#include <QTemporaryDir>
+#include <QFileInfo>
+#include <QFile>
+#include <QDir>
+#include <QDateTime>
+
+using namespace Libutils::image;
+using LibUnionImage_NameSpace::rotateImageFile;
+
+void ut_imageutils::SetUp() {}
+void ut_imageutils::TearDown() {}
+
+// 辅助:创建一张临时 PNG 并返回路径
+static QString makeTempPng(QTemporaryDir &dir, const QString &name, int w = 4, int h = 4)
+{
+    const QString path = dir.path() + "/" + name;
+    QImage img(w, h, QImage::Format_RGB32);
+    img.fill(Qt::red);
+    img.save(path, "PNG");
+    return path;
+}
+
+// ---------------- imageSupportRead ----------------
+TEST_F(ut_imageutils, ImageSupportRead_WhenCommonExt_ReturnsTrue)
+{
+    EXPECT_TRUE(imageSupportRead("/tmp/foo.png"));
+    EXPECT_TRUE(imageSupportRead("/tmp/foo.jpg"));
+}
+
+TEST_F(ut_imageutils, ImageSupportRead_WhenIcnsExt_ReturnsTrue)
+{
+    EXPECT_TRUE(imageSupportRead("/tmp/foo.icns"));
+}
+
+TEST_F(ut_imageutils, ImageSupportRead_WhenX3FExt_ReturnsFalse)
+{
+    EXPECT_FALSE(imageSupportRead("/tmp/foo.x3f"));
+}
+
+// ---------------- imageSupportSave ----------------
+TEST_F(ut_imageutils, ImageSupportSave_DelegatesToUnionImageCanSave)
+{
+    QTemporaryDir dir;
+    const QString path = makeTempPng(dir, "s.png");
+    EXPECT_TRUE(imageSupportSave(path));
+}
+
+TEST_F(ut_imageutils, ImageSupportSave_WhenUnsupportedExt_ReturnsFalse)
+{
+    EXPECT_FALSE(imageSupportSave("/tmp/foo.zzzunknown"));
+}
+
+// ---------------- rotate ----------------
+TEST_F(ut_imageutils, Rotate_WhenAngleInvalid_ReturnsFalse)
+{
+    QTemporaryDir dir;
+    const QString path = makeTempPng(dir, "r.png");
+    EXPECT_FALSE(rotate(path, 30));
+}
+
+TEST_F(ut_imageutils, Rotate_WhenPngAndAngle90_ReturnsTrue)
+{
+    QTemporaryDir dir;
+    const QString path = makeTempPng(dir, "r.png", 4, 2);
+    EXPECT_TRUE(rotate(path, 90));
+}
+
+// ---------------- cutSquareImage (overload 1) ----------------
+TEST_F(ut_imageutils, CutSquareImage_WhenSingleArg_DelegatesToTwoArgOverload)
+{
+    QPixmap src(10, 6);
+    src.fill(Qt::blue);
+    const QPixmap out = cutSquareImage(src);
+    EXPECT_FALSE(out.isNull());
+}
+
+// ---------------- cutSquareImage (overload 2) ----------------
+TEST_F(ut_imageutils, CutSquareImage_WhenSizeProvided_ReturnsNonNullPixmap)
+{
+    QPixmap src(20, 20);
+    src.fill(Qt::green);
+    const QPixmap out = cutSquareImage(src, QSize(8, 8));
+    EXPECT_FALSE(out.isNull());
+}
+
+// ---------------- getImagesInfo ----------------
+TEST_F(ut_imageutils, GetImagesInfo_WhenNonRecursive_ReturnsFilesInDir)
+{
+    QTemporaryDir dir;
+    makeTempPng(dir, "a.png");
+    makeTempPng(dir, "b.png");
+    const QFileInfoList infos = getImagesInfo(dir.path(), false);
+    EXPECT_EQ(infos.size(), 2);
+}
+
+TEST_F(ut_imageutils, GetImagesInfo_WhenRecursive_ReturnsAllFiles)
+{
+    QTemporaryDir dir;
+    makeTempPng(dir, "a.png");
+    QDir().mkdir(dir.path() + "/sub");
+    QImage img(2, 2, QImage::Format_RGB32);
+    img.save(dir.path() + "/sub/c.png", "PNG");
+    const QFileInfoList infos = getImagesInfo(dir.path(), true);
+    EXPECT_EQ(infos.size(), 2);
+}
+
+// ---------------- getOrientation ----------------
+TEST_F(ut_imageutils, GetOrientation_AlwaysReturnsOne)
+{
+    QTemporaryDir dir;
+    const QString path = makeTempPng(dir, "o.png");
+    EXPECT_EQ(getOrientation(path), 1);
+}
+
+// ---------------- getRotatedImage ----------------
+TEST_F(ut_imageutils, GetRotatedImage_WhenValidPng_ReturnsNonEmptyImage)
+{
+    QTemporaryDir dir;
+    const QString path = makeTempPng(dir, "g.png");
+    const QImage img = getRotatedImage(path);
+    EXPECT_FALSE(img.isNull());
+}
+
+TEST_F(ut_imageutils, GetRotatedImage_WhenFileNotExists_ReturnsNullImage)
+{
+    const QImage img = getRotatedImage("/nonexistent/file.png");
+    EXPECT_TRUE(img.isNull());
+}
+
+// ---------------- scaleImage ----------------
+TEST_F(ut_imageutils, ScaleImage_WhenValidImage_ReturnsScaledImage)
+{
+    QTemporaryDir dir;
+    const QString path = makeTempPng(dir, "sc.png", 100, 100);
+    const QImage out = scaleImage(path, QSize(20, 20));
+    EXPECT_FALSE(out.isNull());
+}
+
+TEST_F(ut_imageutils, ScaleImage_WhenUnsupportedFormat_ReturnsNullImage)
+{
+    const QImage out = scaleImage("/tmp/file.zzzunknown", QSize(20, 20));
+    EXPECT_TRUE(out.isNull());
+}
+
+// ---------------- getCreateDateTime ----------------
+TEST_F(ut_imageutils, GetCreateDateTime_WhenFileExists_ReturnsValidDateTime)
+{
+    QTemporaryDir dir;
+    const QString path = makeTempPng(dir, "d.png");
+    const QDateTime dt = getCreateDateTime(path);
+    EXPECT_TRUE(dt.isValid());
+}
+
+// ---------------- getAllMetaData ----------------
+TEST_F(ut_imageutils, GetAllMetaData_WhenValidPng_ReturnsPopulatedMap)
+{
+    QTemporaryDir dir;
+    const QString path = makeTempPng(dir, "m.png");
+    const QMap<QString, QString> data = getAllMetaData(path);
+    EXPECT_TRUE(data.contains("FileName"));
+    EXPECT_TRUE(data.contains("FileFormat"));
+    EXPECT_EQ(data.value("FileFormat"), QString("png"));
+}
+
+// ---------------- cachePixmap ----------------
+TEST_F(ut_imageutils, CachePixmap_WhenFileExists_ReturnsNonEmptyPixmap)
+{
+    QTemporaryDir dir;
+    const QString path = makeTempPng(dir, "c.png");
+    QPixmapCache::clear();
+    const QPixmap pix = cachePixmap(path);
+    EXPECT_FALSE(pix.isNull());
+}
+
+TEST_F(ut_imageutils, CachePixmap_WhenCalledTwice_SecondFromCache)
+{
+    QTemporaryDir dir;
+    const QString path = makeTempPng(dir, "c2.png");
+    QPixmapCache::clear();
+    const QPixmap p1 = cachePixmap(path);
+    const QPixmap p2 = cachePixmap(path);
+    EXPECT_FALSE(p1.isNull());
+    EXPECT_FALSE(p2.isNull());
+}
+
+// ---------------- thumbnailCachePath ----------------
+TEST_F(ut_imageutils, ThumbnailCachePath_ReturnsPathEndingWithThumbnails)
+{
+    const QString p = thumbnailCachePath();
+    EXPECT_TRUE(p.endsWith("/thumbnails"));
+    EXPECT_TRUE(QFileInfo(p).exists());
+}
+
+// ---------------- thumbnailPath ----------------
+TEST_F(ut_imageutils, ThumbnailPath_WhenThumbNormal_ReturnsNormalSubdir)
+{
+    const QString p = thumbnailPath("/tmp/foo.png", ThumbNormal);
+    EXPECT_TRUE(p.contains("/normal/"));
+    EXPECT_TRUE(p.endsWith(".png"));
+}
+
+TEST_F(ut_imageutils, ThumbnailPath_WhenThumbLarge_ReturnsLargeSubdir)
+{
+    const QString p = thumbnailPath("/tmp/foo.png", ThumbLarge);
+    EXPECT_TRUE(p.contains("/large/"));
+}
+
+TEST_F(ut_imageutils, ThumbnailPath_WhenThumbFail_ReturnsFailSubdir)
+{
+    const QString p = thumbnailPath("/tmp/foo.png", ThumbFail);
+    EXPECT_TRUE(p.contains("/fail/"));
+}
+
+// ---------------- thumbnailExist ----------------
+TEST_F(ut_imageutils, ThumbnailExist_WhenNoCache_ReturnsFalse)
+{
+    // 用一个独特路径,确保缓存不存在
+    EXPECT_FALSE(thumbnailExist("/tmp/definitely_not_existing_unique_path.png", ThumbLarge));
+}
+
+// ---------------- generateThumbnail ----------------
+TEST_F(ut_imageutils, GenerateThumbnail_WhenValidPng_ReturnsTrueAndCreatesCache)
+{
+    QTemporaryDir dir;
+    const QString path = makeTempPng(dir, "thumb.png", 100, 100);
+    EXPECT_TRUE(generateThumbnail(path));
+    EXPECT_TRUE(thumbnailExist(path, ThumbLarge));
+}
+
+// ---------------- getThumbnail ----------------
+TEST_F(ut_imageutils, GetThumbnail_WhenCacheOnlyAndNoCache_ReturnsEmptyPixmap)
+{
+    const QPixmap pix = getThumbnail("/tmp/no_such_file_unique.png", true);
+    EXPECT_TRUE(pix.isNull());
+}
+
+TEST_F(ut_imageutils, GetThumbnail_WhenCacheExists_ReturnsNonEmptyPixmap)
+{
+    QTemporaryDir dir;
+    const QString path = makeTempPng(dir, "gt.png", 100, 100);
+    ASSERT_TRUE(generateThumbnail(path));
+    const QPixmap pix = getThumbnail(path, true);
+    EXPECT_FALSE(pix.isNull());
+}
+
+// ---------------- removeThumbnail ----------------
+TEST_F(ut_imageutils, RemoveThumbnail_WhenCalled_RemovesCacheFiles)
+{
+    QTemporaryDir dir;
+    const QString path = makeTempPng(dir, "rm.png", 100, 100);
+    ASSERT_TRUE(generateThumbnail(path));
+    ASSERT_TRUE(thumbnailExist(path, ThumbLarge));
+    removeThumbnail(path);
+    EXPECT_FALSE(thumbnailExist(path, ThumbLarge));
+}
+
+// ---------------- supportedImageFormats ----------------
+TEST_F(ut_imageutils, SupportedImageFormats_ReturnsNonEmptyListWithGlobPrefix)
+{
+    const QStringList list = supportedImageFormats();
+    EXPECT_FALSE(list.isEmpty());
+    EXPECT_TRUE(list.first().startsWith("*."));
+}
+
+// ---------------- imageSupportWallPaper ----------------
+TEST_F(ut_imageutils, ImageSupportWallPaper_WhenSupportedPng_ReturnsTrue)
+{
+    QTemporaryDir dir;
+    const QString path = makeTempPng(dir, "wp.png");
+    EXPECT_TRUE(imageSupportWallPaper(path));
+}
+
+TEST_F(ut_imageutils, ImageSupportWallPaper_WhenUnsupportedExt_ReturnsFalse)
+{
+    EXPECT_FALSE(imageSupportWallPaper("/tmp/file.zzzunknown"));
+}
+
+// ---------------- makeVaultLocalPath ----------------
+TEST_F(ut_imageutils, MakeVaultLocalPath_WhenBaseProvided_UsesGivenBase)
+{
+    const QString p = makeVaultLocalPath("sub/file.txt", "mybase");
+    EXPECT_TRUE(p.contains("mybase"));
+    EXPECT_TRUE(p.endsWith("sub/file.txt"));
+}
+
+TEST_F(ut_imageutils, MakeVaultLocalPath_WhenBaseEmpty_UsesDefaultBase)
+{
+    const QString p = makeVaultLocalPath("file.txt", "");
+    EXPECT_TRUE(p.contains(VAULT_DECRYPT_DIR_NAME));
+}
+
+TEST_F(ut_imageutils, MakeVaultLocalPath_WhenPathStartsWithSlash_DoesNotDoubleSlash)
+{
+    const QString p = makeVaultLocalPath("/file.txt", "base");
+    EXPECT_FALSE(p.contains("base//file.txt"));
+}
+
+// ---------------- isVaultFile ----------------
+TEST_F(ut_imageutils, IsVaultFile_WhenPathUnderVault_ReturnsTrue)
+{
+    const QString vaultPath = makeVaultLocalPath("file.txt", "");
+    EXPECT_TRUE(isVaultFile(vaultPath));
+}
+
+TEST_F(ut_imageutils, IsVaultFile_WhenRegularPath_ReturnsFalse)
+{
+    EXPECT_FALSE(isVaultFile("/tmp/some_regular_file.png"));
+}
+
+// ---------------- isCanRemove ----------------
+TEST_F(ut_imageutils, IsCanRemove_WhenRegularPath_ReturnsTrue)
+{
+    EXPECT_TRUE(isCanRemove("/tmp/some_regular_file.png"));
+}
+
+TEST_F(ut_imageutils, IsCanRemove_WhenVaultFile_ReturnsFalse)
+{
+    const QString vaultPath = makeVaultLocalPath("file.txt", "");
+    EXPECT_FALSE(isCanRemove(vaultPath));
+}
+
+TEST_F(ut_imageutils, IsCanRemove_WhenTrashPath_ReturnsFalse)
+{
+    const QString trashPath = QDir::homePath() + "/.local/share/Trash/file.png";
+    EXPECT_FALSE(isCanRemove(trashPath));
+}

--- a/tests/src/ut_imageutils.h
+++ b/tests/src/ut_imageutils.h
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef UT_IMAGEUTILS_H
+#define UT_IMAGEUTILS_H
+
+#include <gtest/gtest.h>
+
+class ut_imageutils : public testing::Test
+{
+protected:
+    virtual void SetUp() override;
+    virtual void TearDown() override;
+};
+
+#endif  // UT_IMAGEUTILS_H

--- a/tests/src/ut_unionimage.cpp
+++ b/tests/src/ut_unionimage.cpp
@@ -1,0 +1,421 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "ut_unionimage.h"
+#include "unionimage.h"
+
+#include <QImage>
+#include <QTemporaryFile>
+#include <QTemporaryDir>
+#include <QFileInfo>
+#include <QDir>
+#include <QBuffer>
+
+// 被测代码位于该命名空间
+using namespace LibUnionImage_NameSpace;
+
+void ut_unionimage::SetUp() {}
+void ut_unionimage::TearDown() {}
+
+// ---------------- unionImageVersion ----------------
+TEST_F(ut_unionimage, UnionImageVersion_WhenCalled_ReturnsNonEmptyVersionString)
+{
+    const QString ver = unionImageVersion();
+    EXPECT_FALSE(ver.isEmpty());
+    EXPECT_TRUE(ver.contains("0.0.4"));
+}
+
+// ---------------- unionImageSupportFormat ----------------
+TEST_F(ut_unionimage, UnionImageSupportFormat_WhenCalled_ReturnsNonEmptyListContainingCommonFormats)
+{
+    const QStringList list = unionImageSupportFormat();
+    EXPECT_FALSE(list.isEmpty());
+    EXPECT_TRUE(list.contains("JPG"));
+    EXPECT_TRUE(list.contains("PNG"));
+    EXPECT_TRUE(list.contains("BMP"));
+}
+
+// ---------------- supportStaticFormat ----------------
+TEST_F(ut_unionimage, SupportStaticFormat_WhenCalled_ReturnsSameListAsSupportFormat)
+{
+    const QStringList s = supportStaticFormat();
+    EXPECT_FALSE(s.isEmpty());
+    EXPECT_TRUE(s.contains("PNG"));
+}
+
+// ---------------- supportMovieFormat ----------------
+TEST_F(ut_unionimage, SupportMovieFormat_WhenCalled_ReturnsListMaybeEmpty)
+{
+    // m_movie_formats 在实现中从未被填充，结果应为空 list
+    const QStringList m = supportMovieFormat();
+    EXPECT_TRUE(m.isEmpty());
+}
+
+// ---------------- creatNewImage ----------------
+TEST_F(ut_unionimage, CreatNewImage_WhenDepthIs8_CreatesRgb888Image)
+{
+    QImage img;
+    EXPECT_TRUE(creatNewImage(img, 4, 4, 8));
+    EXPECT_FALSE(img.isNull());
+    EXPECT_EQ(img.width(), 4);
+    EXPECT_EQ(img.height(), 4);
+    EXPECT_EQ(img.format(), QImage::Format_RGB888);
+}
+
+TEST_F(ut_unionimage, CreatNewImage_WhenDepthIs16_CreatesRgb16Image)
+{
+    QImage img;
+    EXPECT_TRUE(creatNewImage(img, 2, 3, 16));
+    EXPECT_FALSE(img.isNull());
+    EXPECT_EQ(img.format(), QImage::Format_RGB16);
+}
+
+TEST_F(ut_unionimage, CreatNewImage_WhenDepthIsOther_CreatesRgb32Image)
+{
+    QImage img;
+    EXPECT_TRUE(creatNewImage(img, 5, 5, 32));
+    EXPECT_FALSE(img.isNull());
+    EXPECT_EQ(img.format(), QImage::Format_RGB32);
+}
+
+TEST_F(ut_unionimage, CreatNewImage_WhenWidthHeightZero_CreatesNullImage)
+{
+    QImage img;
+    // QImage(0,0,...) 构造为空图
+    EXPECT_TRUE(creatNewImage(img, 0, 0, 8));
+    EXPECT_TRUE(img.isNull());
+}
+
+// ---------------- isNoneQImage ----------------
+TEST_F(ut_unionimage, IsNoneQImage_WhenImageIsDefaultConstructed_ReturnsTrue)
+{
+    QImage img;  // 默认构造为 null,与 noneQImage()(同样为 null)相等
+    EXPECT_TRUE(isNoneQImage(img));
+}
+
+TEST_F(ut_unionimage, IsNoneQImage_WhenImageIsValid_ReturnsFalse)
+{
+    QImage img(2, 2, QImage::Format_RGB32);
+    EXPECT_FALSE(isNoneQImage(img));
+}
+
+// ---------------- rotateImage ----------------
+TEST_F(ut_unionimage, RotateImage_WhenAngleNotMultipleOf90_ReturnsFalse)
+{
+    QImage img(2, 2, QImage::Format_RGB32);
+    QImage original = img;
+    EXPECT_FALSE(rotateImage(45, img));
+    EXPECT_EQ(img, original);  // 未被旋转
+}
+
+TEST_F(ut_unionimage, RotateImage_WhenImageIsNull_ReturnsFalse)
+{
+    QImage img;
+    EXPECT_FALSE(rotateImage(90, img));
+}
+
+TEST_F(ut_unionimage, RotateImage_WhenRotate90_SwapsWidthAndHeight)
+{
+    QImage img(4, 2, QImage::Format_RGB32);
+    img.fill(Qt::red);
+    EXPECT_TRUE(rotateImage(90, img));
+    EXPECT_EQ(img.width(), 2);
+    EXPECT_EQ(img.height(), 4);
+}
+
+TEST_F(ut_unionimage, RotateImage_WhenRotate180_KeepsDimensions)
+{
+    QImage img(4, 2, QImage::Format_RGB32);
+    EXPECT_TRUE(rotateImage(180, img));
+    EXPECT_EQ(img.width(), 4);
+    EXPECT_EQ(img.height(), 2);
+}
+
+// ---------------- detectImageFormat ----------------
+TEST_F(ut_unionimage, DetectImageFormat_WhenFileCannotOpen_ReturnsEmpty)
+{
+    EXPECT_EQ(detectImageFormat("/nonexistent/path/file.xyz"), QString(""));
+}
+
+TEST_F(ut_unionimage, DetectImageFormat_WhenPngHeader_ReturnsPNG)
+{
+    QTemporaryFile tmp;
+    tmp.open();
+    // PNG 文件头
+    const QByteArray pngHeader = "\x89PNG\x0d\x0a\x1a\x0a";
+    tmp.write(pngHeader);
+    tmp.close();
+    EXPECT_EQ(detectImageFormat(tmp.fileName()), QString("PNG"));
+}
+
+TEST_F(ut_unionimage, DetectImageFormat_WhenJpgHeader_ReturnsJPG)
+{
+    QTemporaryFile tmp;
+    tmp.open();
+    tmp.write("\xff\xd8\xff\xe0");
+    tmp.close();
+    EXPECT_EQ(detectImageFormat(tmp.fileName()), QString("JPG"));
+}
+
+TEST_F(ut_unionimage, DetectImageFormat_WhenBmpHeader_ReturnsBMP)
+{
+    QTemporaryFile tmp;
+    tmp.open();
+    tmp.write("BM");
+    tmp.close();
+    EXPECT_EQ(detectImageFormat(tmp.fileName()), QString("BMP"));
+}
+
+TEST_F(ut_unionimage, DetectImageFormat_WhenGifHeader_ReturnsGIF)
+{
+    QTemporaryFile tmp;
+    tmp.open();
+    tmp.write("GIF89a");
+    tmp.close();
+    EXPECT_EQ(detectImageFormat(tmp.fileName()), QString("GIF"));
+}
+
+TEST_F(ut_unionimage, DetectImageFormat_WhenUnknownHeader_ReturnsSuffix)
+{
+    // 临时文件后缀为空(默认),结果为空字符串；这里通过指定后缀验证 fallback 路径
+    QTemporaryFile tmp("XXXXXX.PNG");
+    tmp.open();
+    tmp.write("randombytes_not_a_real_image");
+    tmp.close();
+    EXPECT_EQ(detectImageFormat(tmp.fileName()), QString("PNG"));
+}
+
+// ---------------- loadStaticImageFromFile ----------------
+TEST_F(ut_unionimage, LoadStaticImageFromFile_WhenFileEmpty_ReturnsFalse)
+{
+    QTemporaryFile tmp;
+    tmp.open();  // 空文件,大小为 0
+    tmp.close();
+    QImage res;
+    QString err;
+    EXPECT_FALSE(loadStaticImageFromFile(tmp.fileName(), res, err));
+    EXPECT_TRUE(res.isNull());
+    EXPECT_TRUE(err.contains("error file"));
+}
+
+TEST_F(ut_unionimage, LoadStaticImageFromFile_WhenValidPng_ReturnsTrueAndLoadsImage)
+{
+    // 先准备一张有效的 PNG
+    QImage src(3, 3, QImage::Format_RGB32);
+    src.fill(Qt::blue);
+
+    QTemporaryFile tmp("XXXXXX.PNG");
+    tmp.open();
+    src.save(&tmp, "PNG");
+    tmp.close();
+
+    QImage res;
+    QString err;
+    EXPECT_TRUE(loadStaticImageFromFile(tmp.fileName(), res, err));
+    EXPECT_FALSE(res.isNull());
+    EXPECT_EQ(res.width(), 3);
+    EXPECT_EQ(res.height(), 3);
+}
+
+TEST_F(ut_unionimage, LoadStaticImageFromFile_WhenUnsupportedFormat_ReturnsFalse)
+{
+    QTemporaryFile tmp("XXXXXX.ZZUNKNOWN");
+    tmp.open();
+    tmp.write("some bytes here that are not empty");
+    tmp.close();
+    QImage res;
+    QString err;
+    EXPECT_FALSE(loadStaticImageFromFile(tmp.fileName(), res, err));
+}
+
+// ---------------- rotateImageFile ----------------
+TEST_F(ut_unionimage, RotateImageFile_WhenAngleNotMultipleOf90_ReturnsFalse)
+{
+    QString err;
+    EXPECT_FALSE(rotateImageFile(30, "/tmp/foo.png", err));
+    EXPECT_TRUE(err.contains("unsupported angel"));
+}
+
+TEST_F(ut_unionimage, RotateImageFile_WhenPng_RotatesAndSavesSuccessfully)
+{
+    QImage src(4, 2, QImage::Format_RGB32);
+    src.fill(Qt::red);
+
+    QTemporaryDir dir;
+    const QString path = dir.path() + "/rot.png";
+    ASSERT_TRUE(src.save(path, "PNG"));
+
+    QString err;
+    EXPECT_TRUE(rotateImageFile(90, path, err));
+
+    QImage rotated(path);
+    EXPECT_FALSE(rotated.isNull());
+    EXPECT_EQ(rotated.width(), 2);
+    EXPECT_EQ(rotated.height(), 4);
+}
+
+TEST_F(ut_unionimage, RotateImageFile_WhenTargetPathProvided_SavesToTarget)
+{
+    QImage src(4, 2, QImage::Format_RGB32);
+    src.fill(Qt::green);
+
+    QTemporaryDir dir;
+    const QString srcPath = dir.path() + "/src.bmp";
+    const QString tgtPath = dir.path() + "/tgt.bmp";
+    ASSERT_TRUE(src.save(srcPath, "BMP"));
+
+    QString err;
+    EXPECT_TRUE(rotateImageFile(90, srcPath, err, tgtPath));
+    EXPECT_TRUE(QFileInfo(tgtPath).exists());
+}
+
+// ---------------- rotateImageFIleWithImage ----------------
+TEST_F(ut_unionimage, RotateImageFIleWithImage_WhenAngleNotMultipleOf90_ReturnsFalse)
+{
+    QImage img(2, 2, QImage::Format_RGB32);
+    QString err;
+    EXPECT_FALSE(rotateImageFIleWithImage(30, img, "/tmp/foo.png", err));
+}
+
+TEST_F(ut_unionimage, RotateImageFIleWithImage_WhenImageIsNull_ReturnsFalse)
+{
+    QImage img;
+    QString err;
+    EXPECT_FALSE(rotateImageFIleWithImage(90, img, "/tmp/foo.png", err));
+}
+
+TEST_F(ut_unionimage, RotateImageFIleWithImage_WhenUnsupportedFormat_ReturnsFalse)
+{
+    QImage img(2, 2, QImage::Format_RGB32);
+    img.fill(Qt::red);
+
+    QTemporaryFile tmp("XXXXXX.ZZUNKNOWN");
+    tmp.open();
+    tmp.write("dummy");
+    tmp.close();
+
+    QString err;
+    EXPECT_FALSE(rotateImageFIleWithImage(90, img, tmp.fileName(), err));
+}
+
+TEST_F(ut_unionimage, RotateImageFIleWithImage_WhenJpgFile_RotatesAndSaves)
+{
+    QImage src(4, 2, QImage::Format_RGB32);
+    src.fill(Qt::blue);
+
+    QTemporaryDir dir;
+    const QString path = dir.path() + "/r.jpg";
+    ASSERT_TRUE(src.save(path, "JPG"));
+
+    QImage img = src;
+    QString err;
+    EXPECT_TRUE(rotateImageFIleWithImage(90, img, path, err));
+}
+
+// ---------------- getAllMetaData ----------------
+TEST_F(ut_unionimage, GetAllMetaData_WhenValidPng_ReturnsPopulatedMap)
+{
+    QImage src(2, 2, QImage::Format_RGB32);
+    src.fill(Qt::red);
+
+    QTemporaryFile tmp("XXXXXX.PNG");
+    tmp.open();
+    src.save(&tmp, "PNG");
+    tmp.close();
+
+    const QMap<QString, QString> data = getAllMetaData(tmp.fileName());
+    EXPECT_TRUE(data.contains("FileName"));
+    EXPECT_TRUE(data.contains("FileFormat"));
+    EXPECT_EQ(data.value("FileFormat"), QString("PNG"));
+    EXPECT_TRUE(data.contains("FileSize"));
+    EXPECT_TRUE(data.contains("Dimension"));
+}
+
+// ---------------- canSave ----------------
+TEST_F(ut_unionimage, CanSave_WhenPng_ReturnsTrue)
+{
+    QImage src(2, 2, QImage::Format_RGB32);
+    QTemporaryFile tmp("XXXXXX.PNG");
+    tmp.open();
+    src.save(&tmp, "PNG");
+    tmp.close();
+    EXPECT_TRUE(canSave(tmp.fileName()));
+}
+
+TEST_F(ut_unionimage, CanSave_WhenUnsupportedExt_ReturnsFalse)
+{
+    QTemporaryFile tmp("XXXXXX.ZZUNK");
+    tmp.open();
+    tmp.write("x");
+    tmp.close();
+    EXPECT_FALSE(canSave(tmp.fileName()));
+}
+
+// ---------------- isImageSupportRotate ----------------
+TEST_F(ut_unionimage, IsImageSupportRotate_DelegatesToCanSave)
+{
+    QImage src(2, 2, QImage::Format_RGB32);
+    QTemporaryFile tmp("XXXXXX.PNG");
+    tmp.open();
+    src.save(&tmp, "PNG");
+    tmp.close();
+    // isImageSupportRotate 内部直接调用 canSave
+    EXPECT_TRUE(isImageSupportRotate(tmp.fileName()));
+}
+
+// ---------------- getOrientation ----------------
+TEST_F(ut_unionimage, GetOrientation_AlwaysReturnsOne)
+{
+    // 实现固定返回 1,忽略参数
+    EXPECT_EQ(getOrientation("/any/path.png"), 1);
+    EXPECT_EQ(getOrientation(""), 1);
+}
+
+// ---------------- getImageType ----------------
+TEST_F(ut_unionimage, GetImageType_WhenEmptyPath_ReturnsBlank)
+{
+    EXPECT_EQ(getImageType(""), imageViewerSpace::ImageTypeBlank);
+}
+
+TEST_F(ut_unionimage, GetImageType_WhenFileNotExists_ReturnsBlank)
+{
+    EXPECT_EQ(getImageType("/nonexistent/file.png"), imageViewerSpace::ImageTypeBlank);
+}
+
+TEST_F(ut_unionimage, GetImageType_WhenValidPng_ReturnsStatic)
+{
+    QImage src(2, 2, QImage::Format_RGB32);
+    QTemporaryFile tmp("XXXXXX.PNG");
+    tmp.open();
+    src.save(&tmp, "PNG");
+    tmp.close();
+    EXPECT_EQ(getImageType(tmp.fileName()), imageViewerSpace::ImageTypeStatic);
+}
+
+// ---------------- getPathType ----------------
+TEST_F(ut_unionimage, GetPathType_WhenLocalPath_ReturnsLOCAL)
+{
+    EXPECT_EQ(getPathType("/tmp/some_local_file.png"), imageViewerSpace::PathTypeLOCAL);
+}
+
+TEST_F(ut_unionimage, GetPathType_WhenSmbSharePath_ReturnsSMB)
+{
+    EXPECT_EQ(getPathType("smb-share:server=foo/path"), imageViewerSpace::PathTypeSMB);
+}
+
+TEST_F(ut_unionimage, GetPathType_WhenMtpPath_ReturnsMTP)
+{
+    EXPECT_EQ(getPathType("mtp:host=device/file"), imageViewerSpace::PathTypeMTP);
+}
+
+TEST_F(ut_unionimage, GetPathType_WhenGphoto2Path_ReturnsPTP)
+{
+    EXPECT_EQ(getPathType("gphoto2:host=device"), imageViewerSpace::PathTypePTP);
+}
+
+TEST_F(ut_unionimage, GetPathType_WhenTrashPath_ReturnsRecycleBin)
+{
+    const QString trashPath = QDir::homePath() + "/.local/share/Trash/file.png";
+    EXPECT_EQ(getPathType(trashPath), imageViewerSpace::PathTypeRECYCLEBIN);
+}

--- a/tests/src/ut_unionimage.h
+++ b/tests/src/ut_unionimage.h
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef UT_UNIONIMAGE_H
+#define UT_UNIONIMAGE_H
+
+#include <gtest/gtest.h>
+
+class ut_unionimage : public testing::Test
+{
+protected:
+    virtual void SetUp() override;
+    virtual void TearDown() override;
+};
+
+#endif  // UT_UNIONIMAGE_H


### PR DESCRIPTION
Add GTest unit tests for LibUnionImage_NameSpace, Libutils::base and Libutils::image namespaces with full function coverage.

为 unionimage 模块的 3 个源文件补充 GTest 单元测试，覆盖
LibUnionImage_NameSpace、Libutils::base、Libutils::image 命名空间下 全部已实现函数，共 112 个测试用例。

Log: 补充 unionimage 模块单元测试
Influence: 仅新增 tests/src 下测试文件，Debug 模式生效，不影响 Release 构建.