### PR TITLE
test(utils): add unit tests for utils module

### DIFF
--- a/tests/src/ut_eventlogutils.cpp
+++ b/tests/src/ut_eventlogutils.cpp
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "ut_eventlogutils.h"
+#include "eventlogutils.h"
+
+#include <QJsonObject>
+#include <QJsonDocument>
+#include <string>
+
+void ut_eventlogutils::SetUp() {}
+void ut_eventlogutils::TearDown() {}
+
+// 测试 GetInstance 返回非空单例
+TEST_F(ut_eventlogutils, GetInstance_ReturnsNonNull)
+{
+    Eventlogutils *inst = Eventlogutils::GetInstance();
+    EXPECT_NE(inst, nullptr);
+}
+
+// 测试 GetInstance 多次调用返回同一实例
+TEST_F(ut_eventlogutils, GetInstance_ReturnsSameSingleton)
+{
+    Eventlogutils *inst1 = Eventlogutils::GetInstance();
+    Eventlogutils *inst2 = Eventlogutils::GetInstance();
+    EXPECT_EQ(inst1, inst2);
+}
+
+// 测试 writeLogs 在 writeEventLogFunc 为空(库未加载)时不崩溃
+TEST_F(ut_eventlogutils, WriteLogs_WithNullFuncPtr_NoCrash)
+{
+    Eventlogutils *inst = Eventlogutils::GetInstance();
+    // 测试环境下 libdeepin-event-log.so 通常不存在，函数指针为 null
+    QJsonObject data;
+    data["tid"] = QString::number(Eventlogutils::StartUp);
+    inst->writeLogs(data);
+    SUCCEED();
+}
+
+// 测试 writeLogs 在设置 writeEventLogFunc 后调用该函数
+TEST_F(ut_eventlogutils, WriteLogs_WithFuncPtrSet_FuncCalled)
+{
+    Eventlogutils *inst = Eventlogutils::GetInstance();
+
+    static bool stubCalled = false;
+    static std::string capturedData;
+    stubCalled = false;
+    capturedData.clear();
+
+    // 桩函数（非捕获 lambda 可转换为函数指针）
+    auto stubFunc = +[](const std::string &data) {
+        stubCalled = true;
+        capturedData = data;
+    };
+
+    // 保存原值，借助 -fno-access-control 访问私有成员
+    auto orig = inst->writeEventLogFunc;
+    inst->writeEventLogFunc = stubFunc;
+
+    QJsonObject data;
+    data["tid"] = QString::number(Eventlogutils::Quit);
+    data["msg"] = QStringLiteral("ut_test_message");
+    inst->writeLogs(data);
+
+    EXPECT_TRUE(stubCalled);
+    EXPECT_FALSE(capturedData.empty());
+    // 验证传递的是 JSON 紧凑格式
+    EXPECT_NE(capturedData.find("ut_test_message"), std::string::npos);
+
+    // 恢复原值
+    inst->writeEventLogFunc = orig;
+}
+
+// 测试 writeLogs 传递空 JSON 对象不崩溃
+TEST_F(ut_eventlogutils, WriteLogs_EmptyJson_NoCrash)
+{
+    Eventlogutils *inst = Eventlogutils::GetInstance();
+    QJsonObject empty;
+    inst->writeLogs(empty);
+    SUCCEED();
+}

--- a/tests/src/ut_eventlogutils.h
+++ b/tests/src/ut_eventlogutils.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef UT_EVENTLOGUTILS_H
+#define UT_EVENTLOGUTILS_H
+
+#include <gtest/gtest.h>
+
+class Eventlogutils;
+
+class ut_eventlogutils : public testing::Test
+{
+protected:
+    virtual void SetUp() override;
+    virtual void TearDown() override;
+};
+
+#endif  // UT_EVENTLOGUTILS_H

--- a/tests/src/ut_filetrashhelper.cpp
+++ b/tests/src/ut_filetrashhelper.cpp
@@ -1,0 +1,288 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "ut_filetrashhelper.h"
+#include "filetrashhelper.h"
+#include "unionimage/baseutils.h"
+
+#include <QUrl>
+#include <QFile>
+#include <QDir>
+#include <QFileInfo>
+#include <QTemporaryFile>
+
+#include "stub.h"
+
+// 与 filetrashhelper.cpp 中的 DeletionResult 枚举值保持一致
+// kTrashTimeout = 0, kTrashInterfaceError = 1, kTrashInvalidUrl = 2, kTrashSuccess = 3
+static const int kUtTrashTimeout = 0;
+static const int kUtTrashInterfaceError = 1;
+static const int kUtTrashInvalidUrl = 2;
+static const int kUtTrashSuccess = 3;
+
+void ut_filetrashhelper::SetUp() {}
+void ut_filetrashhelper::TearDown() {}
+
+// ==================== 构造函数 ====================
+
+// 测试构造函数初始化 DBus 设备管理接口
+TEST_F(ut_filetrashhelper, Constructor_InitializesDeviceManager)
+{
+    FileTrashHelper helper;
+    // m_dfmDeviceManager 在构造函数中通过 reset() 创建
+    EXPECT_NE(helper.m_dfmDeviceManager.data(), nullptr);
+}
+
+// ==================== removeFile ====================
+
+// 测试删除不存在的文件返回 false
+TEST_F(ut_filetrashhelper, RemoveFile_NonExistentFile_ReturnsFalse)
+{
+    FileTrashHelper helper;
+    QUrl url = QUrl::fromLocalFile("/tmp/ut_nonexistent_file_12345_not_exist.png");
+    EXPECT_FALSE(helper.removeFile(url));
+}
+
+// 测试删除存在的文件返回 true 且文件被删除
+TEST_F(ut_filetrashhelper, RemoveFile_ExistingFile_ReturnsTrue)
+{
+    QTemporaryFile tmpFile;
+    ASSERT_TRUE(tmpFile.open());
+    tmpFile.write("test content");
+    tmpFile.close();
+    QString path = tmpFile.fileName();
+    ASSERT_TRUE(QFileInfo::exists(path));
+
+    FileTrashHelper helper;
+    QUrl url = QUrl::fromLocalFile(path);
+    EXPECT_TRUE(helper.removeFile(url));
+    EXPECT_FALSE(QFileInfo::exists(path));
+}
+
+// ==================== resetMountInfo ====================
+
+// 测试 resetMountInfo 清空挂载数据
+TEST_F(ut_filetrashhelper, ResetMountInfo_ClearsState)
+{
+    FileTrashHelper helper;
+    // 借助 -fno-access-control 访问私有成员
+    helper.initData = true;
+    helper.mountDevices.insert("dev1", "/mnt/usb1");
+    helper.mountDevices.insert("dev2", "/mnt/usb2");
+
+    helper.resetMountInfo();
+
+    EXPECT_FALSE(helper.initData);
+    EXPECT_TRUE(helper.mountDevices.isEmpty());
+}
+
+// ==================== isGvfsFile (private, const) ====================
+
+// 测试无效 URL 返回 false
+TEST_F(ut_filetrashhelper, IsGvfsFile_InvalidUrl_ReturnsFalse)
+{
+    FileTrashHelper helper;
+    QUrl invalidUrl;
+    EXPECT_FALSE(helper.isGvfsFile(invalidUrl));
+}
+
+// 测试普通本地路径返回 false
+TEST_F(ut_filetrashhelper, IsGvfsFile_NormalPath_ReturnsFalse)
+{
+    FileTrashHelper helper;
+    EXPECT_FALSE(helper.isGvfsFile(QUrl::fromLocalFile("/tmp/test.png")));
+    EXPECT_FALSE(helper.isGvfsFile(QUrl::fromLocalFile("/home/user/image.jpg")));
+}
+
+// 测试 /run/user/<uid>/gvfs/ 路径返回 true
+TEST_F(ut_filetrashhelper, IsGvfsFile_RunUserGvfsPath_ReturnsTrue)
+{
+    FileTrashHelper helper;
+    QUrl url = QUrl::fromLocalFile("/run/user/1000/gvfs/smb:test/file.png");
+    EXPECT_TRUE(helper.isGvfsFile(url));
+}
+
+// 测试 /root/.gvfs/ 路径返回 true
+TEST_F(ut_filetrashhelper, IsGvfsFile_RootGvfsPath_ReturnsTrue)
+{
+    FileTrashHelper helper;
+    QUrl url = QUrl::fromLocalFile("/root/.gvfs/test/file.png");
+    EXPECT_TRUE(helper.isGvfsFile(url));
+}
+
+// 测试 /media/.../smbmounts 路径返回 true
+TEST_F(ut_filetrashhelper, IsGvfsFile_SmbMountsPath_ReturnsTrue)
+{
+    FileTrashHelper helper;
+    QUrl url = QUrl::fromLocalFile("/media/smb/smbmounts/share/file.png");
+    EXPECT_TRUE(helper.isGvfsFile(url));
+}
+
+// ==================== isExternalDevice (private) ====================
+
+// 测试无挂载设备时返回 false
+TEST_F(ut_filetrashhelper, IsExternalDevice_NoMounts_ReturnsFalse)
+{
+    FileTrashHelper helper;
+    helper.mountDevices.clear();
+    EXPECT_FALSE(helper.isExternalDevice("/mnt/usb/file.png"));
+}
+
+// 测试路径匹配外部设备时返回 true
+TEST_F(ut_filetrashhelper, IsExternalDevice_PathOnExternal_ReturnsTrue)
+{
+    FileTrashHelper helper;
+    helper.mountDevices.clear();
+    helper.mountDevices.insert("dev1", "/mnt/usb");
+    EXPECT_TRUE(helper.isExternalDevice("/mnt/usb/file.png"));
+    EXPECT_TRUE(helper.isExternalDevice("/mnt/usb/subdir/deep/file.png"));
+}
+
+// 测试路径不匹配任何外部设备时返回 false
+TEST_F(ut_filetrashhelper, IsExternalDevice_PathNotOnExternal_ReturnsFalse)
+{
+    FileTrashHelper helper;
+    helper.mountDevices.clear();
+    helper.mountDevices.insert("dev1", "/mnt/usb");
+    EXPECT_FALSE(helper.isExternalDevice("/home/user/file.png"));
+    EXPECT_FALSE(helper.isExternalDevice("/mnt/other/file.png"));
+}
+
+// ==================== queryMountInfo (private) ====================
+
+// 测试 initData 为 true 时不调用 DBus（提前返回）
+TEST_F(ut_filetrashhelper, QueryMountInfo_AlreadyInitialized_NoDBusCall)
+{
+    FileTrashHelper helper;
+    helper.initData = true;
+    helper.queryMountInfo();
+    EXPECT_TRUE(helper.initData);
+}
+
+// 测试 initData 为 false 时调用 DBus（测试环境 DBus 不可用，不应崩溃）
+TEST_F(ut_filetrashhelper, QueryMountInfo_DBusFails_NoCrash)
+{
+    FileTrashHelper helper;
+    helper.initData = false;
+    helper.queryMountInfo();
+    // 无论 DBus 是否成功，initData 都应被设为 true
+    EXPECT_TRUE(helper.initData);
+}
+
+// ==================== fileCanTrash ====================
+
+// 测试 GVFS 路径不可回收（提前返回 false，不触发 DBus 查询）
+TEST_F(ut_filetrashhelper, FileCanTrash_GvfsPath_ReturnsFalse)
+{
+    FileTrashHelper helper;
+    QUrl url = QUrl::fromLocalFile("/run/user/1000/gvfs/smb:test/file.png");
+    EXPECT_FALSE(helper.fileCanTrash(url));
+}
+
+// 测试普通本地路径可回收
+TEST_F(ut_filetrashhelper, FileCanTrash_NormalLocalPath_ReturnsTrue)
+{
+    FileTrashHelper helper;
+    QTemporaryFile tmpFile;
+    ASSERT_TRUE(tmpFile.open());
+    tmpFile.close();
+
+    QUrl url = QUrl::fromLocalFile(tmpFile.fileName());
+    // 本地路径，非外部设备，非 GVFS → 可回收
+    EXPECT_TRUE(helper.fileCanTrash(url));
+}
+
+// 测试同一目录连续调用不重复重置挂载信息
+TEST_F(ut_filetrashhelper, FileCanTrash_SameDirNotResetMountInfo)
+{
+    FileTrashHelper helper;
+    QTemporaryFile tmpFile;
+    ASSERT_TRUE(tmpFile.open());
+    tmpFile.close();
+    QUrl url = QUrl::fromLocalFile(tmpFile.fileName());
+
+    // 第一次调用：lastDir 与 currentDir 不同，会触发 resetMountInfo
+    helper.fileCanTrash(url);
+    QDir firstDir = helper.lastDir;
+
+    // 第二次调用同一目录：lastDir 与 currentDir 相同，不重置
+    helper.fileCanTrash(url);
+    EXPECT_EQ(helper.lastDir, firstDir);
+}
+
+// ==================== moveFileToTrashWithDBus (private) ====================
+
+// 测试无效 URL 返回 kTrashInvalidUrl（提前返回，不触发 DBus）
+TEST_F(ut_filetrashhelper, MoveFileToTrashWithDBus_InvalidUrl_ReturnsInvalidUrlError)
+{
+    FileTrashHelper helper;
+    QUrl invalidUrl;
+    int ret = helper.moveFileToTrashWithDBus(invalidUrl);
+    EXPECT_EQ(ret, kUtTrashInvalidUrl);
+}
+
+// ==================== moveFileToTrash ====================
+
+// 桩：moveFileToTrashWithDBus 返回可配置的值
+static int g_ut_stubMoveDBusRet = kUtTrashSuccess;
+static int ut_stub_moveFileToTrashWithDBus(FileTrashHelper *, const QUrl &)
+{
+    return g_ut_stubMoveDBusRet;
+}
+
+// 测试 DBus 调用成功时 moveFileToTrash 返回 true
+TEST_F(ut_filetrashhelper, MoveFileToTrash_DBusSuccess_ReturnsTrue)
+{
+    FileTrashHelper helper;
+    Stub stub;
+    g_ut_stubMoveDBusRet = kUtTrashSuccess;
+    stub.set(ADDR(FileTrashHelper, moveFileToTrashWithDBus), ut_stub_moveFileToTrashWithDBus);
+
+    QUrl url = QUrl::fromLocalFile("/tmp/ut_filetrashhelper_test.png");
+    EXPECT_TRUE(helper.moveFileToTrash(url));
+}
+
+// 测试 DBus 接口失败且回退接口(trashFile)也失败时返回 false
+TEST_F(ut_filetrashhelper, MoveFileToTrash_DBusErrorAndFallbackFails_ReturnsFalse)
+{
+    FileTrashHelper helper;
+    Stub stub;
+    g_ut_stubMoveDBusRet = kUtTrashInterfaceError;
+    stub.set(ADDR(FileTrashHelper, moveFileToTrashWithDBus), ut_stub_moveFileToTrashWithDBus);
+
+    // 不存在的文件，trashFile 会失败
+    QUrl url = QUrl::fromLocalFile("/tmp/ut_filetrashhelper_nonexistent_12345.png");
+    EXPECT_FALSE(helper.moveFileToTrash(url));
+}
+
+// 桩：trashFile 返回 true
+static bool ut_stub_trashFile_success(const QString &)
+{
+    return true;
+}
+
+// 测试 DBus 接口失败但回退接口(trashFile)成功时返回 true
+TEST_F(ut_filetrashhelper, MoveFileToTrash_DBusErrorAndFallbackSucceeds_ReturnsTrue)
+{
+    FileTrashHelper helper;
+    Stub stub;
+    g_ut_stubMoveDBusRet = kUtTrashInterfaceError;
+    stub.set(ADDR(FileTrashHelper, moveFileToTrashWithDBus), ut_stub_moveFileToTrashWithDBus);
+    stub.set(Libutils::base::trashFile, ut_stub_trashFile_success);
+
+    QUrl url = QUrl::fromLocalFile("/tmp/ut_filetrashhelper_fallback_test.png");
+    EXPECT_TRUE(helper.moveFileToTrash(url));
+}
+
+// 测试 DBus 返回 kTrashInvalidUrl（非 InterfaceError 非 Success）时返回 false
+TEST_F(ut_filetrashhelper, MoveFileToTrash_DBusInvalidUrl_ReturnsFalse)
+{
+    FileTrashHelper helper;
+    Stub stub;
+    g_ut_stubMoveDBusRet = kUtTrashInvalidUrl;
+    stub.set(ADDR(FileTrashHelper, moveFileToTrashWithDBus), ut_stub_moveFileToTrashWithDBus);
+
+    QUrl url = QUrl::fromLocalFile("/tmp/ut_filetrashhelper_invalidurl_test.png");
+    EXPECT_FALSE(helper.moveFileToTrash(url));
+}

--- a/tests/src/ut_filetrashhelper.h
+++ b/tests/src/ut_filetrashhelper.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef UT_FILETRASHHELPER_H
+#define UT_FILETRASHHELPER_H
+
+#include <gtest/gtest.h>
+
+class FileTrashHelper;
+
+class ut_filetrashhelper : public testing::Test
+{
+protected:
+    virtual void SetUp() override;
+    virtual void TearDown() override;
+};
+
+#endif  // UT_FILETRASHHELPER_H

--- a/tests/src/ut_rotateimagehelper.cpp
+++ b/tests/src/ut_rotateimagehelper.cpp
@@ -1,0 +1,233 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "ut_rotateimagehelper.h"
+#include "rotateimagehelper.h"
+
+#include <QImage>
+#include <QFile>
+#include <QDir>
+#include <QFileInfo>
+#include <QTemporaryFile>
+#include <QTemporaryDir>
+#include <QSignalSpy>
+#include <QTest>
+
+void ut_rotateimagehelper::SetUp()
+{
+    // 重置单例旋转状态，保证用例间隔离
+    RotateImageHelper::instance()->resetRotateState();
+}
+
+void ut_rotateimagehelper::TearDown() {}
+
+// ==================== instance() ====================
+
+// 测试 instance() 返回非空单例
+TEST_F(ut_rotateimagehelper, Instance_ReturnsNonNull)
+{
+    RotateImageHelper *inst = RotateImageHelper::instance();
+    EXPECT_NE(inst, nullptr);
+}
+
+// 测试 instance() 多次调用返回同一单例
+TEST_F(ut_rotateimagehelper, Instance_ReturnsSameSingleton)
+{
+    RotateImageHelper *inst1 = RotateImageHelper::instance();
+    RotateImageHelper *inst2 = RotateImageHelper::instance();
+    EXPECT_EQ(inst1, inst2);
+}
+
+// ==================== rotateImageFile ====================
+
+// 测试 0 度旋转被跳过（提前返回）
+TEST_F(ut_rotateimagehelper, RotateImageFile_ZeroAngle_ReturnsEarly)
+{
+    RotateImageHelper::instance()->rotateImageFile("/tmp/ut_rotate_zero.png", 0);
+    SUCCEED();
+}
+
+// 测试 360 度等同于 0 度，被跳过
+TEST_F(ut_rotateimagehelper, RotateImageFile_FullRotation_ReturnsEarly)
+{
+    RotateImageHelper::instance()->rotateImageFile("/tmp/ut_rotate_360.png", 360);
+    SUCCEED();
+}
+
+// 测试对真实文件执行旋转，最终发送 rotateImageFinished 信号
+TEST_F(ut_rotateimagehelper, RotateImageFile_RealFile_EmitsFinishedSignal)
+{
+    // 准备临时图片文件
+    QTemporaryDir tmpDir;
+    ASSERT_TRUE(tmpDir.isValid());
+    QString srcPath = tmpDir.filePath("rotate_src.png");
+    QImage img(4, 4, QImage::Format_ARGB32);
+    img.fill(Qt::red);
+    ASSERT_TRUE(img.save(srcPath, "PNG"));
+
+    QSignalSpy spy(RotateImageHelper::instance(), &RotateImageHelper::rotateImageFinished);
+
+    RotateImageHelper::instance()->rotateImageFile(srcPath, 90);
+
+    // 等待异步任务完成（最多 3 秒）
+    ASSERT_TRUE(spy.wait(3000));
+    ASSERT_GE(spy.count(), 1);
+
+    // 验证信号参数：path 和 ret
+    QList<QVariant> args = spy.takeFirst();
+    EXPECT_EQ(args.at(0).toString(), srcPath);
+    EXPECT_TRUE(args.at(1).toBool());
+}
+
+// ==================== resetRotateState ====================
+
+// 测试在单例上调用 resetRotateState 不崩溃
+TEST_F(ut_rotateimagehelper, ResetRotateState_OnSingleton_NoCrash)
+{
+    RotateImageHelper::instance()->resetRotateState();
+    SUCCEED();
+}
+
+// 测试 data 为 null 时调用 resetRotateState 不崩溃（借助 -fno-access-control 构造私有构造函数）
+TEST_F(ut_rotateimagehelper, ResetRotateState_NullData_NoCrash)
+{
+    // 直接构造新实例（构造函数私有，-fno-access-control 允许访问）
+    RotateImageHelper *fresh = new RotateImageHelper();
+    // data 此时为 null
+    fresh->resetRotateState();
+    delete fresh;
+    SUCCEED();
+}
+
+// 测试 data 已初始化时调用 resetRotateState 不崩溃
+// (RotateImageHelperData 在 .cpp 中定义，无法直接访问其成员，
+//  此处验证 watcher 未运行时 resetRotateState 的 cacheDir.remove() 分支)
+TEST_F(ut_rotateimagehelper, ResetRotateState_WithDataInitialized_NoCrash)
+{
+    RotateImageHelper *fresh = new RotateImageHelper();
+    fresh->checkDataValid();
+    fresh->resetRotateState();  // watcher 未运行，触发 cacheDir.remove() 分支
+    delete fresh;
+    SUCCEED();
+}
+
+// ==================== rotateImageImpl (static) ====================
+
+// 测试源文件不存在时 rotateImageImpl 返回 false（copy 失败）
+TEST_F(ut_rotateimagehelper, RotateImageImpl_NonExistentSource_ReturnsFalse)
+{
+    QTemporaryDir tmpDir;
+    ASSERT_TRUE(tmpDir.isValid());
+    QString cachePath = tmpDir.filePath("nonexistent_cache.png");
+    QString sourcePath = tmpDir.filePath("nonexistent_source.png");
+    QFile::remove(cachePath);
+    QFile::remove(sourcePath);
+    ASSERT_FALSE(QFileInfo::exists(sourcePath));
+
+    bool ret = RotateImageHelper::rotateImageImpl(cachePath, sourcePath, 90);
+    EXPECT_FALSE(ret);
+}
+
+// 测试对真实文件旋转成功
+TEST_F(ut_rotateimagehelper, RotateImageImpl_ValidFile_ReturnsTrue)
+{
+    QTemporaryDir tmpDir;
+    ASSERT_TRUE(tmpDir.isValid());
+    QString sourcePath = tmpDir.filePath("valid_source.png");
+    QString cachePath = tmpDir.filePath("valid_cache.png");
+    QImage img(4, 4, QImage::Format_ARGB32);
+    img.fill(Qt::blue);
+    ASSERT_TRUE(img.save(sourcePath, "PNG"));
+    QFile::remove(cachePath);
+    ASSERT_FALSE(QFileInfo::exists(cachePath));
+
+    QSignalSpy spy(RotateImageHelper::instance(), &RotateImageHelper::rotateImageFinished);
+
+    bool ret = RotateImageHelper::rotateImageImpl(cachePath, sourcePath, 90);
+    EXPECT_TRUE(ret);
+
+    // 等待 queued 信号送达（rotateImageImpl 发射 3 个信号）
+    spy.wait(500);
+}
+
+// 测试 cachePath 已存在时跳过拷贝直接旋转
+TEST_F(ut_rotateimagehelper, RotateImageImpl_CacheExists_SkipsCopy)
+{
+    QTemporaryDir tmpDir;
+    ASSERT_TRUE(tmpDir.isValid());
+    QString sourcePath = tmpDir.filePath("skip_copy_source.png");
+    QString cachePath = tmpDir.filePath("skip_copy_cache.png");
+
+    // 同时创建 source 和 cache
+    QImage img(4, 4, QImage::Format_ARGB32);
+    img.fill(Qt::green);
+    ASSERT_TRUE(img.save(sourcePath, "PNG"));
+    ASSERT_TRUE(img.save(cachePath, "PNG"));
+    ASSERT_TRUE(QFileInfo::exists(cachePath));
+
+    QSignalSpy spy(RotateImageHelper::instance(), &RotateImageHelper::rotateImageFinished);
+
+    bool ret = RotateImageHelper::rotateImageImpl(cachePath, sourcePath, 90);
+    EXPECT_TRUE(ret);
+
+    spy.wait(500);
+}
+
+// ==================== checkDataValid (private) ====================
+
+// 测试 checkDataValid 在新实例上创建 data
+TEST_F(ut_rotateimagehelper, CheckDataValid_NewInstance_CreatesData)
+{
+    RotateImageHelper *fresh = new RotateImageHelper();
+    EXPECT_EQ(fresh->data.data(), nullptr);
+
+    fresh->checkDataValid();
+
+    // data 指针应为非空（RotateImageHelperData 为不完整类型，仅比较指针）
+    EXPECT_NE(fresh->data.data(), nullptr);
+    delete fresh;
+}
+
+// 测试 checkDataValid 在已初始化实例上不重复创建
+TEST_F(ut_rotateimagehelper, CheckDataValid_AlreadyValid_NoDuplicateCreation)
+{
+    RotateImageHelper *fresh = new RotateImageHelper();
+    fresh->checkDataValid();
+    auto dataPtr = fresh->data.data();
+
+    fresh->checkDataValid();
+    // 指针应未变（未重新创建）
+    EXPECT_EQ(fresh->data.data(), dataPtr);
+    delete fresh;
+}
+
+// ==================== enqueueRotateTask (private) ====================
+
+// 测试 enqueueRotateTask 将任务加入队列并异步处理
+TEST_F(ut_rotateimagehelper, EnqueueRotateTask_QueuesAndProcesses)
+{
+    RotateImageHelper *fresh = new RotateImageHelper();
+    fresh->checkDataValid();
+
+    QTemporaryDir tmpDir;
+    ASSERT_TRUE(tmpDir.isValid());
+    QString srcPath = tmpDir.filePath("enqueue_test.png");
+    QImage img(2, 2, QImage::Format_ARGB32);
+    img.fill(Qt::yellow);
+    ASSERT_TRUE(img.save(srcPath, "PNG"));
+
+    QSignalSpy spy(RotateImageHelper::instance(), &RotateImageHelper::rotateImageFinished);
+
+    fresh->enqueueRotateTask(srcPath, 90);
+
+    // 等待 rotateImageFinished 信号（由 rotateImageImpl 在子线程中发射）
+    ASSERT_TRUE(spy.wait(3000));
+    EXPECT_GE(spy.count(), 1);
+
+    // 给后台任务额外时间完成循环退出（无法直接访问 RotateImageHelperData::watcher）
+    QTest::qSleep(200);
+
+    delete fresh;
+    SUCCEED();
+}

--- a/tests/src/ut_rotateimagehelper.h
+++ b/tests/src/ut_rotateimagehelper.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef UT_ROTATEIMAGEHELPER_H
+#define UT_ROTATEIMAGEHELPER_H
+
+#include <gtest/gtest.h>
+
+class RotateImageHelper;
+
+class ut_rotateimagehelper : public testing::Test
+{
+protected:
+    virtual void SetUp() override;
+    virtual void TearDown() override;
+};
+
+#endif  // UT_ROTATEIMAGEHELPER_H


### PR DESCRIPTION
Add GTest unit tests for Eventlogutils, FileTrashHelper and RotateImageHelper with full function coverage.

为 utils 模块的 3 个类补充 GTest 单元测试，覆盖全部 public 与
private 函数，共 41 个测试用例。

Log: 补充 utils 模块单元测试
Influence: 仅新增 tests/src 下测试文件，Debug 模式生效，不影响 Release 构建.