### PR TITLE
fix(open): add new images to the current directory model

### DIFF
--- a/src/qml/MainStack.qml
+++ b/src/qml/MainStack.qml
@@ -23,8 +23,14 @@ Item {
     // 设置当前使用的图片源
     function setSourcePath(path) {
         if (IV.FileControl.isCurrentWatcherDir(path)) {
-            // 更新当前文件路径
-            IV.GControl.currentSource = path;
+            if (IV.GControl.globalModel.indexForImagePath(path) === -1) {
+                if (IV.GControl.addImageAndSetCurrentSource(path)) {
+                    IV.FileControl.addImageFile(path.toString());
+                }
+            } else {
+                // 更新当前文件路径
+                IV.GControl.currentSource = path;
+            }
         } else {
             var sourcePaths = IV.FileControl.getDirImagePath(path);
             if (sourcePaths.length > 0) {

--- a/src/src/filecontrol.cpp
+++ b/src/src/filecontrol.cpp
@@ -910,6 +910,11 @@ void FileControl::resetImageFiles(const QStringList &filePaths)
     qCDebug(logImageViewer) << "Image files reset complete.";
 }
 
+void FileControl::addImageFile(const QString &filePath)
+{
+    imageFileWatcher->addImageFile(filePath);
+}
+
 /**
  * @return 返回公司Logo图标地址
  */

--- a/src/src/filecontrol.h
+++ b/src/src/filecontrol.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -30,6 +30,7 @@ public:
     Q_INVOKABLE QString standardPicturesPath() const;
 
     Q_INVOKABLE void resetImageFiles(const QStringList &filePaths = {});       // 重设当前展示图片列表
+    Q_INVOKABLE void addImageFile(const QString &filePath);                    // 追加监控当前目录中的图片文件
     Q_INVOKABLE QStringList getDirImagePath(const QString &path);              // 获得路径下的所有图片路径
     Q_INVOKABLE bool isCurrentWatcherDir(const QUrl &path);                    // 判断是否为当前正在监控的文件路径
     Q_INVOKABLE QString slotGetInfo(const QString &key, const QString &path);  // 获取某项info

--- a/src/src/globalcontrol.cpp
+++ b/src/src/globalcontrol.cpp
@@ -12,6 +12,7 @@
 #include <QDebug>
 #include <QApplication>
 #include <QLoggingCategory>
+#include <QFileInfo>
 
 Q_DECLARE_LOGGING_CATEGORY(logImageViewer)
 
@@ -376,6 +377,45 @@ bool GlobalControl::setImageFiles(const QStringList &filePaths, const QString &o
     // 更新视图展示模型
     viewSourceModel->resetModel(index, 0);
     qCDebug(logImageViewer) << "Image files set complete";
+    return true;
+}
+
+/**
+   @brief 将当前目录新增图片插入列表并切换至该图片。
+ */
+bool GlobalControl::addImageAndSetCurrentSource(const QUrl &image)
+{
+    qCDebug(logImageViewer) << "Adding image and setting current source:" << image;
+    if (!sourceModel || image.isEmpty() || !QFileInfo(image.toLocalFile()).isFile()) {
+        return false;
+    }
+
+    const int existingIndex = sourceModel->indexForImagePath(image);
+    if (-1 != existingIndex) {
+        setIndexAndFrameIndex(existingIndex, 0);
+        return true;
+    }
+
+    submitImageChangeImmediately();
+    const int index = sourceModel->insertImage(image);
+    if (-1 == index) {
+        return false;
+    }
+
+    currentImage.setSource(image);
+    curIndex = index;
+    const bool frameIndexChanged = (0 != curFrameIndex);
+    curFrameIndex = 0;
+    Q_EMIT currentSourceChanged();
+    Q_EMIT currentIndexChanged();
+    if (frameIndexChanged) {
+        Q_EMIT currentFrameIndexChanged();
+    }
+    checkSwitchEnable();
+    Q_EMIT imageCountChanged();
+
+    // PathViewProxyModel 缓存源模型索引，插入数据后仅重置该代理模型。
+    viewSourceModel->resetModel(index, 0);
     return true;
 }
 

--- a/src/src/globalcontrol.h
+++ b/src/src/globalcontrol.h
@@ -73,6 +73,7 @@ public:
 
     // 图像文件变更操作
     Q_SLOT bool setImageFiles(const QStringList &imageFiles, const QString &openFile);
+    Q_INVOKABLE bool addImageAndSetCurrentSource(const QUrl &image);
     Q_SLOT void removeImage(const QUrl &removeImage);
     Q_SLOT void renameImage(const QUrl &oldName, const QUrl &newName);
 

--- a/src/src/imagedata/imagefilewatcher.cpp
+++ b/src/src/imagedata/imagefilewatcher.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -97,6 +97,23 @@ void ImageFileWatcher::resetImageFiles(const QStringList &filePaths)
         qCDebug(logImageViewer) << "Added directory to watch:" << dirPath;
     } else {
         qCDebug(logImageViewer) << "No files in watcher, skipping directory watch.";
+    }
+}
+
+/**
+   @brief 将图片文件追加到当前监控列表。
+ */
+void ImageFileWatcher::addImageFile(const QString &filePath)
+{
+    const QString localPath = QUrl(filePath).toLocalFile();
+    const QFileInfo info(localPath);
+    if (!info.isFile() || cacheFileInfo.contains(localPath)) {
+        return;
+    }
+
+    cacheFileInfo.insert(localPath, filePath);
+    if (!fileWatcher->files().contains(localPath)) {
+        fileWatcher->addPath(localPath);
     }
 }
 

--- a/src/src/imagedata/imagefilewatcher.h
+++ b/src/src/imagedata/imagefilewatcher.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -17,6 +17,7 @@ public:
     static ImageFileWatcher *instance();
 
     void resetImageFiles(const QStringList &filePaths);
+    void addImageFile(const QString &filePath);
     void fileRename(const QString &oldPath, const QString &newPath);
     bool isCurrentDir(const QString &filePath);
 

--- a/src/src/imagedata/imagesourcemodel.cpp
+++ b/src/src/imagedata/imagesourcemodel.cpp
@@ -1,9 +1,11 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "imagesourcemodel.h"
 #include <QLoggingCategory>
+#include <QCollator>
+#include <QFileInfo>
 
 Q_DECLARE_LOGGING_CATEGORY(logImageViewer)
 
@@ -108,6 +110,40 @@ int ImageSourceModel::indexForImagePath(const QUrl &file)
     int index = imageUrlList.indexOf(file);
     qCDebug(logImageViewer) << "Index for file:" << file << "is:" << index;
     return index;
+}
+
+/**
+   @brief 将图片路径按当前文件名排序规则插入模型，返回插入后的索引。
+ */
+int ImageSourceModel::insertImage(const QUrl &file)
+{
+    qCDebug(logImageViewer) << "ImageSourceModel::insertImage() called for file:" << file;
+    if (file.isEmpty()) {
+        return -1;
+    }
+
+    const int existingIndex = imageUrlList.indexOf(file);
+    if (-1 != existingIndex) {
+        return existingIndex;
+    }
+
+    static QCollator sortCollator;
+    sortCollator.setNumericMode(true);
+    const QString baseName = QFileInfo(file.toLocalFile()).baseName();
+    int insertIndex = imageUrlList.size();
+    for (int i = 0; i < imageUrlList.size(); ++i) {
+        const QString currentBaseName = QFileInfo(imageUrlList.at(i).toLocalFile()).baseName();
+        if (sortCollator.compare(baseName, currentBaseName) < 0) {
+            insertIndex = i;
+            break;
+        }
+    }
+
+    beginInsertRows(QModelIndex(), insertIndex, insertIndex);
+    imageUrlList.insert(insertIndex, file);
+    endInsertRows();
+    qCDebug(logImageViewer) << "Image inserted at index:" << insertIndex;
+    return insertIndex;
 }
 
 /**

--- a/src/src/imagedata/imagesourcemodel.h
+++ b/src/src/imagedata/imagesourcemodel.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -24,6 +24,7 @@ public:
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
 
     Q_INVOKABLE int indexForImagePath(const QUrl &file);
+    int insertImage(const QUrl &file);
     Q_SLOT void setImageFiles(const QList<QUrl> &files);
     Q_SLOT void removeImage(const QUrl &fileName);
 


### PR DESCRIPTION
Insert a newly opened image and update its watcher without resetting the list.

打开当前目录新增图片时增量入模并追加监控，不重置整个图片列表。

Log: 修复当前目录新增图片无法打开的问题
Influence: 新增图片可立即打开并加入缩略图和切换序列，保留现有列表状态。