### PR TITLE
test(declarative,dbus): add unit tests for declarative and dbus modules

### DIFF
--- a/tests/src/ut_applicationadpator.cpp
+++ b/tests/src/ut_applicationadpator.cpp
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "ut_applicationadpator.h"
+#include "applicationadpator.h"
+#include "filecontrol.h"
+
+#include <QSignalSpy>
+#include "stub.h"
+
+// 可配置返回值的桩函数, 控制 FileControl::isCanReadable 的行为
+static bool g_ut_adpator_canReadable = true;
+static bool ut_adpator_stub_isCanReadable(FileControl *, const QString &)
+{
+    return g_ut_adpator_canReadable;
+}
+
+// 可配置返回值的桩函数, 控制 FileControl::isImage 的行为
+static bool g_ut_adpator_isImage = true;
+static bool ut_adpator_stub_isImage(FileControl *, const QString &)
+{
+    return g_ut_adpator_isImage;
+}
+
+void ut_applicationadpator::SetUp()
+{
+    g_ut_adpator_canReadable = true;
+    g_ut_adpator_isImage = true;
+}
+
+void ut_applicationadpator::TearDown() {}
+
+// 构造函数: 传入有效 FileControl, 内部 fileControl 应被保存
+TEST_F(ut_applicationadpator, Construct_WithFileControl)
+{
+    FileControl control;
+    ApplicationAdaptor adaptor(&control);
+    // 通过行为间接验证 fileControl 已被保存: 调用 openImageFile 不应崩溃
+    Stub stub;
+    g_ut_adpator_canReadable = false;
+    g_ut_adpator_isImage = false;
+    stub.set(ADDR(FileControl, isCanReadable), ut_adpator_stub_isCanReadable);
+    stub.set(ADDR(FileControl, isImage), ut_adpator_stub_isImage);
+    EXPECT_FALSE(adaptor.openImageFile("/tmp/nonexistent.png"));
+}
+
+// 构造函数: 传入 nullptr, openImageFile 应安全返回 false
+TEST_F(ut_applicationadpator, Construct_WithNullptr_FileControlIsNull)
+{
+    ApplicationAdaptor adaptor(nullptr);
+    EXPECT_FALSE(adaptor.openImageFile("/tmp/whatever.png"));
+}
+
+// openImageFile: fileControl 为空时返回 false, 不访问桩函数
+TEST_F(ut_applicationadpator, OpenImageFile_NullFileControl_ReturnsFalse)
+{
+    ApplicationAdaptor adaptor(nullptr);
+    EXPECT_FALSE(adaptor.openImageFile("/tmp/any.png"));
+}
+
+// openImageFile: 不可读时返回 false, 不发射 openImageFile 信号
+TEST_F(ut_applicationadpator, OpenImageFile_NotReadable_ReturnsFalse)
+{
+    FileControl control;
+    ApplicationAdaptor adaptor(&control);
+    QSignalSpy spy(&control, &FileControl::openImageFile);
+
+    Stub stub;
+    g_ut_adpator_canReadable = false;
+    g_ut_adpator_isImage = true;
+    stub.set(ADDR(FileControl, isCanReadable), ut_adpator_stub_isCanReadable);
+    stub.set(ADDR(FileControl, isImage), ut_adpator_stub_isImage);
+
+    EXPECT_FALSE(adaptor.openImageFile("/tmp/notreadable.png"));
+    EXPECT_EQ(spy.count(), 0);
+}
+
+// openImageFile: 可读但非图片时返回 false, 不发射信号
+TEST_F(ut_applicationadpator, OpenImageFile_ReadableButNotImage_ReturnsFalse)
+{
+    FileControl control;
+    ApplicationAdaptor adaptor(&control);
+    QSignalSpy spy(&control, &FileControl::openImageFile);
+
+    Stub stub;
+    g_ut_adpator_canReadable = true;
+    g_ut_adpator_isImage = false;
+    stub.set(ADDR(FileControl, isCanReadable), ut_adpator_stub_isCanReadable);
+    stub.set(ADDR(FileControl, isImage), ut_adpator_stub_isImage);
+
+    EXPECT_FALSE(adaptor.openImageFile("/tmp/notimage.png"));
+    EXPECT_EQ(spy.count(), 0);
+}
+
+// openImageFile: 可读且为图片, 传入普通本地路径, 应发射信号并返回 true
+TEST_F(ut_applicationadpator, OpenImageFile_ReadableAndImage_PlainPath_ReturnsTrue)
+{
+    FileControl control;
+    ApplicationAdaptor adaptor(&control);
+    QSignalSpy spy(&control, &FileControl::openImageFile);
+
+    Stub stub;
+    g_ut_adpator_canReadable = true;
+    g_ut_adpator_isImage = true;
+    stub.set(ADDR(FileControl, isCanReadable), ut_adpator_stub_isCanReadable);
+    stub.set(ADDR(FileControl, isImage), ut_adpator_stub_isImage);
+
+    EXPECT_TRUE(adaptor.openImageFile("/tmp/image.png"));
+    EXPECT_EQ(spy.count(), 1);
+    // 传入普通路径时, 内部会转换为 file:// URL
+    EXPECT_EQ(spy.takeFirst().at(0).toString(), QString("file:///tmp/image.png"));
+}
+
+// openImageFile: 可读且为图片, 传入 file:// URL, 同样应成功
+TEST_F(ut_applicationadpator, OpenImageFile_ReadableAndImage_FileUrl_ReturnsTrue)
+{
+    FileControl control;
+    ApplicationAdaptor adaptor(&control);
+    QSignalSpy spy(&control, &FileControl::openImageFile);
+
+    Stub stub;
+    g_ut_adpator_canReadable = true;
+    g_ut_adpator_isImage = true;
+    stub.set(ADDR(FileControl, isCanReadable), ut_adpator_stub_isCanReadable);
+    stub.set(ADDR(FileControl, isImage), ut_adpator_stub_isImage);
+
+    EXPECT_TRUE(adaptor.openImageFile("file:///tmp/url_image.png"));
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.takeFirst().at(0).toString(), QString("file:///tmp/url_image.png"));
+}

--- a/tests/src/ut_applicationadpator.h
+++ b/tests/src/ut_applicationadpator.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef UT_APPLICATIONADPATOR_H
+#define UT_APPLICATIONADPATOR_H
+
+#include <gtest/gtest.h>
+
+class ApplicationAdaptor;
+
+class ut_applicationadpator : public testing::Test
+{
+protected:
+    virtual void SetUp() override;
+    virtual void TearDown() override;
+};
+
+#endif  // UT_APPLICATIONADPATOR_H

--- a/tests/src/ut_mousetrackitem.cpp
+++ b/tests/src/ut_mousetrackitem.cpp
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "ut_mousetrackitem.h"
+#include "mousetrackitem.h"
+
+#include <QMouseEvent>
+#include <QSignalSpy>
+
+void ut_mousetrackitem::SetUp() {}
+void ut_mousetrackitem::TearDown() {}
+
+// 构造函数: 默认状态为非按下
+TEST_F(ut_mousetrackitem, Construct_DefaultNotPressed)
+{
+    MouseTrackItem item;
+    EXPECT_FALSE(item.pressed());
+}
+
+// pressed() 默认返回 false (单独列出以保证函数覆盖)
+TEST_F(ut_mousetrackitem, Pressed_InitialState_ReturnsFalse)
+{
+    MouseTrackItem item;
+    EXPECT_FALSE(item.pressed());
+}
+
+// setPressed: 从 false -> true, 应发射 pressedChanged
+TEST_F(ut_mousetrackitem, SetPressed_True_EmitsSignal)
+{
+    MouseTrackItem item;
+    QSignalSpy spy(&item, &MouseTrackItem::pressedChanged);
+
+    item.setPressed(true);
+    EXPECT_TRUE(item.pressed());
+    EXPECT_EQ(spy.count(), 1);
+}
+
+// setPressed: 设置相同值不应发射信号
+TEST_F(ut_mousetrackitem, SetPressed_SameValue_NoSignal)
+{
+    MouseTrackItem item;
+    QSignalSpy spy(&item, &MouseTrackItem::pressedChanged);
+
+    item.setPressed(false);  // 与默认值相同
+    EXPECT_FALSE(item.pressed());
+    EXPECT_EQ(spy.count(), 0);
+}
+
+// setPressed: true -> false, 应发射 pressedChanged
+TEST_F(ut_mousetrackitem, SetPressed_BackToFalse_EmitsSignal)
+{
+    MouseTrackItem item;
+    item.setPressed(true);
+
+    QSignalSpy spy(&item, &MouseTrackItem::pressedChanged);
+    item.setPressed(false);
+    EXPECT_FALSE(item.pressed());
+    EXPECT_EQ(spy.count(), 1);
+}
+
+// mousePressEvent: 应将 pressed 置 true 并 accept 事件
+TEST_F(ut_mousetrackitem, MousePressEvent_SetsPressedAndAccepts)
+{
+    MouseTrackItem item;
+    QSignalSpy spy(&item, &MouseTrackItem::pressedChanged);
+
+    QMouseEvent event(QEvent::MouseButtonPress, QPointF(0, 0), QPointF(0, 0),
+                      Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    item.mousePressEvent(&event);
+
+    EXPECT_TRUE(item.pressed());
+    EXPECT_TRUE(event.isAccepted());
+    EXPECT_EQ(spy.count(), 1);
+}
+
+// mouseReleaseEvent: 应将 pressed 置 false 并 accept 事件
+TEST_F(ut_mousetrackitem, MouseReleaseEvent_ClearsPressedAndAccepts)
+{
+    MouseTrackItem item;
+    item.setPressed(true);
+
+    QSignalSpy spy(&item, &MouseTrackItem::pressedChanged);
+    QMouseEvent event(QEvent::MouseButtonRelease, QPointF(0, 0), QPointF(0, 0),
+                      Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+    item.mouseReleaseEvent(&event);
+
+    EXPECT_FALSE(item.pressed());
+    EXPECT_TRUE(event.isAccepted());
+    EXPECT_EQ(spy.count(), 1);
+}
+
+// mouseDoubleClickEvent: 应发射 doubleClicked 并 accept 事件
+TEST_F(ut_mousetrackitem, MouseDoubleClickEvent_EmitsDoubleClickedAndAccepts)
+{
+    MouseTrackItem item;
+    QSignalSpy spy(&item, &MouseTrackItem::doubleClicked);
+
+    QMouseEvent event(QEvent::MouseButtonDblClick, QPointF(0, 0), QPointF(0, 0),
+                      Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    item.mouseDoubleClickEvent(&event);
+
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_TRUE(event.isAccepted());
+}

--- a/tests/src/ut_mousetrackitem.h
+++ b/tests/src/ut_mousetrackitem.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef UT_MOUSETRACKITEM_H
+#define UT_MOUSETRACKITEM_H
+
+#include <gtest/gtest.h>
+
+class MouseTrackItem;
+
+class ut_mousetrackitem : public testing::Test
+{
+protected:
+    virtual void SetUp() override;
+    virtual void TearDown() override;
+};
+
+#endif  // UT_MOUSETRACKITEM_H

--- a/tests/src/ut_pathviewrangehandler.cpp
+++ b/tests/src/ut_pathviewrangehandler.cpp
@@ -1,0 +1,242 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "ut_pathviewrangehandler.h"
+#include "pathviewrangehandler.h"
+
+#include <QEvent>
+#include <QMouseEvent>
+#include <QQuickItem>
+#include <QSignalSpy>
+
+void ut_pathviewrangehandler::SetUp() {}
+void ut_pathviewrangehandler::TearDown() {}
+
+// 构造函数与默认属性初值
+TEST_F(ut_pathviewrangehandler, Construct_DefaultInitialState)
+{
+    PathViewRangeHandler handler;
+    EXPECT_EQ(handler.target(), nullptr);
+    EXPECT_TRUE(handler.enableForward());
+    EXPECT_TRUE(handler.enableBackward());
+}
+
+// 显式传入 parent 构造
+TEST_F(ut_pathviewrangehandler, Construct_WithParent_OwnedByParent)
+{
+    QObject parent;
+    PathViewRangeHandler *handler = new PathViewRangeHandler(&parent);
+    EXPECT_EQ(handler->parent(), &parent);
+    delete handler;
+}
+
+// target() 默认返回 nullptr（已在上覆盖，单独列出保证函数覆盖）
+TEST_F(ut_pathviewrangehandler, Target_InitialState_ReturnsNull)
+{
+    PathViewRangeHandler handler;
+    EXPECT_EQ(handler.target(), nullptr);
+}
+
+// setTarget: null -> valid item, 应发射 targetChanged 并安装事件过滤器
+TEST_F(ut_pathviewrangehandler, SetTarget_FromNullToItem_EmitsSignal)
+{
+    PathViewRangeHandler handler;
+    QSignalSpy spy(&handler, &PathViewRangeHandler::targetChanged);
+
+    QQuickItem item;
+    handler.setTarget(&item);
+    EXPECT_EQ(handler.target(), &item);
+    EXPECT_EQ(spy.count(), 1);
+}
+
+// setTarget: 相同对象不应再次发射信号
+TEST_F(ut_pathviewrangehandler, SetTarget_SameItem_NoSignal)
+{
+    PathViewRangeHandler handler;
+    QQuickItem item;
+    handler.setTarget(&item);
+
+    QSignalSpy spy(&handler, &PathViewRangeHandler::targetChanged);
+    handler.setTarget(&item);
+    EXPECT_EQ(spy.count(), 0);
+    EXPECT_EQ(handler.target(), &item);
+}
+
+// setTarget: 切换到新对象应卸载旧的过滤器并安装新的
+TEST_F(ut_pathviewrangehandler, SetTarget_SwitchToAnother_EmitsSignal)
+{
+    PathViewRangeHandler handler;
+    QQuickItem item1;
+    QQuickItem item2;
+    handler.setTarget(&item1);
+
+    QSignalSpy spy(&handler, &PathViewRangeHandler::targetChanged);
+    handler.setTarget(&item2);
+    EXPECT_EQ(handler.target(), &item2);
+    EXPECT_EQ(spy.count(), 1);
+}
+
+// setTarget: 切回 nullptr 应清理 target
+TEST_F(ut_pathviewrangehandler, SetTarget_ToNull_EmitsSignal)
+{
+    PathViewRangeHandler handler;
+    QQuickItem item;
+    handler.setTarget(&item);
+
+    QSignalSpy spy(&handler, &PathViewRangeHandler::targetChanged);
+    handler.setTarget(nullptr);
+    EXPECT_EQ(handler.target(), nullptr);
+    EXPECT_EQ(spy.count(), 1);
+}
+
+// enableForward / setEnableForward: 默认 true, 切到 false 应发射信号
+TEST_F(ut_pathviewrangehandler, EnableForward_Toggle_EmitsSignalOnChange)
+{
+    PathViewRangeHandler handler;
+    EXPECT_TRUE(handler.enableForward());
+
+    QSignalSpy spy(&handler, &PathViewRangeHandler::enableForwardChanged);
+    handler.setEnableForward(false);
+    EXPECT_FALSE(handler.enableForward());
+    EXPECT_EQ(spy.count(), 1);
+}
+
+// setEnableForward: 设置相同值不应发射信号
+TEST_F(ut_pathviewrangehandler, EnableForward_SameValue_NoSignal)
+{
+    PathViewRangeHandler handler;
+    QSignalSpy spy(&handler, &PathViewRangeHandler::enableForwardChanged);
+    handler.setEnableForward(true);  // 与默认值相同
+    EXPECT_EQ(spy.count(), 0);
+    EXPECT_TRUE(handler.enableForward());
+}
+
+// enableBackward / setEnableBackward: 默认 true, 切到 false 应发射信号
+TEST_F(ut_pathviewrangehandler, EnableBackward_Toggle_EmitsSignalOnChange)
+{
+    PathViewRangeHandler handler;
+    EXPECT_TRUE(handler.enableBackward());
+
+    QSignalSpy spy(&handler, &PathViewRangeHandler::enableBackwardChanged);
+    handler.setEnableBackward(false);
+    EXPECT_FALSE(handler.enableBackward());
+    EXPECT_EQ(spy.count(), 1);
+}
+
+// setEnableBackward: 设置相同值不应发射信号
+TEST_F(ut_pathviewrangehandler, EnableBackward_SameValue_NoSignal)
+{
+    PathViewRangeHandler handler;
+    QSignalSpy spy(&handler, &PathViewRangeHandler::enableBackwardChanged);
+    handler.setEnableBackward(true);  // 与默认值相同
+    EXPECT_EQ(spy.count(), 0);
+    EXPECT_TRUE(handler.enableBackward());
+}
+
+// eventFilter: 双向均允许且对象为 target 时直接返回 false
+TEST_F(ut_pathviewrangehandler, EventFilter_BothEnabledAndTarget_ReturnsFalse)
+{
+    PathViewRangeHandler handler;
+    QQuickItem item;
+    handler.setTarget(&item);
+
+    QMouseEvent event(QEvent::MouseMove, QPointF(10, 10), QPointF(10, 10),
+                      Qt::NoButton, Qt::NoButton, Qt::NoModifier);
+    EXPECT_FALSE(handler.eventFilter(&item, &event));
+}
+
+// eventFilter: MouseButtonRelease 重置 basePoint 并返回 false
+TEST_F(ut_pathviewrangehandler, EventFilter_MouseRelease_ResetsBasePoint)
+{
+    PathViewRangeHandler handler;
+    QQuickItem item;
+    handler.setTarget(&item);
+    handler.setEnableForward(false);  // 避免触发提前 return
+
+    QMouseEvent event(QEvent::MouseButtonRelease, QPointF(5, 5), QPointF(5, 5),
+                      Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+    EXPECT_FALSE(handler.eventFilter(&item, &event));
+}
+
+// eventFilter: MouseMove 且 basePoint 为空时, 设置 basePoint 并返回 false
+TEST_F(ut_pathviewrangehandler, EventFilter_MouseMove_NullBasePoint_SetsBasePoint)
+{
+    PathViewRangeHandler handler;
+    QQuickItem item;
+    handler.setTarget(&item);
+    handler.setEnableForward(false);
+
+    QMouseEvent event(QEvent::MouseMove, QPointF(20, 20), QPointF(20, 20),
+                      Qt::NoButton, Qt::LeftButton, Qt::NoModifier);
+    EXPECT_FALSE(handler.eventFilter(&item, &event));
+}
+
+// eventFilter: MouseMove 禁止向前且向右拖动, 应过滤事件返回 true
+TEST_F(ut_pathviewrangehandler, EventFilter_MouseMove_ForwardDisabledAndMovingRight_Filtered)
+{
+    PathViewRangeHandler handler;
+    QQuickItem item;
+    handler.setTarget(&item);
+    handler.setEnableForward(false);
+
+    // 先建立 basePoint
+    QMouseEvent first(QEvent::MouseMove, QPointF(10, 10), QPointF(10, 10),
+                      Qt::NoButton, Qt::LeftButton, Qt::NoModifier);
+    handler.eventFilter(&item, &first);
+
+    // 向右移动 (newPoint.x > basePoint.x), 应被过滤
+    QMouseEvent second(QEvent::MouseMove, QPointF(50, 10), QPointF(50, 10),
+                       Qt::NoButton, Qt::LeftButton, Qt::NoModifier);
+    EXPECT_TRUE(handler.eventFilter(&item, &second));
+}
+
+// eventFilter: MouseMove 禁止向后且向左拖动, 应过滤事件返回 true
+TEST_F(ut_pathviewrangehandler, EventFilter_MouseMove_BackwardDisabledAndMovingLeft_Filtered)
+{
+    PathViewRangeHandler handler;
+    QQuickItem item;
+    handler.setTarget(&item);
+    handler.setEnableBackward(false);
+
+    // 先建立 basePoint
+    QMouseEvent first(QEvent::MouseMove, QPointF(50, 10), QPointF(50, 10),
+                      Qt::NoButton, Qt::LeftButton, Qt::NoModifier);
+    handler.eventFilter(&item, &first);
+
+    // 向左移动 (newPoint.x < basePoint.x), 应被过滤
+    QMouseEvent second(QEvent::MouseMove, QPointF(10, 10), QPointF(10, 10),
+                       Qt::NoButton, Qt::LeftButton, Qt::NoModifier);
+    EXPECT_TRUE(handler.eventFilter(&item, &second));
+}
+
+// eventFilter: MouseMove 方向允许, 不应过滤, 返回 false
+TEST_F(ut_pathviewrangehandler, EventFilter_MouseMove_DirectionAllowed_NotFiltered)
+{
+    PathViewRangeHandler handler;
+    QQuickItem item;
+    handler.setTarget(&item);
+    handler.setEnableForward(false);
+
+    // basePoint
+    QMouseEvent first(QEvent::MouseMove, QPointF(50, 10), QPointF(50, 10),
+                      Qt::NoButton, Qt::LeftButton, Qt::NoModifier);
+    handler.eventFilter(&item, &first);
+
+    // 继续向左移动 (允许的方向, 因 forward 已禁用但只在向右时过滤)
+    QMouseEvent second(QEvent::MouseMove, QPointF(30, 10), QPointF(30, 10),
+                       Qt::NoButton, Qt::LeftButton, Qt::NoModifier);
+    EXPECT_FALSE(handler.eventFilter(&item, &second));
+}
+
+// eventFilter: 其它事件类型走 default 分支, 返回 false
+TEST_F(ut_pathviewrangehandler, EventFilter_OtherEventType_DefaultBranch)
+{
+    PathViewRangeHandler handler;
+    QQuickItem item;
+    handler.setTarget(&item);
+    handler.setEnableForward(false);
+
+    QEvent event(QEvent::Resize);
+    EXPECT_FALSE(handler.eventFilter(&item, &event));
+}

--- a/tests/src/ut_pathviewrangehandler.h
+++ b/tests/src/ut_pathviewrangehandler.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef UT_PATHVIEWRANGEHANDLER_H
+#define UT_PATHVIEWRANGEHANDLER_H
+
+#include <gtest/gtest.h>
+
+class PathViewRangeHandler;
+
+class ut_pathviewrangehandler : public testing::Test
+{
+protected:
+    virtual void SetUp() override;
+    virtual void TearDown() override;
+};
+
+#endif  // UT_PATHVIEWRANGEHANDLER_H


### PR DESCRIPTION
Add GTest unit tests for PathViewRangeHandler, MouseTrackItem and ApplicationAdaptor with full function coverage.

为 declarative 与 dbus 模块的 3 个类补充 GTest 单元测试，覆盖全部
public 与 protected 函数，共 33 个测试用例。

Log: 补充 declarative 与 dbus 模块单元测试
Influence: 仅新增 tests/src 下测试文件，Debug 模式生效，不影响 Release 构建.