### PR TITLE
test(ocr): add unit tests for printdialog and ocr modules

### DIFF
--- a/tests/src/ut_livetextanalyzer.cpp
+++ b/tests/src/ut_livetextanalyzer.cpp
@@ -1,0 +1,448 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "ut_livetextanalyzer.h"
+#include "livetextanalyzer.h"
+
+#include <deepin-ocr-plugin-manager/deepinocrplugin.h>
+#include <deepin-ocr-plugin-manager/deepinocrplugindef.h>
+
+#include <QImage>
+#include <QSignalSpy>
+#include <QVariantList>
+
+#include "stub.h"
+
+using namespace DeepinOCRPlugin;
+
+// ==================== DeepinOCRDriver 桩函数 ====================
+
+static bool g_ut_lt_loadPlugin = true;
+static bool ut_lt_stub_loadDefaultPlugin(DeepinOCRDriver *)
+{
+    return g_ut_lt_loadPlugin;
+}
+
+static bool ut_lt_stub_setUseHardware(DeepinOCRDriver *, const std::vector<std::pair<HardwareID, int>> &)
+{
+    return true;
+}
+
+static int g_ut_lt_setMatrixHeight = 0;
+static int g_ut_lt_setMatrixWidth = 0;
+static bool ut_lt_stub_setMatrix(DeepinOCRDriver *, int height, int width, unsigned char *, size_t, PixelType)
+{
+    g_ut_lt_setMatrixHeight = height;
+    g_ut_lt_setMatrixWidth = width;
+    return true;
+}
+
+static bool g_ut_lt_analyzeRet = false;
+static bool g_ut_lt_isRunning = false;
+static bool ut_lt_stub_analyze(DeepinOCRDriver *)
+{
+    return g_ut_lt_analyzeRet;
+}
+static bool ut_lt_stub_isRunning(DeepinOCRDriver *)
+{
+    return g_ut_lt_isRunning;
+}
+static bool g_ut_lt_breakAnalyzeCalled = false;
+static bool ut_lt_stub_breakAnalyze(DeepinOCRDriver *)
+{
+    g_ut_lt_breakAnalyzeCalled = true;
+    return true;
+}
+
+static std::vector<TextBox> g_ut_lt_textBoxes;
+static std::vector<TextBox> ut_lt_stub_getTextBoxes(const DeepinOCRDriver *)
+{
+    return g_ut_lt_textBoxes;
+}
+
+static std::vector<TextBox> g_ut_lt_charBoxes;
+static std::vector<TextBox> ut_lt_stub_getCharBoxes(const DeepinOCRDriver *, size_t)
+{
+    return g_ut_lt_charBoxes;
+}
+
+static std::string g_ut_lt_resultStr;
+static std::string ut_lt_stub_getResultFromBox(DeepinOCRDriver *, size_t)
+{
+    return g_ut_lt_resultStr;
+}
+
+// 安装构造函数相关的桩（loadDefaultPlugin / setUseHardware）
+static void ut_lt_installCtorStubs(Stub &stub)
+{
+    stub.set(ADDR(DeepinOCRDriver, loadDefaultPlugin), ut_lt_stub_loadDefaultPlugin);
+    stub.set(ADDR(DeepinOCRDriver, setUseHardware), ut_lt_stub_setUseHardware);
+}
+
+void ut_livetextanalyzer::SetUp()
+{
+    g_ut_lt_loadPlugin = true;
+    g_ut_lt_analyzeRet = false;
+    g_ut_lt_isRunning = false;
+    g_ut_lt_breakAnalyzeCalled = false;
+    g_ut_lt_setMatrixHeight = 0;
+    g_ut_lt_setMatrixWidth = 0;
+    g_ut_lt_textBoxes.clear();
+    g_ut_lt_charBoxes.clear();
+    g_ut_lt_resultStr.clear();
+}
+void ut_livetextanalyzer::TearDown() {}
+
+// ==================== 构造函数 ====================
+
+// 构造函数：创建 OCR driver，初始化 pixelRatio
+TEST_F(ut_livetextanalyzer, Construct_CreatesDriverAndPixelRatio)
+{
+    Stub stub;
+    ut_lt_installCtorStubs(stub);
+    LiveTextAnalyzer analyzer;
+    EXPECT_NE(analyzer.ocrDriver, nullptr);
+    EXPECT_GE(analyzer.pixelRatio, 1.0);
+    // 默认 imageCache 为空
+    EXPECT_TRUE(analyzer.imageCache.isNull());
+}
+
+// ==================== setImage ====================
+
+// setImage: 有效图片缓存到 imageCache
+TEST_F(ut_livetextanalyzer, SetImage_ValidImage_CachesImage)
+{
+    Stub stub;
+    ut_lt_installCtorStubs(stub);
+    stub.set(ADDR(DeepinOCRDriver, setMatrix), ut_lt_stub_setMatrix);
+    LiveTextAnalyzer analyzer;
+    QImage img(32, 32, QImage::Format_RGB32);
+    img.fill(Qt::red);
+    analyzer.setImage(img);
+    EXPECT_EQ(analyzer.imageCache, img);
+    EXPECT_EQ(g_ut_lt_setMatrixHeight, 32);
+    EXPECT_EQ(g_ut_lt_setMatrixWidth, 32);
+}
+
+// setImage: 高 DPI 下缩放 image_copy（pixelRatio>1 分支）
+TEST_F(ut_livetextanalyzer, SetImage_HighDpi_ScalesImageCopy)
+{
+    Stub stub;
+    ut_lt_installCtorStubs(stub);
+    stub.set(ADDR(DeepinOCRDriver, setMatrix), ut_lt_stub_setMatrix);
+    LiveTextAnalyzer analyzer;
+    analyzer.pixelRatio = 2.0;  // 模拟高 DPI
+    QImage img(40, 40, QImage::Format_RGB32);
+    img.fill(Qt::green);
+    analyzer.setImage(img);
+    EXPECT_EQ(analyzer.imageCache, img);  // imageCache 保留原图
+    EXPECT_EQ(g_ut_lt_setMatrixHeight, 20);
+    EXPECT_EQ(g_ut_lt_setMatrixWidth, 20);
+}
+
+// setImage: null 图片不崩溃
+TEST_F(ut_livetextanalyzer, SetImage_NullImage_NoCrash)
+{
+    Stub stub;
+    ut_lt_installCtorStubs(stub);
+    stub.set(ADDR(DeepinOCRDriver, setMatrix), ut_lt_stub_setMatrix);
+    LiveTextAnalyzer analyzer;
+    QImage nullImg;
+    analyzer.setImage(nullImg);
+    EXPECT_TRUE(analyzer.imageCache.isNull());
+}
+
+// ==================== liveBlock ====================
+
+// liveBlock: 无文本块返回空列表
+TEST_F(ut_livetextanalyzer, LiveBlock_NoTextBoxes_ReturnsEmptyList)
+{
+    Stub stub;
+    ut_lt_installCtorStubs(stub);
+    stub.set(ADDR(DeepinOCRDriver, getTextBoxes), ut_lt_stub_getTextBoxes);
+    LiveTextAnalyzer analyzer;
+    g_ut_lt_textBoxes.clear();
+    QVariant result = analyzer.liveBlock();
+    EXPECT_TRUE(result.toList().isEmpty());
+}
+
+// liveBlock: 有文本块返回格式化数据（4点*2 + angle = 9项/块）
+TEST_F(ut_livetextanalyzer, LiveBlock_WithTextBoxes_ReturnsFormattedData)
+{
+    Stub stub;
+    ut_lt_installCtorStubs(stub);
+    stub.set(ADDR(DeepinOCRDriver, getTextBoxes), ut_lt_stub_getTextBoxes);
+    LiveTextAnalyzer analyzer;
+    TextBox box;
+    box.points = {{10.0f, 20.0f}, {30.0f, 20.0f}, {30.0f, 40.0f}, {10.0f, 40.0f}};
+    box.angle = 0.0f;
+    g_ut_lt_textBoxes = {box};
+    QVariant result = analyzer.liveBlock();
+    QList<QVariant> outer = result.toList();
+    ASSERT_EQ(outer.size(), 1);
+    QList<QVariant> inner = outer.at(0).toList();
+    EXPECT_EQ(inner.size(), 9);  // 8 坐标 + 1 角度
+}
+
+// ==================== charBox ====================
+
+// charBox: 越界索引返回无效 QVariant
+TEST_F(ut_livetextanalyzer, CharBox_InvalidIndex_ReturnsInvalidVariant)
+{
+    Stub stub;
+    ut_lt_installCtorStubs(stub);
+    stub.set(ADDR(DeepinOCRDriver, getTextBoxes), ut_lt_stub_getTextBoxes);
+    LiveTextAnalyzer analyzer;
+    g_ut_lt_textBoxes.clear();
+    QVariant result = analyzer.charBox(0);
+    EXPECT_FALSE(result.isValid());
+}
+
+// charBox: 有效索引返回字符位置列表（0 + 每字符相对 x）
+TEST_F(ut_livetextanalyzer, CharBox_ValidIndex_ReturnsCharPositions)
+{
+    Stub stub;
+    ut_lt_installCtorStubs(stub);
+    stub.set(ADDR(DeepinOCRDriver, getTextBoxes), ut_lt_stub_getTextBoxes);
+    stub.set(ADDR(DeepinOCRDriver, getCharBoxes), ut_lt_stub_getCharBoxes);
+    LiveTextAnalyzer analyzer;
+    TextBox tb;
+    tb.points = {{0, 0}, {1, 0}, {1, 1}, {0, 1}};
+    tb.angle = 0;
+    g_ut_lt_textBoxes = {tb};
+
+    TextBox cb1, cb2;
+    cb1.points = {{5.0f, 0.0f}, {6.0f, 0.0f}, {6.0f, 1.0f}, {5.0f, 1.0f}};
+    cb1.angle = 0;
+    cb2.points = {{10.0f, 0.0f}, {11.0f, 0.0f}, {11.0f, 1.0f}, {10.0f, 1.0f}};
+    cb2.angle = 0;
+    g_ut_lt_charBoxes = {cb1, cb2};
+
+    QVariant result = analyzer.charBox(0);
+    QList<QVariant> list = result.toList();
+    // 期望: [0, 6-5, 11-5] = [0, 1, 6]
+    ASSERT_EQ(list.size(), 3);
+    EXPECT_EQ(list.at(0).toInt(), 0);
+    EXPECT_FLOAT_EQ(list.at(1).toReal(), 1.0f);
+    EXPECT_FLOAT_EQ(list.at(2).toReal(), 6.0f);
+}
+
+// ==================== textResult ====================
+
+// textResult: 越界 blockIndex 返回空
+TEST_F(ut_livetextanalyzer, TextResult_InvalidBlockIndex_ReturnsEmpty)
+{
+    Stub stub;
+    ut_lt_installCtorStubs(stub);
+    stub.set(ADDR(DeepinOCRDriver, getTextBoxes), ut_lt_stub_getTextBoxes);
+    LiveTextAnalyzer analyzer;
+    g_ut_lt_textBoxes.clear();
+    QString result = analyzer.textResult(0, 0, 5);
+    EXPECT_TRUE(result.isEmpty());
+}
+
+// textResult: 负的 startIndex 返回空
+TEST_F(ut_livetextanalyzer, TextResult_NegativeStartIndex_ReturnsEmpty)
+{
+    Stub stub;
+    ut_lt_installCtorStubs(stub);
+    stub.set(ADDR(DeepinOCRDriver, getTextBoxes), ut_lt_stub_getTextBoxes);
+    LiveTextAnalyzer analyzer;
+    TextBox tb;
+    tb.points = {{0, 0}, {1, 0}, {1, 1}, {0, 1}};
+    tb.angle = 0;
+    g_ut_lt_textBoxes = {tb};
+    QString result = analyzer.textResult(0, -1, 5);
+    EXPECT_TRUE(result.isEmpty());
+}
+
+// textResult: len<=0 返回空
+TEST_F(ut_livetextanalyzer, TextResult_NonPositiveLength_ReturnsEmpty)
+{
+    Stub stub;
+    ut_lt_installCtorStubs(stub);
+    stub.set(ADDR(DeepinOCRDriver, getTextBoxes), ut_lt_stub_getTextBoxes);
+    LiveTextAnalyzer analyzer;
+    TextBox tb;
+    tb.points = {{0, 0}, {1, 0}, {1, 1}, {0, 1}};
+    tb.angle = 0;
+    g_ut_lt_textBoxes = {tb};
+    QString result = analyzer.textResult(0, 0, 0);
+    EXPECT_TRUE(result.isEmpty());
+}
+
+// textResult: 有效参数返回子串
+TEST_F(ut_livetextanalyzer, TextResult_ValidParams_ReturnsSubstring)
+{
+    Stub stub;
+    ut_lt_installCtorStubs(stub);
+    stub.set(ADDR(DeepinOCRDriver, getTextBoxes), ut_lt_stub_getTextBoxes);
+    stub.set(ADDR(DeepinOCRDriver, getResultFromBox), ut_lt_stub_getResultFromBox);
+    LiveTextAnalyzer analyzer;
+    TextBox tb;
+    tb.points = {{0, 0}, {1, 0}, {1, 1}, {0, 1}};
+    tb.angle = 0;
+    g_ut_lt_textBoxes = {tb};
+    g_ut_lt_resultStr = "hello world";
+    QString result = analyzer.textResult(0, 0, 5);
+    EXPECT_EQ(result, QString("hello"));
+    // 截取中间段
+    EXPECT_EQ(analyzer.textResult(0, 6, 5), QString("world"));
+}
+
+// ==================== analyze ====================
+
+// analyze: 异步执行后发射 analyzeFinished(result, token)
+TEST_F(ut_livetextanalyzer, Analyze_EmitsAnalyzeFinishedWithResultAndToken)
+{
+    Stub stub;
+    ut_lt_installCtorStubs(stub);
+    stub.set(ADDR(DeepinOCRDriver, isRunning), ut_lt_stub_isRunning);
+    stub.set(ADDR(DeepinOCRDriver, analyze), ut_lt_stub_analyze);
+    LiveTextAnalyzer analyzer;
+    g_ut_lt_isRunning = false;
+    g_ut_lt_analyzeRet = true;
+
+    QSignalSpy spy(&analyzer, &LiveTextAnalyzer::analyzeFinished);
+    analyzer.analyze("ut_token_123");
+
+    EXPECT_TRUE(spy.wait(3000));
+    ASSERT_EQ(spy.count(), 1);
+    QList<QVariant> args = spy.takeFirst();
+    EXPECT_TRUE(args.at(0).toBool());
+    EXPECT_EQ(args.at(1).toString(), QString("ut_token_123"));
+}
+
+// analyze: analyze 返回 false 时信号仍发射
+TEST_F(ut_livetextanalyzer, Analyze_DriverReturnsFalse_EmitsFalseResult)
+{
+    Stub stub;
+    ut_lt_installCtorStubs(stub);
+    stub.set(ADDR(DeepinOCRDriver, isRunning), ut_lt_stub_isRunning);
+    stub.set(ADDR(DeepinOCRDriver, analyze), ut_lt_stub_analyze);
+    LiveTextAnalyzer analyzer;
+    g_ut_lt_isRunning = false;
+    g_ut_lt_analyzeRet = false;
+
+    QSignalSpy spy(&analyzer, &LiveTextAnalyzer::analyzeFinished);
+    analyzer.analyze("fail_token");
+
+    EXPECT_TRUE(spy.wait(3000));
+    ASSERT_EQ(spy.count(), 1);
+    EXPECT_FALSE(spy.takeFirst().at(0).toBool());
+}
+
+// ==================== breakAnalyze ====================
+
+// breakAnalyze: 未运行时不调用 driver->breakAnalyze
+TEST_F(ut_livetextanalyzer, BreakAnalyze_NotRunning_DoesNotCallDriverBreak)
+{
+    Stub stub;
+    ut_lt_installCtorStubs(stub);
+    stub.set(ADDR(DeepinOCRDriver, isRunning), ut_lt_stub_isRunning);
+    stub.set(ADDR(DeepinOCRDriver, breakAnalyze), ut_lt_stub_breakAnalyze);
+    LiveTextAnalyzer analyzer;
+    g_ut_lt_isRunning = false;
+    g_ut_lt_breakAnalyzeCalled = false;
+    analyzer.breakAnalyze();
+    EXPECT_FALSE(g_ut_lt_breakAnalyzeCalled);
+}
+
+// breakAnalyze: 运行中调用 driver->breakAnalyze
+TEST_F(ut_livetextanalyzer, BreakAnalyze_Running_CallsDriverBreak)
+{
+    Stub stub;
+    ut_lt_installCtorStubs(stub);
+    stub.set(ADDR(DeepinOCRDriver, isRunning), ut_lt_stub_isRunning);
+    stub.set(ADDR(DeepinOCRDriver, breakAnalyze), ut_lt_stub_breakAnalyze);
+    LiveTextAnalyzer analyzer;
+    g_ut_lt_isRunning = true;
+    g_ut_lt_breakAnalyzeCalled = false;
+    analyzer.breakAnalyze();
+    EXPECT_TRUE(g_ut_lt_breakAnalyzeCalled);
+}
+
+// ==================== requestImage (protected) ====================
+
+// requestImage: 越界索引返回 null 图片
+TEST_F(ut_livetextanalyzer, RequestImage_InvalidIndex_ReturnsNullImage)
+{
+    Stub stub;
+    ut_lt_installCtorStubs(stub);
+    stub.set(ADDR(DeepinOCRDriver, getTextBoxes), ut_lt_stub_getTextBoxes);
+    LiveTextAnalyzer analyzer;
+    g_ut_lt_textBoxes.clear();
+    QSize outSize;
+    QImage result = analyzer.requestImage("img_999", &outSize, QSize(0, 0));
+    EXPECT_TRUE(result.isNull());
+}
+
+// requestImage: 有效索引、空 requestedSize，返回裁剪后的图片
+TEST_F(ut_livetextanalyzer, RequestImage_ValidIndex_ReturnsCroppedImage)
+{
+    Stub stub;
+    ut_lt_installCtorStubs(stub);
+    stub.set(ADDR(DeepinOCRDriver, getTextBoxes), ut_lt_stub_getTextBoxes);
+    stub.set(ADDR(DeepinOCRDriver, setMatrix), ut_lt_stub_setMatrix);
+    LiveTextAnalyzer analyzer;
+    analyzer.pixelRatio = 1.0;
+    QImage cache(100, 100, QImage::Format_RGB32);
+    cache.fill(Qt::green);
+    analyzer.setImage(cache);
+
+    TextBox tb;
+    tb.points = {{10.0f, 10.0f}, {50.0f, 10.0f}, {50.0f, 50.0f}, {10.0f, 50.0f}};
+    tb.angle = 0;
+    g_ut_lt_textBoxes = {tb};
+
+    QSize outSize;
+    QImage result = analyzer.requestImage("anything_0", &outSize, QSize(0, 0));
+    EXPECT_FALSE(result.isNull());
+    EXPECT_EQ(outSize, result.size());
+}
+
+// requestImage: 有效 requestedSize 时缩放图片
+TEST_F(ut_livetextanalyzer, RequestImage_WithRequestedSize_ScalesImage)
+{
+    Stub stub;
+    ut_lt_installCtorStubs(stub);
+    stub.set(ADDR(DeepinOCRDriver, getTextBoxes), ut_lt_stub_getTextBoxes);
+    stub.set(ADDR(DeepinOCRDriver, setMatrix), ut_lt_stub_setMatrix);
+    LiveTextAnalyzer analyzer;
+    analyzer.pixelRatio = 1.0;
+    QImage cache(100, 100, QImage::Format_RGB32);
+    cache.fill(Qt::green);
+    analyzer.setImage(cache);
+
+    TextBox tb;
+    tb.points = {{10.0f, 10.0f}, {50.0f, 10.0f}, {50.0f, 50.0f}, {10.0f, 50.0f}};
+    tb.angle = 0;
+    g_ut_lt_textBoxes = {tb};
+
+    QSize outSize;
+    QImage result = analyzer.requestImage("x_0", &outSize, QSize(20, 20));
+    EXPECT_EQ(result.size(), QSize(20, 20));
+}
+
+// requestImage: size 指针为 nullptr 不崩溃
+TEST_F(ut_livetextanalyzer, RequestImage_NullSizePointer_NoCrash)
+{
+    Stub stub;
+    ut_lt_installCtorStubs(stub);
+    stub.set(ADDR(DeepinOCRDriver, getTextBoxes), ut_lt_stub_getTextBoxes);
+    stub.set(ADDR(DeepinOCRDriver, setMatrix), ut_lt_stub_setMatrix);
+    LiveTextAnalyzer analyzer;
+    analyzer.pixelRatio = 1.0;
+    QImage cache(100, 100, QImage::Format_RGB32);
+    cache.fill(Qt::green);
+    analyzer.setImage(cache);
+
+    TextBox tb;
+    tb.points = {{10.0f, 10.0f}, {50.0f, 10.0f}, {50.0f, 50.0f}, {10.0f, 50.0f}};
+    tb.angle = 0;
+    g_ut_lt_textBoxes = {tb};
+
+    QImage result = analyzer.requestImage("x_0", nullptr, QSize(0, 0));
+    EXPECT_FALSE(result.isNull());
+}

--- a/tests/src/ut_livetextanalyzer.h
+++ b/tests/src/ut_livetextanalyzer.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef UT_LIVETEXTANALYZER_H
+#define UT_LIVETEXTANALYZER_H
+
+#include <gtest/gtest.h>
+
+class LiveTextAnalyzer;
+
+class ut_livetextanalyzer : public testing::Test
+{
+protected:
+    virtual void SetUp() override;
+    virtual void TearDown() override;
+};
+
+#endif  // UT_LIVETEXTANALYZER_H

--- a/tests/src/ut_main.cpp
+++ b/tests/src/ut_main.cpp
@@ -4,8 +4,9 @@
 
 #include <gtest/gtest.h>
 
-#include <QGuiApplication>
+#include <QApplication>
 #include <QCoreApplication>
+#include <QLoggingCategory>
 #include <DLog>
 
 // 定义日志分类，与 src/main.cpp 中的定义保持一致
@@ -14,11 +15,17 @@ Q_LOGGING_CATEGORY(logImageViewer, "org.deepin.dde.imageviewer")
 
 int main(int argc, char *argv[])
 {
-    QGuiApplication app(argc, argv);
+    QApplication app(argc, argv);
     QCoreApplication::setOrganizationName("deepin");
     QCoreApplication::setApplicationName("deepin-image-viewer");
 
     Dtk::Core::DLogManager::registerConsoleAppender();
+
+    // 关闭该分类的 debug 输出。原因：unionimage 中的全局静态对象
+    // UnionImage_Private 的析构函数会调用 qCDebug(logImageViewer)，而在进程
+    // 退出阶段 spdlog/DTK 日志器已先于该静态对象析构，会触发析构顺序冲突
+    // （段错误，已影响 ut_unionimage）。关闭 debug 后该析构期日志为空操作。
+    QLoggingCategory::setFilterRules(QStringLiteral("org.deepin.dde.imageviewer.debug=false"));
 
     testing::InitGoogleTest(&argc, argv);
 

--- a/tests/src/ut_ocrinterface.cpp
+++ b/tests/src/ut_ocrinterface.cpp
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "ut_ocrinterface.h"
+#include "ocrinterface.h"
+
+#include <QDBusConnection>
+#include <QDBusPendingReply>
+#include <QDBusMessage>
+#include <QImage>
+#include <QVariant>
+
+#include "stub.h"
+
+// 桩：拦截 QDBusAbstractInterface::doCall，避免真实 DBus 调用（open* 方法的
+// 内联 call() 模板最终都委托给私有 doCall）。
+static QDBusMessage ut_ocr_stub_doCall(QDBusAbstractInterface *, QDBus::CallMode,
+                                       const QString &, const QVariant *, size_t)
+{
+    return QDBusMessage();
+}
+
+void ut_ocrinterface::SetUp() {}
+void ut_ocrinterface::TearDown() {}
+
+// ==================== staticInterfaceName ====================
+
+TEST_F(ut_ocrinterface, StaticInterfaceName_ReturnsComDeepinOcr)
+{
+    EXPECT_STREQ(OcrInterface::staticInterfaceName(), "com.deepin.Ocr");
+}
+
+// ==================== 构造函数 ====================
+
+// 构造：基础属性 service/path/interface 正确设置
+TEST_F(ut_ocrinterface, Construct_SetsServicePathInterface)
+{
+    OcrInterface iface("com.deepin.Ocr.Fake",
+                       "/com/deepin/Ocr/Fake",
+                       QDBusConnection::sessionBus());
+    EXPECT_EQ(iface.service(), QString("com.deepin.Ocr.Fake"));
+    EXPECT_EQ(iface.path(), QString("/com/deepin/Ocr/Fake"));
+    EXPECT_EQ(iface.interface(), QString("com.deepin.Ocr"));
+}
+
+// 构造：public 成员 dbus 默认绑定到 sessionBus
+TEST_F(ut_ocrinterface, Construct_PublicDbusMemberIsSessionBus)
+{
+    OcrInterface iface("com.deepin.Ocr.Fake",
+                       "/com/deepin/Ocr/Fake",
+                       QDBusConnection::sessionBus());
+    EXPECT_EQ(iface.dbus.name(), QDBusConnection::sessionBus().name());
+}
+
+// 构造：使用 systemBus 不崩溃
+TEST_F(ut_ocrinterface, Construct_WithSystemBus_NoCrash)
+{
+    OcrInterface iface("com.deepin.Ocr.Fake",
+                       "/com/deepin/Ocr/Fake",
+                       QDBusConnection::systemBus());
+    EXPECT_EQ(iface.interface(), QString("com.deepin.Ocr"));
+}
+
+// ==================== 析构函数 ====================
+
+TEST_F(ut_ocrinterface, Destruct_DoesNotCrash)
+{
+    OcrInterface *iface = new OcrInterface("com.deepin.Ocr.Fake",
+                                           "/com/deepin/Ocr/Fake",
+                                           QDBusConnection::sessionBus());
+    delete iface;
+    SUCCEED();
+}
+
+// ==================== openFile ====================
+
+// openFile: 不触发真实 DBus，返回非空 reply（不崩溃）
+TEST_F(ut_ocrinterface, OpenFile_ReturnsPendingReply_NoCrash)
+{
+    Stub stub;
+    stub.set(ADDR(QDBusAbstractInterface, doCall), ut_ocr_stub_doCall);
+    OcrInterface iface("com.deepin.Ocr.Fake",
+                       "/com/deepin/Ocr/Fake",
+                       QDBusConnection::sessionBus());
+    QDBusPendingReply<> reply = iface.openFile("/tmp/ut_ocr_test.png");
+    (void)reply;
+    SUCCEED();
+}
+
+// ==================== openImage ====================
+
+// openImage: 有效图片经 PNG 编码、压缩、base64 后发出 call
+TEST_F(ut_ocrinterface, OpenImage_ValidImage_NoCrash)
+{
+    Stub stub;
+    stub.set(ADDR(QDBusAbstractInterface, doCall), ut_ocr_stub_doCall);
+    OcrInterface iface("com.deepin.Ocr.Fake",
+                       "/com/deepin/Ocr/Fake",
+                       QDBusConnection::sessionBus());
+    QImage img(20, 20, QImage::Format_RGB32);
+    img.fill(Qt::red);
+    QDBusPendingReply<> reply = iface.openImage(img);
+    (void)reply;
+    SUCCEED();
+}
+
+// openImage: null 图片时 save 失败，data 保持空，仍发出 call（else 分支）
+TEST_F(ut_ocrinterface, OpenImage_NullImage_NoCrash)
+{
+    Stub stub;
+    stub.set(ADDR(QDBusAbstractInterface, doCall), ut_ocr_stub_doCall);
+    OcrInterface iface("com.deepin.Ocr.Fake",
+                       "/com/deepin/Ocr/Fake",
+                       QDBusConnection::sessionBus());
+    QImage nullImg;
+    QDBusPendingReply<> reply = iface.openImage(nullImg);
+    (void)reply;
+    SUCCEED();
+}
+
+// ==================== openImageAndName ====================
+
+// openImageAndName: 有效图片 + 名称
+TEST_F(ut_ocrinterface, OpenImageAndName_ValidImageAndName_NoCrash)
+{
+    Stub stub;
+    stub.set(ADDR(QDBusAbstractInterface, doCall), ut_ocr_stub_doCall);
+    OcrInterface iface("com.deepin.Ocr.Fake",
+                       "/com/deepin/Ocr/Fake",
+                       QDBusConnection::sessionBus());
+    QImage img(20, 20, QImage::Format_RGB32);
+    img.fill(Qt::blue);
+    QDBusPendingReply<> reply = iface.openImageAndName(img, "ut_image.png");
+    (void)reply;
+    SUCCEED();
+}
+
+// openImageAndName: null 图片（save 失败分支）
+TEST_F(ut_ocrinterface, OpenImageAndName_NullImage_NoCrash)
+{
+    Stub stub;
+    stub.set(ADDR(QDBusAbstractInterface, doCall), ut_ocr_stub_doCall);
+    OcrInterface iface("com.deepin.Ocr.Fake",
+                       "/com/deepin/Ocr/Fake",
+                       QDBusConnection::sessionBus());
+    QImage nullImg;
+    QDBusPendingReply<> reply = iface.openImageAndName(nullImg, "ut_null.png");
+    (void)reply;
+    SUCCEED();
+}

--- a/tests/src/ut_ocrinterface.h
+++ b/tests/src/ut_ocrinterface.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef UT_OCRINTERFACE_H
+#define UT_OCRINTERFACE_H
+
+#include <gtest/gtest.h>
+
+class OcrInterface;
+
+class ut_ocrinterface : public testing::Test
+{
+protected:
+    virtual void SetUp() override;
+    virtual void TearDown() override;
+};
+
+#endif  // UT_OCRINTERFACE_H

--- a/tests/src/ut_printhelper.cpp
+++ b/tests/src/ut_printhelper.cpp
@@ -1,0 +1,215 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "ut_printhelper.h"
+#include "printhelper.h"
+
+#include <DDialog>
+#include <dprintpreviewwidget.h>
+#include <QImage>
+#include <QTemporaryFile>
+#include <QFile>
+#include <QFileInfo>
+#include <dlfcn.h>
+
+#include "stub.h"
+
+DWIDGET_USE_NAMESPACE
+
+// 桩：避免 DPrintPreviewDialog（继承自 DDialog）的 exec() 阻塞测试。
+// 注意：exec 为虚函数，ADDR(DDialog, exec) 返回的是 vtable 偏移而非真实代码地址，
+// 会导致 Stub::set 内部 memcpy 越界。这里通过 dlsym 解析其真实符号地址。
+static int ut_printhelper_stub_exec(DDialog *)
+{
+    return 0;
+}
+
+static void ut_printhelper_install_exec_stub(Stub &stub)
+{
+    void *addr = dlsym(RTLD_DEFAULT, "_ZN3Dtk6Widget7DDialog4execEv");
+    ASSERT_TRUE(addr != nullptr);
+    stub.set(addr, ut_printhelper_stub_exec);
+}
+
+void ut_printhelper::SetUp() {}
+void ut_printhelper::TearDown() {}
+
+// ==================== RequestedSlot ====================
+
+// 测试构造函数初始化成员为空
+TEST_F(ut_printhelper, RequestedSlot_Construct_InitializesEmptyMembers)
+{
+    RequestedSlot slot;
+    EXPECT_TRUE(slot.m_paths.isEmpty());
+    EXPECT_TRUE(slot.m_imgs.isEmpty());
+}
+
+// 测试析构函数不崩溃
+TEST_F(ut_printhelper, RequestedSlot_Destruct_DoesNotCrash)
+{
+    RequestedSlot *slot = new RequestedSlot();
+    delete slot;
+    SUCCEED();
+}
+
+// 测试 public 成员 m_paths / m_imgs 可读写
+TEST_F(ut_printhelper, RequestedSlot_PublicMembers_ReadWrite)
+{
+    RequestedSlot slot;
+    slot.m_paths << "path1" << "path2";
+    QImage img(10, 10, QImage::Format_RGB32);
+    slot.m_imgs << img;
+    EXPECT_EQ(slot.m_paths.size(), 2);
+    EXPECT_EQ(slot.m_imgs.size(), 1);
+}
+
+// paintRequestSync: m_imgs 为空时仅创建 painter 并 end，不崩溃
+TEST_F(ut_printhelper, RequestedSlot_PaintRequestSync_EmptyImgs_NoCrash)
+{
+    RequestedSlot slot;
+    DPrinter printer;
+    slot.paintRequestSync(&printer);  // private slot，借助 -fno-access-control 直调
+    SUCCEED();
+}
+
+// paintRequestSync: 单张有效图片，走 drawImage 分支
+TEST_F(ut_printhelper, RequestedSlot_PaintRequestSync_SingleValidImage)
+{
+    RequestedSlot slot;
+    QImage img(100, 100, QImage::Format_RGB32);
+    img.fill(Qt::white);
+    slot.m_imgs << img;
+    DPrinter printer;
+    slot.paintRequestSync(&printer);
+    SUCCEED();
+}
+
+// paintRequestSync: 含 null 图片（跳过绘制分支）+ 有效图片
+TEST_F(ut_printhelper, RequestedSlot_PaintRequestSync_NullImageSkipped)
+{
+    RequestedSlot slot;
+    QImage nullImg;  // null
+    QImage validImg(50, 50, QImage::Format_RGB32);
+    validImg.fill(Qt::red);
+    slot.m_imgs << nullImg << validImg;
+    DPrinter printer;
+    slot.paintRequestSync(&printer);
+    SUCCEED();
+}
+
+// paintRequestSync: 多张有效图片触发 newPage 分支
+TEST_F(ut_printhelper, RequestedSlot_PaintRequestSync_MultipleImages_NewPage)
+{
+    RequestedSlot slot;
+    QImage img1(80, 80, QImage::Format_RGB32);
+    img1.fill(Qt::blue);
+    QImage img2(120, 60, QImage::Format_RGB32);
+    img2.fill(Qt::green);
+    slot.m_imgs << img1 << img2;
+    DPrinter printer;
+    slot.paintRequestSync(&printer);
+    SUCCEED();
+}
+
+// paintRequestSync: 宽扁图片（适配宽度分支）
+TEST_F(ut_printhelper, RequestedSlot_PaintRequestSync_WideImage_FitWidth)
+{
+    RequestedSlot slot;
+    QImage wide(300, 30, QImage::Format_RGB32);
+    wide.fill(Qt::yellow);
+    slot.m_imgs << wide;
+    DPrinter printer;
+    slot.paintRequestSync(&printer);
+    SUCCEED();
+}
+
+// ==================== PrintHelper ====================
+
+// getIntance: 返回非空且单例一致
+TEST_F(ut_printhelper, PrintHelper_GetIntance_ReturnsSingleton)
+{
+    PrintHelper *p1 = PrintHelper::getIntance();
+    PrintHelper *p2 = PrintHelper::getIntance();
+    EXPECT_NE(p1, nullptr);
+    EXPECT_EQ(p1, p2);
+}
+
+// getIntance 后实例持有 m_re
+TEST_F(ut_printhelper, PrintHelper_Instance_HasRequestedSlotMember)
+{
+    PrintHelper *p = PrintHelper::getIntance();
+    EXPECT_NE(p->m_re, nullptr);
+}
+
+// 私有构造函数（借 -fno-access-control 直调）创建 m_re
+TEST_F(ut_printhelper, PrintHelper_PrivateConstructor_CreatesRequestedSlot)
+{
+    PrintHelper *p = new PrintHelper();
+    EXPECT_NE(p->m_re, nullptr);
+    delete p;  // 析构会调用 m_re->deleteLater()，随后 QObject 销毁子对象
+}
+
+// showPrintDialog: 空路径列表，exec 被桩住，结束后成员被清空
+TEST_F(ut_printhelper, PrintHelper_ShowPrintDialog_EmptyPaths_ClearsState)
+{
+    PrintHelper *p = PrintHelper::getIntance();
+    Stub stub;
+    ut_printhelper_install_exec_stub(stub);
+    p->showPrintDialog(QStringList(), nullptr);
+    EXPECT_TRUE(p->m_re->m_paths.isEmpty());
+    EXPECT_TRUE(p->m_re->m_imgs.isEmpty());
+}
+
+// showPrintDialog: 不存在的路径，图片加载失败但不崩溃
+TEST_F(ut_printhelper, PrintHelper_ShowPrintDialog_NonexistentPath_NoCrash)
+{
+    PrintHelper *p = PrintHelper::getIntance();
+    Stub stub;
+    ut_printhelper_install_exec_stub(stub);
+    QStringList paths;
+    paths << "/tmp/ut_printhelper_nonexistent_12345.png";
+    p->showPrintDialog(paths, nullptr);
+    EXPECT_TRUE(p->m_re->m_paths.isEmpty());
+    EXPECT_TRUE(p->m_re->m_imgs.isEmpty());
+}
+
+// showPrintDialog: 有效图片路径，加载后走 setDocName 路径
+TEST_F(ut_printhelper, PrintHelper_ShowPrintDialog_ValidImage_LoadsAndClears)
+{
+    // 生成临时 PNG 文件
+    QString tmpPath = QString("/tmp/ut_printhelper_%1.png").arg(QCoreApplication::instance()->applicationPid());
+    QImage img(50, 50, QImage::Format_RGB32);
+    img.fill(Qt::blue);
+    ASSERT_TRUE(img.save(tmpPath, "PNG"));
+
+    PrintHelper *p = PrintHelper::getIntance();
+    Stub stub;
+    ut_printhelper_install_exec_stub(stub);
+    QStringList paths;
+    paths << tmpPath;
+    p->showPrintDialog(paths, nullptr);
+    EXPECT_TRUE(p->m_re->m_paths.isEmpty());
+    EXPECT_TRUE(p->m_re->m_imgs.isEmpty());
+
+    QFile::remove(tmpPath);
+}
+
+// showPrintDialog: 多路径混合（含一个有效）
+TEST_F(ut_printhelper, PrintHelper_ShowPrintDialog_MultiplePaths_NoCrash)
+{
+    QString tmpPath = QString("/tmp/ut_printhelper_multi_%1.jpg").arg(QCoreApplication::instance()->applicationPid());
+    QImage img(40, 60, QImage::Format_RGB32);
+    img.fill(Qt::green);
+    ASSERT_TRUE(img.save(tmpPath, "JPG"));
+
+    PrintHelper *p = PrintHelper::getIntance();
+    Stub stub;
+    ut_printhelper_install_exec_stub(stub);
+    QStringList paths;
+    paths << tmpPath << "/tmp/ut_printhelper_missing.png";
+    p->showPrintDialog(paths, nullptr);
+    EXPECT_TRUE(p->m_re->m_paths.isEmpty());
+
+    QFile::remove(tmpPath);
+}

--- a/tests/src/ut_printhelper.h
+++ b/tests/src/ut_printhelper.h
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef UT_PRINTHELPER_H
+#define UT_PRINTHELPER_H
+
+#include <gtest/gtest.h>
+
+class PrintHelper;
+class RequestedSlot;
+
+class ut_printhelper : public testing::Test
+{
+protected:
+    virtual void SetUp() override;
+    virtual void TearDown() override;
+};
+
+#endif  // UT_PRINTHELPER_H


### PR DESCRIPTION
Add GTest unit tests for RequestedSlot, PrintHelper, LiveTextAnalyzer and OcrInterface with full function coverage. Switch test main to QApplication for QWidget-based print dialog.

为 printdialog 与 ocr 模块的 4 个类补充 GTest 单元测试，覆盖全部
public 与 protected 函数，共 45 个测试用例；测试入口改用 QApplication 以支持 DPrintPreviewDialog 等 QWidget。

Log: 补充 printdialog 与 ocr 模块单元测试
Influence: 新增 tests/src 下测试文件并调整测试入口应用类型，仅 Debug 模式生效，不影响 Release 构建.