### PR TITLE
test(types): augment unit tests for types and related modules

### DIFF
--- a/tests/src/ut_commandparser.cpp
+++ b/tests/src/ut_commandparser.cpp
@@ -7,6 +7,10 @@
 
 #include <QCoreApplication>
 #include <QStringList>
+#include <QCommandLineOption>
+
+#include "stub.h"
+#include "printhelper.h"
 
 void ut_commandparser::SetUp()
 {
@@ -59,4 +63,107 @@ TEST_F(ut_commandparser, ValueOfOption)
     // 不存在的选项值应为空
     QString val = parser->value("nonexistent_option");
     EXPECT_TRUE(val.isEmpty());
+}
+
+// ---- 桩函数 ----
+// 桩: 替换 QCoreApplication::arguments, 避免测试进程真实的 --gtest_filter
+// 等参数被 QCommandLineParser 视为未知选项而触发 exit
+static QStringList ut_commandparser_stub_appArguments()
+{
+    return QStringList() << QCoreApplication::applicationFilePath()
+                         << QStringLiteral("stub_image.png");
+}
+
+// 桩: 替换 PrintHelper::showPrintDialog, 避免弹出真实打印对话框(首参为 this)
+static void ut_commandparser_stub_showPrintDialog(PrintHelper *,
+                                                  const QStringList &,
+                                                  QWidget *)
+{
+}
+
+// 测试无参 process() 重载(内部调用 qApp->arguments())
+TEST_F(ut_commandparser, ProcessNoArgs_UsesAppArguments_ParsesPositional)
+{
+    Stub stub;
+    stub.set(&QCoreApplication::arguments, ut_commandparser_stub_appArguments);
+
+    CommandParser *parser = CommandParser::instance();
+    parser->process();
+
+    QStringList positional = parser->positionalArguments();
+    ASSERT_FALSE(positional.isEmpty());
+    EXPECT_EQ(positional.first(), QStringLiteral("stub_image.png"));
+}
+
+// 测试 quickPrint 在无位置参数时提前返回(不弹打印对话框)
+TEST_F(ut_commandparser, QuickPrint_NoPositional_ReturnsEarly)
+{
+    CommandParser *parser = CommandParser::instance();
+
+    QStringList args;
+    args << QCoreApplication::applicationFilePath();
+    parser->process(args);
+
+    // 无位置参数, 提前返回, 不应崩溃
+    parser->quickPrint();
+    SUCCEED();
+}
+
+// 测试 quickPrint 在有位置参数时调用打印对话框(打桩避免 GUI 阻塞)
+TEST_F(ut_commandparser, QuickPrint_WithPositional_CallsPrintDialog)
+{
+    CommandParser *parser = CommandParser::instance();
+
+    QStringList args;
+    args << QCoreApplication::applicationFilePath() << QStringLiteral("image.jpg");
+    parser->process(args);
+
+    Stub stub;
+    stub.set(ADDR(PrintHelper, showPrintDialog),
+             ut_commandparser_stub_showPrintDialog);
+
+    // 打桩后调用不应弹窗也不应崩溃
+    parser->quickPrint();
+    SUCCEED();
+}
+
+// 测试 isSet 对已设置选项(--print)返回 true
+TEST_F(ut_commandparser, IsSet_SetOption_ReturnsTrue)
+{
+    CommandParser *parser = CommandParser::instance();
+
+    QStringList args;
+    args << QCoreApplication::applicationFilePath() << QStringLiteral("--print");
+    parser->process(args);
+
+    EXPECT_TRUE(parser->isSet(QStringLiteral("print")));
+}
+
+// 测试 value 对已设置的标志选项返回空字符串
+TEST_F(ut_commandparser, Value_SetFlagOption_ReturnsEmpty)
+{
+    CommandParser *parser = CommandParser::instance();
+
+    QStringList args;
+    args << QCoreApplication::applicationFilePath() << QStringLiteral("--print");
+    parser->process(args);
+
+    QString val = parser->value(QStringLiteral("print"));
+    EXPECT_TRUE(val.isEmpty());
+}
+
+// 测试私有方法 addOption(-fno-access-control 启用) 添加自定义选项后可识别
+TEST_F(ut_commandparser, AddOption_CustomOption_BecomesRecognized)
+{
+    CommandParser *parser = CommandParser::instance();
+
+    QCommandLineOption customOpt(QStringLiteral("ut_custom_option"));
+    parser->addOption(customOpt);
+
+    QStringList args;
+    args << QCoreApplication::applicationFilePath()
+         << QStringLiteral("--ut_custom_option");
+    parser->process(args);
+
+    EXPECT_TRUE(parser->isSet(QStringLiteral("ut_custom_option")));
 }

--- a/tests/src/ut_configsetter.cpp
+++ b/tests/src/ut_configsetter.cpp
@@ -61,3 +61,45 @@ TEST_F(ut_configsetter, ValueChangedSignal)
     setter->setValue("signal_group", "signal_key", QString("signal_value"));
     EXPECT_EQ(spy.count(), 1);
 }
+
+// 测试私有构造函数与析构函数(-fno-access-control 允许访问私有成员)
+// 仅构造与析构, 不写入数据以免污染共享配置文件
+TEST_F(ut_configsetter, PrivateConstructorDestructor_RunsClean)
+{
+    LibConfigSetter *setter = new LibConfigSetter();
+    ASSERT_TRUE(setter != nullptr);
+    delete setter;
+}
+
+// 测试设置并读取整型值
+TEST_F(ut_configsetter, SetValue_IntType_RoundTrips)
+{
+    LibConfigSetter *setter = LibConfigSetter::instance();
+    setter->setValue("ut_int_group", "ut_int_key", 42);
+
+    QVariant readValue = setter->value("ut_int_group", "ut_int_key");
+    EXPECT_EQ(readValue.toInt(), 42);
+}
+
+// 测试读取不存在的键且未提供默认值时返回无效(空)结果
+TEST_F(ut_configsetter, Value_NonexistentKeyNoDefault_ReturnsInvalid)
+{
+    LibConfigSetter *setter = LibConfigSetter::instance();
+    QVariant v = setter->value("ut_nonexist_group", "ut_nonexist_key");
+    EXPECT_FALSE(v.isValid());
+}
+
+// 测试 valueChanged 信号携带正确的 group/key/value 参数
+TEST_F(ut_configsetter, ValueChangedSignal_CarriesCorrectParameters)
+{
+    LibConfigSetter *setter = LibConfigSetter::instance();
+
+    QSignalSpy spy(setter, &LibConfigSetter::valueChanged);
+    setter->setValue("ut_signal_group", "ut_signal_key", QString("ut_signal_value"));
+
+    ASSERT_EQ(spy.count(), 1);
+    QList<QVariant> args = spy.takeFirst();
+    EXPECT_EQ(args.at(0).toString(), QStringLiteral("ut_signal_group"));
+    EXPECT_EQ(args.at(1).toString(), QStringLiteral("ut_signal_key"));
+    EXPECT_EQ(args.at(2).toString(), QStringLiteral("ut_signal_value"));
+}

--- a/tests/src/ut_cursortool.cpp
+++ b/tests/src/ut_cursortool.cpp
@@ -8,6 +8,9 @@
 #include <QCursor>
 #include <QPoint>
 #include <QSignalSpy>
+#include <QTest>
+
+#include "stub.h"
 
 void ut_cursortool::SetUp()
 {
@@ -49,4 +52,60 @@ TEST_F(ut_cursortool, ActiveColor)
     CursorTool tool;
     QColor color = tool.activeColor();
     EXPECT_TRUE(color.isValid());
+}
+
+// ---- 桩函数 ----
+// 桩: 替换 QCursor::pos, 提供确定性的光标位置以触发 cursorPosChanged 信号
+static QPoint ut_cursortool_stub_cursorPos()
+{
+    return QPoint(100, 200);
+}
+
+// 测试采样定时器触发后发出 cursorPosChanged 信号(光标位置变化时)
+TEST_F(ut_cursortool, SetCaptureCursor_PositionChanged_EmitsSignal)
+{
+    Stub stub;
+    stub.set(static_cast<QPoint (*)()>(&QCursor::pos),
+             ut_cursortool_stub_cursorPos);
+
+    CursorTool tool;
+    QSignalSpy spy(&tool, &CursorTool::cursorPosChanged);
+
+    tool.setCaptureCursor(true);
+    // 采样间隔 50ms, 等待足够时间触发首次位置变化
+    QTest::qWait(200);
+    tool.setCaptureCursor(false);
+
+    // m_lastPos 初始为 (0,0), 桩返回 (100,200), 首次触发应发信号
+    EXPECT_GE(spy.count(), 1);
+    if (spy.count() > 0) {
+        QList<QVariant> args = spy.takeFirst();
+        EXPECT_EQ(args.at(0).toInt(), 100);
+        EXPECT_EQ(args.at(1).toInt(), 200);
+    }
+}
+
+// 测试重复启停采样定时器不崩溃(覆盖 if/else 两个分支多次进入)
+TEST_F(ut_cursortool, SetCaptureCursor_RepeatedToggle_NoCrash)
+{
+    CursorTool tool;
+    // 停止状态下再次停止(走 stop 分支)
+    tool.setCaptureCursor(false);
+    // 连续启动(走 start 分支)
+    tool.setCaptureCursor(true);
+    tool.setCaptureCursor(true);
+    // 再次停止
+    tool.setCaptureCursor(false);
+    tool.setCaptureCursor(false);
+    SUCCEED();
+}
+
+// 测试构造函数传入父对象时建立正确的父子关系
+TEST_F(ut_cursortool, Constructor_WithParent_HoldsParent)
+{
+    QObject parent;
+    CursorTool *tool = new CursorTool(&parent);
+    ASSERT_TRUE(tool != nullptr);
+    EXPECT_EQ(tool->parent(), &parent);
+    delete tool;
 }

--- a/tests/src/ut_types.cpp
+++ b/tests/src/ut_types.cpp
@@ -38,3 +38,20 @@ TEST_F(ut_types, ItemRoleEnumValues)
     EXPECT_EQ(static_cast<int>(Types::FrameIndexRole), Qt::UserRole + 2);
     EXPECT_EQ(static_cast<int>(Types::ImageAngleRole), Qt::UserRole + 3);
 }
+
+// 验证构造函数(无父对象)与析构函数正常执行
+TEST_F(ut_types, ConstructorDefault_NoParent_HoldsNoParent)
+{
+    Types types;
+    EXPECT_EQ(types.parent(), nullptr);
+}
+
+// 验证带父对象的构造函数正确建立父子关系
+TEST_F(ut_types, ConstructorWithParent_ParentGiven_HoldsParent)
+{
+    QObject parent;
+    Types *child = new Types(&parent);
+    ASSERT_TRUE(child != nullptr);
+    EXPECT_EQ(child->parent(), &parent);
+    delete child;
+}


### PR DESCRIPTION
Augment existing GTest unit tests for Types, CommandParser, Configsetter and CursorTool to reach full function coverage.

增量补全 Types、CommandParser、Configsetter、CursorTool 四个类的 已有测试，新增 15 个用例覆盖此前未测的构造析构、私有方法、信号路径
与命令分支，达到 100% 函数覆盖。

Log: 增量补全四个简单类单元测试至全覆盖
Influence: 仅追加 tests/src 下已有测试文件用例，Debug 模式生效，不影响 Release 构建.

## Summary by Sourcery

Extend unit test coverage for several utility classes to fully exercise constructors, destructors, signals, and command paths.

Tests:
- Expand CommandParser tests to cover argument processing, quickPrint behavior, option handling, and a private addOption path using stubs to avoid GUI and real process arguments.
- Extend CursorTool tests to verify cursor capture signaling with deterministic cursor positions, repeated timer toggling, and parent-child relationships.
- Augment LibConfigSetter tests to cover private construction/destruction, integer round-trip persistence, missing-key behavior, and valueChanged signal payloads.
- Enhance Types tests to validate constructor behavior with and without parent objects.