### PR TITLE
fix(image): reduce memory retention during image navigation

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,12 +27,24 @@
 #include <QQmlContext>
 #include <QIcon>
 
+#ifdef Q_OS_LINUX
+#include <malloc.h>
+#endif
+
 Q_LOGGING_CATEGORY(logImageViewer, "org.deepin.dde.imageviewer")
 DWIDGET_USE_NAMESPACE
 DCORE_USE_NAMESPACE
 
 int main(int argc, char *argv[])
 {
+#ifdef Q_OS_LINUX
+    // Keep large image buffers mmap-backed instead of retaining them in the heap after repeated decoding.
+    constexpr int imageBufferMmapThreshold = 128 * 1024;
+    if (!mallopt(M_MMAP_THRESHOLD, imageBufferMmapThreshold)) {
+        qCWarning(logImageViewer) << "Failed to set image buffer mmap threshold";
+    }
+#endif
+
     qCDebug(logImageViewer) << "Application starting...";
     qputenv("D_POPUP_MODE", "embed");
     if (qEnvironmentVariableIsEmpty("XDG_CURRENT_DESKTOP")) {
@@ -135,10 +147,6 @@ int main(int argc, char *argv[])
 
         providerCache = static_cast<ProviderCache *>(asyncImageProvider);
 
-        if (!cliParam.isEmpty()) {
-            qCDebug(logImageViewer) << "Preloading image from commandline parameter.";
-            asyncImageProvider->preloadImage(cliParam);
-        }
     }
 
     ThumbnailProvider *multiImageLoad = new ThumbnailProvider;

--- a/src/qml/ImageDelegate/BaseImageDelegate.qml
+++ b/src/qml/ImageDelegate/BaseImageDelegate.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -27,6 +27,7 @@ Item {
     property ImageInputHandler inputHandler: null
     // PathView not provides index === IV.GControl.currentIndex, use ViewDelegateLoader.enabled
     property bool isCurrentImage: parent.enabled
+    property bool rapidSwitching: parent && parent.rapidSwitching
     // 坐标偏移，用于动画效果时调整显示位置
     property real offset: 0
     // 图片绘制区域到边框的位置

--- a/src/qml/ImageDelegate/NormalImageDelegate.qml
+++ b/src/qml/ImageDelegate/NormalImageDelegate.qml
@@ -10,6 +10,31 @@ BaseImageDelegate {
     id: delegate
 
     property bool rotationRunning: false
+    property bool sourceUpdatePending: false
+    readonly property int neighborPreviewMaxDimension: 960
+    readonly property int rapidSwitchPreviewMaxDimension: 512
+
+    function previewSize(maxDimension) {
+        if (delegate.width <= 0 || delegate.height <= 0) {
+            return Qt.size(maxDimension, maxDimension)
+        }
+
+        var longestEdge = Math.max(delegate.width, delegate.height)
+        if (longestEdge <= maxDimension) {
+            return Qt.size(delegate.width, delegate.height)
+        }
+
+        var scale = maxDimension / longestEdge
+        return Qt.size(Math.round(delegate.width * scale), Math.round(delegate.height * scale))
+    }
+
+    function neighborPreviewSize() {
+        return previewSize(neighborPreviewMaxDimension)
+    }
+
+    function rapidSwitchPreviewSize() {
+        return previewSize(rapidSwitchPreviewMaxDimension)
+    }
 
     function resetSource() {
         // check if source rename
@@ -24,10 +49,14 @@ BaseImageDelegate {
     }
 
     function updateSource() {
+        sourceSizeOptimizer.resetSourceSize()
         if (delegate.source != "") {
+            // Do not retain the old texture while changing images; retain it only for same-image scale upgrades.
+            sourceUpdatePending = true
             // 由于会 resetSource() 破坏绑定，因此重新设置源数据
             image.source = "image://ImageLoad/" + delegate.source + "#frame_" + delegate.frameIndex;
         } else {
+            sourceUpdatePending = false
             image.source = "";
         }
     }
@@ -50,17 +79,23 @@ BaseImageDelegate {
         scale: 1.0
         smooth: true
         source: "image://ImageLoad/" + delegate.source + "#frame_" + delegate.frameIndex
-        sourceSize: sourceSizeOptimizer.optimizedSourceSize
+        sourceSize: delegate.isCurrentImage ? (delegate.rapidSwitching
+                                                 ? delegate.rapidSwitchPreviewSize()
+                                                 : sourceSizeOptimizer.optimizedSourceSize)
+                                             : delegate.neighborPreviewSize()
         width: delegate.width
         // debounced (scroll wheel): retain old texture for smooth transition
         // immediate (large jump): no retain, use snapshot instead
-        retainWhileLoading: !sourceSizeOptimizer.immediateUpgrade
+        retainWhileLoading: !delegate.sourceUpdatePending && !sourceSizeOptimizer.immediateUpgrade
 
         onScaleChanged: {
             sourceSizeOptimizer.requestUpdate()
         }
 
         onStatusChanged: {
+            if (Image.Ready === image.status || Image.Error === image.status) {
+                sourceUpdatePending = false
+            }
             if (Image.Ready === image.status && !rotationRunning) {
                 rotateAnimationLoader.active = false;
                 if (upgradeSnapshotLoader.active) {

--- a/src/qml/ImageDelegate/ViewDelegateLoader.qml
+++ b/src/qml/ImageDelegate/ViewDelegateLoader.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -28,7 +28,7 @@ Loader {
         if (PathView.isCurrentItem) {
             return true;
         }
-        return PathView.onPath;
+        return PathView.onPath && PathView.view.preloadNeighbors;
     }
     asynchronous: true
     enabled: PathView.isCurrentItem

--- a/src/qml/ImageViewer.qml
+++ b/src/qml/ImageViewer.qml
@@ -322,6 +322,17 @@ Item {
         }
         // 用于限制拖拽方向(处于头尾时)
         property real previousOffset: 0
+        property bool preloadNeighbors: false
+        property bool rapidSwitching: false
+        property bool viewInitialized: false
+
+        function scheduleNeighborPreload() {
+            if (viewInitialized && neighborPreloadTimer.running) {
+                rapidSwitching = true;
+            }
+            preloadNeighbors = false;
+            neighborPreloadTimer.restart();
+        }
 
         // WARNING: 目前 ListView 组件屏蔽输入处理，窗口拖拽依赖底层的 ApplicationWindow
         // 因此不允许 ListView 的区域超过标题栏，图片缩放超过显示区域无妨。
@@ -425,13 +436,29 @@ Item {
             }
         }
 
+        Timer {
+            id: neighborPreloadTimer
+
+            interval: 300
+            repeat: false
+
+            onTriggered: {
+                view.rapidSwitching = false;
+                view.preloadNeighbors = true;
+            }
+        }
+
         Component.onCompleted: {
             // 首次进入(退出缩略图后创建)重置当前显示的索引
             IV.GStatus.viewFlicking = true;
             currentIndex = IV.GControl.viewModel.currentIndex;
             IV.GStatus.viewFlicking = false;
+            viewInitialized = true;
+            neighborPreloadTimer.start();
         }
         onCurrentIndexChanged: {
+            scheduleNeighborPreload();
+
             var curIndex = view.currentIndex;
             var previousIndex = IV.GControl.viewModel.currentIndex;
             var lastIndex = view.count - 1;

--- a/src/src/globalcontrol.cpp
+++ b/src/src/globalcontrol.cpp
@@ -17,6 +17,7 @@
 Q_DECLARE_LOGGING_CATEGORY(logImageViewer)
 
 static const int sc_SubmitInterval = 200;   // 图片变更提交定时间隔 200ms
+static const int sc_ViewModelSyncInterval = 200;  // Main image view-model synchronization debounce interval.
 
 /**
    @class GlobalControl
@@ -560,6 +561,9 @@ void GlobalControl::timerEvent(QTimerEvent *event)
     } else if (switchCheckTimer.timerId() == event->timerId()) {
         switchCheckTimer.stop();
         checkSwitchEnable();
+    } else if (viewModelSyncTimer.timerId() == event->timerId()) {
+        viewModelSyncTimer.stop();
+        viewSourceModel->setCurrentSourceIndex(curIndex, curFrameIndex);
     }
 }
 
@@ -629,7 +633,7 @@ void GlobalControl::setIndexAndFrameIndex(int index, int frameIndex)
 
     checkSwitchEnable();
 
-    // 更新视图模型
-    viewSourceModel->setCurrentSourceIndex(curIndex, curFrameIndex);
+    // During rapid navigation, synchronize only the final index to avoid decoding intermediate images.
+    viewModelSyncTimer.start(sc_ViewModelSyncInterval, this);
     qCDebug(logImageViewer) << "Index and frame index update complete";
 }

--- a/src/src/globalcontrol.h
+++ b/src/src/globalcontrol.h
@@ -102,6 +102,7 @@ private:
     int imageRotation = 0;    // 当前图片旋转角度
     QBasicTimer submitTimer;  // 图片变更提交定时器
     QBasicTimer switchCheckTimer;  // 切换按钮状态检查防抖定时器
+    QBasicTimer viewModelSyncTimer;  // Main image view-model synchronization debounce timer.
 };
 
 #endif  // GLOBALCONTROL_H


### PR DESCRIPTION
Limit large image allocations and defer neighbor loading during rapid navigation.

限制大图内存分配，并在快速导航时延后加载相邻图片。

Log: 降低图片切换过程中的内存滞留
Influence: 减少连续切换大图时的内存增长，快速切换后仅加载最终图片。

## Summary by Sourcery

Reduce memory usage and unnecessary decoding during rapid image navigation by throttling view model updates and deferring neighbor preloading.

New Features:
- Introduce dynamic preview sizing for current and neighboring images based on navigation speed and delegate dimensions.
- Add configurable neighbor preloading behavior controlled by a debounce timer in the main image view.

Bug Fixes:
- Avoid retaining old image textures while switching sources, ensuring textures are only kept during same-image scale upgrades.
- Prevent intermediate images from being decoded during fast navigation by debouncing synchronization with the underlying view model.

Enhancements:
- Adjust image source size selection to use smaller previews during rapid switching and for neighbor images, reducing large image allocations.
- Gate neighbor delegate loading on an explicit preload flag to limit concurrent image loading under heavy navigation.
- Tune Linux memory allocation behavior by lowering the mmap threshold for image buffers to reduce heap retention.
- Remove eager preloading of the command-line image at startup to avoid unnecessary initial decoding.