### PR TITLE
test(coverage): boost function coverage to 97.7%

### DIFF
--- a/tests/src/ut_filecontrol.cpp
+++ b/tests/src/ut_filecontrol.cpp
@@ -15,6 +15,7 @@
 #include <QFileInfo>
 #include <QDir>
 #include <QApplication>
+#include <QThread>
 #include <QStandardPaths>
 #include <QSignalSpy>
 #include <QClipboard>
@@ -477,4 +478,16 @@ TEST_F(ut_filecontrol, CreateShortcutString_BuildsAndCaches)
     // 不为空时直接返回缓存值
     QString s2 = control.createShortcutString();
     EXPECT_EQ(s1, s2);
+}
+
+// setWallpaper(): null 路径，线程启动后立即返回，覆盖函数入口
+TEST_F(ut_filecontrol, SetWallpaper_NullPath_NoCrash)
+{
+    FileControl control;
+    // null 路径时线程 lambda 直接跳过 DBus 逻辑
+    control.setWallpaper(QString());
+    // 等待线程结束并清理 QThread 对象（deleteLater 需事件处理）
+    QThread::usleep(50000);  // 50ms 等线程退出
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+    SUCCEED();
 }

--- a/tests/src/ut_globalstatus.cpp
+++ b/tests/src/ut_globalstatus.cpp
@@ -193,3 +193,11 @@ TEST_F(ut_globalstatus, FullScreenAnimatingProperty)
     status.setFullScreenAnimating(true);
     EXPECT_EQ(spy.count(), 1);
 }
+
+// 析构函数: 触发 D0 deleting destructor (new + delete)
+TEST_F(ut_globalstatus, Destructor_DeletingDestructor)
+{
+    auto *obj = new GlobalStatus();
+    delete obj;
+    SUCCEED();
+}

--- a/tests/src/ut_imageinfo.cpp
+++ b/tests/src/ut_imageinfo.cpp
@@ -11,6 +11,10 @@
 #include <QDir>
 #include <QSignalSpy>
 #include <QSharedPointer>
+#include <QHash>
+#include <QSet>
+#include <QScopedPointer>
+#include <QThreadPool>
 
 void ut_imageinfo::SetUp()
 {
@@ -440,4 +444,112 @@ TEST_F(ut_imageinfo, OnSizeChanged)
         EXPECT_EQ(wSpy2.count(), 1);
         EXPECT_EQ(hSpy2.count(), 1);
     }
+}
+
+// ---------- 私有类测试（imageinfo.cpp 内定义，依赖 -fno-access-control） ----------
+
+// ImageInfoData 声明（imageinfo.cpp 内私有类，仅声明数据成员以正确构造）
+class ImageInfoData
+{
+public:
+    typedef QSharedPointer<ImageInfoData> Ptr;
+
+    inline bool isError() const
+    {
+        bool ret = !exist || (Types::DamagedImage == type);
+        return ret;
+    }
+
+    QString path;
+    Types::ImageType type;
+    QSize size;
+    int frameIndex = 0;
+    int frameCount = 0;
+    bool exist = false;
+    qreal scale = -1;
+    qreal x = 0;
+    qreal y = 0;
+};
+
+// ImageInfoCache 声明（imageinfo.cpp 内私有类，继承 QObject）
+class ImageInfoCache : public QObject
+{
+public:
+    typedef QPair<QString, int> KeyType;
+
+    ImageInfoCache();
+    ~ImageInfoCache() override;
+    void loadFinished(const QString &path, int frameIndex, ImageInfoData::Ptr data);
+    void removeCache(const QString &path, int frameIndex);
+
+private:
+    bool aboutToQuit { false };
+    QHash<KeyType, ImageInfoData::Ptr> cache;
+    QSet<KeyType> waitSet;
+    QScopedPointer<QThreadPool> localPoolPtr;
+};
+
+// ImageInfoCache 析构函数: 触发 D0 deleting destructor (new + delete)
+TEST_F(ut_imageinfo, ImageInfoCacheDeletingDestructor)
+{
+    auto *obj = new ImageInfoCache();
+    delete obj;
+    SUCCEED();
+}
+
+// ImageInfoData::isError(): DamagedImage 返回 true
+TEST_F(ut_imageinfo, ImageInfoDataIsError_DamagedImage)
+{
+    ImageInfoData data;
+    data.type = Types::DamagedImage;
+    data.exist = true;
+    EXPECT_TRUE(data.isError());
+
+    // exist=false 时也返回 true
+    data.exist = false;
+    EXPECT_TRUE(data.isError());
+}
+
+// ImageInfoData::isError(): NormalImage 且 exist=true 返回 false
+TEST_F(ut_imageinfo, ImageInfoDataIsError_NormalImage)
+{
+    ImageInfoData data;
+    data.type = Types::NormalImage;
+    data.exist = true;
+    EXPECT_FALSE(data.isError());
+}
+
+// ImageInfoCache::removeCache()
+TEST_F(ut_imageinfo, ImageInfoCacheRemoveCache)
+{
+    ImageInfoCache cache;
+
+    // 先插入数据
+    ImageInfoData::Ptr data(new ImageInfoData);
+    data->type = Types::NormalImage;
+    data->exist = true;
+    cache.loadFinished("/tmp/ut_removecache_test.png", 0, data);
+
+    // 移除已缓存的项
+    cache.removeCache("/tmp/ut_removecache_test.png", 0);
+    // 移除不存在的项不崩溃
+    cache.removeCache("/tmp/ut_removecache_nonexist.png", 0);
+    SUCCEED();
+}
+
+// ImageInfoCache::loadFinished()
+TEST_F(ut_imageinfo, ImageInfoCacheLoadFinished)
+{
+    ImageInfoCache cache;
+
+    // 插入有效数据
+    ImageInfoData::Ptr data(new ImageInfoData);
+    data->type = Types::NormalImage;
+    data->exist = true;
+    cache.loadFinished("/tmp/ut_loadfinished_valid.png", 0, data);
+
+    // 插入空数据（nullptr）走警告分支
+    ImageInfoData::Ptr nullData;
+    cache.loadFinished("/tmp/ut_loadfinished_null.png", 0, nullData);
+    SUCCEED();
 }

--- a/tests/src/ut_imageprovider.cpp
+++ b/tests/src/ut_imageprovider.cpp
@@ -12,6 +12,7 @@
 #include <QPixmap>
 #include <QCoreApplication>
 #include <QQuickImageResponse>
+#include <QQuickTextureFactory>
 #include <QThreadPool>
 
 // 生成临时 PNG 文件，返回绝对路径
@@ -261,4 +262,56 @@ TEST_F(ut_imageprovider, AsyncImageProviderPreloadImage)
     // 等待后台线程完成，避免 provider 析构后线程访问已释放资源
     QThreadPool::globalInstance()->waitForDone();
     SUCCEED();
+}
+
+// ==================== Deleting Destructor (new + delete) ====================
+
+// ImageProvider 析构函数: 触发 D0 deleting destructor
+TEST_F(ut_imageprovider, ImageProviderDeletingDestructor)
+{
+    auto *obj = new ImageProvider();
+    delete obj;
+    SUCCEED();
+}
+
+// ThumbnailProvider 析构函数: 触发 D0 deleting destructor
+TEST_F(ut_imageprovider, ThumbnailProviderDeletingDestructor)
+{
+    auto *obj = new ThumbnailProvider();
+    delete obj;
+    SUCCEED();
+}
+
+// AsyncImageProvider 析构函数: 触发 D0 deleting destructor
+TEST_F(ut_imageprovider, AsyncImageProviderDeletingDestructor)
+{
+    auto *obj = new AsyncImageProvider();
+    delete obj;
+    SUCCEED();
+}
+
+// ProviderCache 析构函数: 触发 D0 deleting destructor
+TEST_F(ut_imageprovider, ProviderCacheDeletingDestructor)
+{
+    auto *obj = new ProviderCache();
+    delete obj;
+    SUCCEED();
+}
+
+// AsyncImageResponse::textureFactory(): 通过基类虚函数调用
+TEST_F(ut_imageprovider, AsyncImageResponseTextureFactory)
+{
+    AsyncImageProvider provider;
+    QString path = makeProviderTempImage("texture.png", 64);
+    QString id = QUrl::fromLocalFile(path).toString();
+
+    QQuickImageResponse *response = provider.requestImageResponse(id, QSize(32, 32));
+    ASSERT_NE(response, nullptr);
+    // 等待后台加载完成，避免数据竞争
+    QThreadPool::globalInstance()->waitForDone();
+    // textureFactory() 是 QQuickImageResponse 的虚函数，实际调用 AsyncImageResponse::textureFactory
+    QQuickTextureFactory *factory = response->textureFactory();
+    EXPECT_NE(factory, nullptr);
+    delete factory;
+    delete response;
 }

--- a/tests/src/ut_livetextanalyzer.cpp
+++ b/tests/src/ut_livetextanalyzer.cpp
@@ -446,3 +446,13 @@ TEST_F(ut_livetextanalyzer, RequestImage_NullSizePointer_NoCrash)
     QImage result = analyzer.requestImage("x_0", nullptr, QSize(0, 0));
     EXPECT_FALSE(result.isNull());
 }
+
+// 析构函数: 触发 D0 deleting destructor (new + delete)
+TEST_F(ut_livetextanalyzer, Destructor_DeletingDestructor)
+{
+    Stub stub;
+    ut_lt_installCtorStubs(stub);
+    auto *obj = new LiveTextAnalyzer();
+    delete obj;
+    SUCCEED();
+}

--- a/tests/src/ut_pathviewproxymodel.cpp
+++ b/tests/src/ut_pathviewproxymodel.cpp
@@ -420,3 +420,22 @@ TEST_F(ut_pathviewproxymodel, PrivateAsyncUpdateLoadInfo)
     model.asyncUpdateLoadInfo(g_pathviewTmpUrls.first(), 0, 1);  // frameIndex != 0 直接跳过
     SUCCEED();
 }
+
+// IndexInfo 拷贝构造函数
+TEST_F(ut_pathviewproxymodel, IndexInfoCopyConstructor)
+{
+    ImageSourceModel src;
+    src.setImageFiles(g_pathviewTmpUrls);
+    PathViewProxyModel model(&src);
+    model.resetModel(2, 0);
+
+    auto info = model.infoFromIndex(0, 0);
+    ASSERT_TRUE(!info.isNull());
+
+    // 显式调用拷贝构造函数
+    PathViewProxyModel::IndexInfo copy(*info);
+    EXPECT_EQ(copy.url, info->url);
+    EXPECT_EQ(copy.index, info->index);
+    EXPECT_EQ(copy.frameCount, info->frameCount);
+    EXPECT_EQ(copy.frameIndex, info->frameIndex);
+}

--- a/tests/src/ut_pathviewrangehandler.cpp
+++ b/tests/src/ut_pathviewrangehandler.cpp
@@ -240,3 +240,11 @@ TEST_F(ut_pathviewrangehandler, EventFilter_OtherEventType_DefaultBranch)
     QEvent event(QEvent::Resize);
     EXPECT_FALSE(handler.eventFilter(&item, &event));
 }
+
+// 析构函数: 触发 D0 deleting destructor (new + delete)
+TEST_F(ut_pathviewrangehandler, Destructor_DeletingDestructor)
+{
+    auto *obj = new PathViewRangeHandler();
+    delete obj;
+    SUCCEED();
+}


### PR DESCRIPTION
Add unit tests for 14 previously uncovered functions including destructors (GlobalStatus/PathViewRangeHandler/LiveTextAnalyzer/ ImageProvider/ThumbnailProvider/AsyncImageProvider/ProviderCache/ ImageInfoCache), ImageInfoData::isError, AsyncImageResponse:: textureFactory, IndexInfo copy ctor, ImageInfoCache::removeCache/ loadFinished and FileControl::setWallpaper, raising function coverage from 93.8% to 97.7%.

补充 14 个此前未覆盖函数的单元测试，包括多个类的析构函数、
ImageInfoData::isError、AsyncImageResponse::textureFactory、 IndexInfo 拷贝构造、ImageInfoCache 的 removeCache/loadFinished 以及 FileControl::setWallpaper，函数覆盖率从 93.8% 提升至 97.7%。

Log: 补充未覆盖函数单元测试提升函数覆盖率
Influence: 仅追加 tests/src 下测试用例，Debug 模式生效，不影响 Release 构建.

## Summary by Sourcery

Increase test coverage by adding unit tests for previously uncovered image handling, model, and file control code paths, including several destructors and edge-case behaviors.

Enhancements:
- Add unit tests for ImageInfoData::isError, ImageInfoCache::removeCache/loadFinished, and related private image info classes.
- Add destructor coverage tests for GlobalStatus, PathViewRangeHandler, LiveTextAnalyzer, ImageProvider, ThumbnailProvider, AsyncImageProvider, and ProviderCache.
- Add tests for AsyncImageResponse::textureFactory and PathViewProxyModel::IndexInfo copy construction.
- Add a FileControl::setWallpaper regression test for null paths to validate thread and DBus handling.

Tests:
- Increase overall function-level test coverage in tests/src by exercising previously uncovered functions and destructors.