### PR TITLE
fix: eliminate position jitter at end of rotation animation

### DIFF
--- a/src/qml/ImageDelegate/NormalImageDelegate.qml
+++ b/src/qml/ImageDelegate/NormalImageDelegate.qml
@@ -150,6 +150,16 @@ BaseImageDelegate {
                 imageProxy.scale = image.scale;
                 imageScaleBehavior.enabled = true;
 
+                // 代理从图片当前拖拽位置启动，使动画起始帧与真实图片重合，
+                // 避免旋转开始/结束时代理（居中）与真实图片（拖拽偏移）位置不一致导致的抖动
+                imageProxy.x = image.x;
+                imageProxy.y = image.y;
+
+                // 重置缓存位置为中心，确保图片重载后 resetCache() 恢复到 (0,0)，
+                // 与代理动画终点 (0,0) 一致，消除动画结束时位置跳变
+                delegate.targetImageInfo.x = 0;
+                delegate.targetImageInfo.y = 0;
+
                 // 记录之前的绘制宽度，用于计算缩放比例
                 previousRealWidth = image.paintedWidth;
 
@@ -172,7 +182,7 @@ BaseImageDelegate {
             ShaderEffectSource {
                 id: imageProxy
 
-                anchors.centerIn: parent
+                // 不使用 anchors.centerIn，位置由 calcAnimation() 根据图片当前位置设置
                 height: image.height
                 live: false
                 sourceItem: image


### PR DESCRIPTION
## 根因分析

**Bug**: [PMS #279099](https://pms.uniontech.com/bug-view-279099.html) — 图片放大后旋转，旋转动画停止那一刻图片有轻微向下的抖动。

**根因**：旋转动画代理 `imageProxy` 使用 `anchors.centerIn: parent` 始终居中于 (0, 0)，而旋转后真实图片从缓存（`targetImageInfo`）恢复旋转前的拖拽偏移位置（经 `updateDragRect()` clamp）。动画结束时代理销毁、真实图片显示，两者位置不一致产生可见跳变——当 `image.y > 0`（用户旋转前向下拖拽过）时表现为"向下的抖动"。

**关键证据**：
- `NormalImageDelegate.qml:165` — `imageProxy` 设有 `anchors.centerIn: parent`，代理始终居中
- `NormalImageDelegate.qml:237–240` — `NumberAnimation { to: 0 }` 因代理已在 (0,0) 而为空操作
- `BaseImageDelegate.qml:69–70` — `resetCache()` 从 `targetImageInfo` 恢复旋转前拖拽位置
- `ImageInputHandler.qml:60–74` — `updateDragRect()` clamp 后位置可能非零

## 修复方案

1. 移除 `imageProxy` 的 `anchors.centerIn: parent`，在 `calcAnimation()` 中将代理初始位置设为 `image.x / image.y`（图片当前拖拽位置），使动画起始帧与真实图片重合。
2. 在 `calcAnimation()` 中重置缓存 `delegate.targetImageInfo.x = 0; delegate.targetImageInfo.y = 0`，确保图片重载后 `resetCache()` 恢复到 (0, 0)，与代理动画终点 (0, 0) 一致。

## 改动安全评估

**风险等级**：低风险。改动仅涉及旋转动画代理的初始位置设置和缓存值重置，不改变函数签名、不影响外部调用者。非旋转路径（`currentRotation == 0`）完全不受影响。未缩放/未拖拽时 `image.x = image.y = 0`，代理仍从 (0,0) 启动，行为与原代码一致。

## Summary by Sourcery

Bug Fixes:
- Fix a positional jitter when a zoomed, dragged image finishes its rotation animation by ensuring the proxy and real image share consistent positions before and after the animation.