### PR TITLE
fix: add hover effect to fullscreen float navigation buttons

### DIFF
--- a/src/qml/FullImageView.qml
+++ b/src/qml/FullImageView.qml
@@ -7,6 +7,7 @@ import QtQuick.Controls
 import QtQuick.Window
 import Qt5Compat.GraphicalEffects
 import org.deepin.dtk 1.0
+import org.deepin.dtk 1.0 as DTK
 import org.deepin.dtk.style 1.0 as DS
 import org.deepin.image.viewer 1.0 as IV
 import "./Utils"
@@ -233,17 +234,39 @@ Item {
         Accessible.role: Accessible.Button
 
         property bool animationShow: false
+        property bool containsMouse: animationShow && imageViewerArea.containsMouse
+            && imageViewerArea.mouseX >= floatLeftButton.x
+            && imageViewerArea.mouseX <= floatLeftButton.x + floatLeftButton.width
+            && imageViewerArea.mouseY + IV.GStatus.titleHeight >= floatLeftButton.y
+            && imageViewerArea.mouseY + IV.GStatus.titleHeight <= floatLeftButton.y + floatLeftButton.height
 
         function updatePosition() {
             floatLeftButton.x = animationShow ? 20 : -50;
         }
 
         checked: false
+        hoverEnabled: true
         enabled: IV.GControl.hasPreviousImage
         height: 50
         icon.name: "icon_previous"
         visible: enabled
         width: 50
+
+        contentItem: DTK.DciIcon {
+            name: floatLeftButton.icon.name
+            palette: DTK.DTK.makeIconPalette(floatLeftButton.palette)
+            mode: floatLeftButton.containsMouse ? DTK.DTK.HoveredState : DTK.DTK.NormalState
+            theme: floatLeftButton.ColorSelector.controlTheme
+            sourceSize: Qt.size(floatLeftButton.icon.width, floatLeftButton.icon.height)
+        }
+
+        background: Rectangle {
+            anchors.fill: parent
+            radius: floatLeftButton.width / 2
+            color: floatLeftButton.palette.window.hslLightness < 0.5
+                   ? (floatLeftButton.containsMouse ? Qt.rgba(1, 1, 1, 0.2) : Qt.rgba(1, 1, 1, 0.1))
+                   : (floatLeftButton.containsMouse ? "#e1e1e1" : "#f7f7f7")
+        }
 
         Behavior on x {
             enabled: fullThumbnail.enableAnimation
@@ -269,17 +292,39 @@ Item {
         Accessible.role: Accessible.Button
 
         property bool animationShow: false
+        property bool containsMouse: animationShow && imageViewerArea.containsMouse
+            && imageViewerArea.mouseX >= floatRightButton.x
+            && imageViewerArea.mouseX <= floatRightButton.x + floatRightButton.width
+            && imageViewerArea.mouseY + IV.GStatus.titleHeight >= floatRightButton.y
+            && imageViewerArea.mouseY + IV.GStatus.titleHeight <= floatRightButton.y + floatRightButton.height
 
         function updatePosition() {
             floatRightButton.x = animationShow ? Window.width - 70 : Window.width;
         }
 
         checked: false
+        hoverEnabled: true
         enabled: IV.GControl.hasNextImage
         height: 50
         icon.name: "icon_next"
         visible: enabled
         width: 50
+
+        contentItem: DTK.DciIcon {
+            name: floatRightButton.icon.name
+            palette: DTK.DTK.makeIconPalette(floatRightButton.palette)
+            mode: floatRightButton.containsMouse ? DTK.DTK.HoveredState : DTK.DTK.NormalState
+            theme: floatRightButton.ColorSelector.controlTheme
+            sourceSize: Qt.size(floatRightButton.icon.width, floatRightButton.icon.height)
+        }
+
+        background: Rectangle {
+            anchors.fill: parent
+            radius: floatRightButton.width / 2
+            color: floatRightButton.palette.window.hslLightness < 0.5
+                   ? (floatRightButton.containsMouse ? Qt.rgba(1, 1, 1, 0.2) : Qt.rgba(1, 1, 1, 0.1))
+                   : (floatRightButton.containsMouse ? "#e1e1e1" : "#f7f7f7")
+        }
 
         Behavior on x {
             enabled: fullThumbnail.enableAnimation


### PR DESCRIPTION
## Problem

The floating previous/next navigation buttons (`floatLeftButton` / `floatRightButton`) in the fullscreen image view (`FullImageView.qml`) showed no visible hover feedback — the button background and icon did not change when the mouse hovered over them.

## Root cause

The `imageViewerArea` MouseArea is layered **above** the floating buttons (higher z-order) and has `hoverEnabled: true`. It intercepts the hover events, so `T.Button.hovered` stays `false` and the built-in `FloatingButton` hover styling never activates.

## Fix

Keep the original circular `FloatingButton` style (unchanged shape/size) and add explicit hover styling:

1. **Manual hover detection** — add a `containsMouse` property that reads `imageViewerArea.mouseX/mouseY` and bounds-checks it against the button geometry. This works around the hover-event interception.
2. **Icon hover state** — set `contentItem` to a `DTK.DciIcon` whose `mode` switches to `HoveredState` when `containsMouse` is true, giving the icon the same hover color shift as the bottom toolbar `IconButton`s.
3. **Background hover color** — add a custom `Rectangle` background whose `color` changes on hover, matching the bottom toolbar style (`#f7f7f7` → `#e1e1e1` in light theme; `rgba(1,1,1,0.1)` → `rgba(1,1,1,0.2)` in dark theme).
4. **Theme support** — dark/light is detected via `palette.window.hslLightness`, which reads the actual rendered palette and is more reliable than the cached `D.DTK.themeType` / `ColorSelector.controlTheme` values.

## Verification

Tested on Deepin 25 (crimson), X11, light theme:

| State | Background | Icon |
|-------|-----------|------|
| Normal | (247,247,247) = #f7f7f7 | (74,74,74) |
| Hover | (225,225,225) = #e1e1e1 | (67,67,67) |

Click navigation (prev/next) and keyboard arrow navigation both still work.

<!-- See PR #329 for the related window-button DTK standard fix. -->

## Summary by Sourcery

Improve hover feedback for fullscreen floating previous/next navigation buttons in the image viewer.

Bug Fixes:
- Restore visible hover feedback for fullscreen floating navigation buttons whose hover events were previously intercepted by the image viewer mouse area.

Enhancements:
- Add manual hover detection and theme-aware icon/background styling to fullscreen floating navigation buttons for consistent hover appearance in light and dark modes.