### PR TITLE
chore: update version to 6.0.48

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-image-viewer (6.0.48) unstable; urgency=medium
+
+  * fix: eliminate position jitter at end of rotation animation
+
+ -- Wang Yu <wangyu@uniontech.com>  Fri, 07 Aug 2026 11:07:25 +0800
+
 deepin-image-viewer (6.0.47) unstable; urgency=medium
 
   * chore: Update version to 6.0.47

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.image.viewer
   name: deepin-image-viewer
-  version: 6.0.47.1
+  version: 6.0.48.1
   kind: app
   description: |
     view images for deepin os.


### PR DESCRIPTION
- bump version to 6.0.48

Log : bump version to 6.0.48

## Summary by Sourcery

Chores:
- Update application package version in linglong metadata to 6.0.48.1.