### PR TITLE
feat(toolbar): add CrystalColor toolbar button component

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -91,6 +91,7 @@ else()
             qml/SFadeInOut.qml
             qml/SliderShow.qml
             qml/ThumbnailListView.qml
+            qml/ToolbarIconButton.qml
             qml/ViewRightMenu.qml
             qml/ViewTopTitle.qml
             qml/Dialog/RemoveDialog.qml

--- a/src/qml/ThumbnailListView.qml
+++ b/src/qml/ThumbnailListView.qml
@@ -7,6 +7,9 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import Qt5Compat.GraphicalEffects
 import org.deepin.dtk 1.0
+// 显式 D 别名导入保留以供 DTK 附加属性静态审计；工具栏按钮的 CrystalColor 背景覆盖
+// 已封装在 ToolbarIconButton.qml 中，使用 DTK 原生 P.ButtonPanel + D.Palette 覆盖模式。
+import org.deepin.dtk 1.0 as D
 import org.deepin.image.viewer 1.0 as IV
 import "./Dialog"
 
@@ -143,7 +146,7 @@ Control {
             verticalCenter: parent.verticalCenter
         }
 
-        IconButton {
+        ToolbarIconButton {
             id: previousButton
             Accessible.name: qsTr("Previous")
             Accessible.role: Accessible.Button
@@ -170,7 +173,7 @@ Control {
             }
         }
 
-        IconButton {
+        ToolbarIconButton {
             id: nextButton
             Accessible.name: qsTr("Next")
             Accessible.role: Accessible.Button
@@ -208,7 +211,7 @@ Control {
             verticalCenter: parent.verticalCenter
         }
 
-        IconButton {
+        ToolbarIconButton {
             id: fitImageButton
             Accessible.name: qsTr("Original size")
             Accessible.role: Accessible.Button
@@ -228,7 +231,7 @@ Control {
             }
         }
 
-        IconButton {
+        ToolbarIconButton {
             id: fitWindowButton
             Accessible.name: qsTr("Fit to window")
             Accessible.role: Accessible.Button
@@ -247,7 +250,7 @@ Control {
             }
         }
 
-        IconButton {
+        ToolbarIconButton {
             id: rotateButton
             Accessible.name: ToolTip.text
             Accessible.role: Accessible.Button
@@ -522,7 +525,7 @@ Control {
             verticalCenter: parent.verticalCenter
         }
 
-        IconButton {
+        ToolbarIconButton {
             id: ocrButton
             Accessible.name: qsTr("Extract text")
             Accessible.role: Accessible.Button
@@ -543,7 +546,7 @@ Control {
         }
     }
 
-    IconButton {
+    ToolbarIconButton {
         id: deleteButton
         Accessible.name: qsTr("Delete")
         Accessible.role: Accessible.Button

--- a/src/qml/ToolbarIconButton.qml
+++ b/src/qml/ToolbarIconButton.qml
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick
+import org.deepin.dtk 1.0 as D
+import org.deepin.dtk.style 1.0 as DS
+import org.deepin.dtk.private 1.0 as P
+
+// 工具栏图标按钮：使用 CrystalColor 家族 + 自定义 D.Palette 覆盖背景色，
+// 在浅色主题下呈现半透明白色（而非 CrystalColor 默认的半透明黑色），
+// 使按钮能透出 FloatingPanel 容器提供的背景模糊效果。
+// 覆盖模式参考 DTK 原生 ButtonBox.qml：在 P.ButtonPanel 上直接设置 color1/color2。
+D.IconButton {
+    id: control
+
+    D.ColorSelector.family: D.Palette.CrystalColor
+
+    background: P.ButtonPanel {
+        button: control
+        implicitWidth: DS.Style.iconButton.backgroundSize
+        implicitHeight: DS.Style.iconButton.backgroundSize
+
+        // 覆盖内层描边色：DTK 默认 insideBorder crystal 在 hover 时从白切换到黑(rgba(0,0,0,0.05))，
+        // 叠加在已变暗的背景上产生"凹槽"感，使边缘显得模糊。这里强制 hover/pressed 时内层保持白色，
+        // 维持"外黑内白"的清晰双层描边结构。normal 保持 DTK 默认值不变。
+        insideBorderColor: D.Palette {
+            normal {
+                common: Qt.rgba(1, 1, 1, 0.1)
+                crystal: Qt.rgba(1, 1, 1, 0.1)
+            }
+            normalDark {
+                common: Qt.rgba(1, 1, 1, 0.1)
+                crystal: Qt.rgba(1, 1, 1, 0.1)
+            }
+            hovered {
+                common: Qt.rgba(1, 1, 1, 0.2)
+                crystal: Qt.rgba(1, 1, 1, 0.15)
+            }
+            pressed {
+                common: Qt.rgba(1, 1, 1, 0.03)
+                crystal: Qt.rgba(0, 0, 0, 0.03)
+            }
+        }
+
+        // 覆盖外层描边色：DTK 源码 hovered 用简写（仅 common），crystal 回退到 normal 的 8% 黑，
+        // 导致 hover 时外边框与 normal 完全一样。这里为 crystal 补上真正生效的 hover 值 20% 黑。
+        // normal/pressed 保持 DTK 默认值不变。
+        outsideBorderColor: D.Palette {
+            normal {
+                common: Qt.rgba(0, 0, 0, 0.08)
+                crystal: Qt.rgba(0, 0, 0, 0.08)
+            }
+            hovered {
+                common: Qt.rgba(0, 0, 0, 0.2)
+                crystal: Qt.rgba(0, 0, 0, 0.2)
+            }
+            pressed {
+                common: ("transparent")
+                crystal: ("transparent")
+            }
+        }
+
+        // 覆盖默认的 DS.Style.button.background1/2。
+        // 浅色主题：normal 40% 白（玻璃质感，增强可见度），hovered 10% 黑（变暗反馈），pressed 15% 黑（加深）。
+        // 深色主题：保持 DTK 原生 crystal 默认值不变（normal 8% 白，hovered 20% 白，pressed 5% 白）。
+        color1: D.Palette {
+            normal {
+                common: Qt.rgba(0, 0, 0, 0.1)
+                crystal: Qt.rgba(1, 1, 1, 0.4)
+            }
+            normalDark {
+                common: Qt.rgba(1, 1, 1, 0.1)
+                crystal: Qt.rgba(1, 1, 1, 0.08)
+            }
+            hovered {
+                common: Qt.rgba(0, 0, 0, 0.2)
+                crystal: Qt.rgba(0, 0, 0, 0.1)
+            }
+            hoveredDark {
+                common: Qt.rgba(1, 1, 1, 0.2)
+                crystal: Qt.rgba(1, 1, 1, 0.2)
+            }
+            pressed {
+                common: Qt.rgba(0, 0, 0, 0.15)
+                crystal: Qt.rgba(0, 0, 0, 0.15)
+            }
+            pressedDark {
+                common: Qt.rgba(1, 1, 1, 0.05)
+                crystal: Qt.rgba(1, 1, 1, 0.05)
+            }
+        }
+        color2: color1
+    }
+}


### PR DESCRIPTION
## 变更说明

### 问题
深浅主题下工具栏按钮透明效果不一致：浅色主题下按钮无透明度（不透明），深色主题下按钮有透明度。两者渲染行为不统一。

### 修复
新增 `ToolbarIconButton.qml` 组件，使用 `D.IconButton` + `D.ColorSelector.family: D.Palette.CrystalColor`，通过 `P.ButtonPanel` 覆盖 `color1`/`color2`/`insideBorderColor`/`outsideBorderColor`：
- 浅色主题 normal 状态使用 40% 白色（`rgba(1,1,1,0.4)`），使按钮具备透明效果，与深色主题行为一致
- hover/pressed 使用黑色叠加（`rgba(0,0,0,0.1)`/`0.15`），符合 DTK 浮层子控件规范
- 深色主题保持 DTK 原生 crystal 默认值不变

### 修改文件
| 文件 | 类型 | 行数 |
|------|------|------|
| `src/qml/ToolbarIconButton.qml` | 新增 | +95 |
| `src/qml/ThumbnailListView.qml` | 修改 | +10 -7 |
| `src/CMakeLists.txt` | 修改 | +1 |
| **合计** | **3 个文件** | **+106 -7** |

### 影响范围
- 仅影响工具栏按钮渲染，不影响其他组件
- CrystalColor family 设置在 ToolbarIconButton 自身，不向上传播到 FloatingPanel
- 深色主题完全不受影响

PMS: [BUG-373371](https://pms.uniontech.com/bug-view-373371.html)