### PR TITLE
feat(editor): add corner handles, rotation and effect strength tuning

### DIFF
--- a/src/qml/EditCanvas.qml
+++ b/src/qml/EditCanvas.qml
@@ -13,6 +13,7 @@ Item {
 
     property color currentColor: "#e53935"
     property string currentTool: "pen"
+    property int effectStrength: 15
     property int selectedIndex: -1
     property var strokes: []
     property string blurMode: "gaussian"
@@ -106,7 +107,11 @@ Item {
             { name: "top", x: (bounds.left + bounds.right) / 2, y: bounds.top },
             { name: "right", x: bounds.right, y: (bounds.top + bounds.bottom) / 2 },
             { name: "bottom", x: (bounds.left + bounds.right) / 2, y: bounds.bottom },
-            { name: "left", x: bounds.left, y: (bounds.top + bounds.bottom) / 2 }
+            { name: "left", x: bounds.left, y: (bounds.top + bounds.bottom) / 2 },
+            { name: "topLeft", x: bounds.left, y: bounds.top },
+            { name: "topRight", x: bounds.right, y: bounds.top },
+            { name: "bottomLeft", x: bounds.left, y: bounds.bottom },
+            { name: "bottomRight", x: bounds.right, y: bounds.bottom }
         ];
         for (var i = 0; i < handles.length; ++i) {
             if (Math.abs(x - handles[i].x) <= 7 && Math.abs(y - handles[i].y) <= 7)
@@ -180,6 +185,22 @@ Item {
         selectedIndex = -1;
         strokeCommitted();
         drawingCanvas.requestPaint();
+    }
+
+    function rotateSelected() {
+        if (selectedIndex < 0 || selectedIndex >= strokes.length) return;
+        var stroke = strokes[selectedIndex];
+        var bounds = boundsFor(stroke);
+        var centerX = (bounds.left + bounds.right) / 2;
+        var centerY = (bounds.top + bounds.bottom) / 2;
+        var rotated = [];
+        for (var i = 0; i < stroke.points.length; ++i) {
+            var dx = stroke.points[i].x - centerX;
+            var dy = stroke.points[i].y - centerY;
+            rotated.push(Qt.point(centerX - dy, centerY + dx));
+        }
+        replaceStroke(selectedIndex, Object.assign({}, stroke, { points: rotated }));
+        strokeCommitted();
     }
 
     function updateSelectedStyle(color, width) {
@@ -476,7 +497,11 @@ Item {
                     [(bounds.left + bounds.right) / 2, bounds.top],
                     [bounds.right, (bounds.top + bounds.bottom) / 2],
                     [(bounds.left + bounds.right) / 2, bounds.bottom],
-                    [bounds.left, (bounds.top + bounds.bottom) / 2]
+                    [bounds.left, (bounds.top + bounds.bottom) / 2],
+                    [bounds.left, bounds.top],
+                    [bounds.right, bounds.top],
+                    [bounds.left, bounds.bottom],
+                    [bounds.right, bounds.bottom]
                 ];
                 for (var h = 0; h < handles.length; ++h) {
                     context.beginPath();
@@ -607,37 +632,51 @@ Item {
                     var right = originalBounds.right;
                     var top = originalBounds.top;
                     var bottom = originalBounds.bottom;
+                    var handle = drawingCanvas.resizeHandle;
                     var resizedPoints = [];
                     if (selected.type === "rect" || selected.type === "ellipse") {
-                        if (drawingCanvas.resizeHandle === "left") left = mouse.x;
-                        else if (drawingCanvas.resizeHandle === "right") right = mouse.x;
-                        else if (drawingCanvas.resizeHandle === "top") top = mouse.y;
-                        else if (drawingCanvas.resizeHandle === "bottom") bottom = mouse.y;
+                        if (handle.indexOf("Left") >= 0) left = mouse.x;
+                        if (handle.indexOf("Right") >= 0) right = mouse.x;
+                        if (handle.indexOf("top") === 0) top = mouse.y;
+                        if (handle.indexOf("bottom") === 0) bottom = mouse.y;
+                        if (handle === "left") left = mouse.x;
+                        else if (handle === "right") right = mouse.x;
+                        else if (handle === "top") top = mouse.y;
+                        else if (handle === "bottom") bottom = mouse.y;
                         resizedPoints = [Qt.point(left, top), Qt.point(right, bottom)];
                     } else {
-                        var centerX = (left + right) / 2;
-                        var centerY = (top + bottom) / 2;
-                        var anchorX = centerX;
-                        var anchorY = centerY;
-                        var scale = 1;
-                        if (drawingCanvas.resizeHandle === "left" && originalBounds.width > 0) {
-                            anchorX = right;
-                            scale = (right - mouse.x) / originalBounds.width;
-                        } else if (drawingCanvas.resizeHandle === "right" && originalBounds.width > 0) {
-                            anchorX = left;
-                            scale = (mouse.x - left) / originalBounds.width;
-                        } else if (drawingCanvas.resizeHandle === "top" && originalBounds.height > 0) {
-                            anchorY = bottom;
-                            scale = (bottom - mouse.y) / originalBounds.height;
-                        } else if (drawingCanvas.resizeHandle === "bottom" && originalBounds.height > 0) {
-                            anchorY = top;
-                            scale = (mouse.y - top) / originalBounds.height;
+                        var anchorX = (left + right) / 2;
+                        var anchorY = (top + bottom) / 2;
+                        var scaleX = 1;
+                        var scaleY = 1;
+                        if (handle === "left" || handle === "topLeft" || handle === "bottomLeft") {
+                            if (originalBounds.width > 0) {
+                                anchorX = right;
+                                scaleX = (right - mouse.x) / originalBounds.width;
+                            }
+                        } else if (handle === "right" || handle === "topRight" || handle === "bottomRight") {
+                            if (originalBounds.width > 0) {
+                                anchorX = left;
+                                scaleX = (mouse.x - left) / originalBounds.width;
+                            }
                         }
-                        scale = Math.max(0.05, scale);
+                        if (handle === "top" || handle === "topLeft" || handle === "topRight") {
+                            if (originalBounds.height > 0) {
+                                anchorY = bottom;
+                                scaleY = (bottom - mouse.y) / originalBounds.height;
+                            }
+                        } else if (handle === "bottom" || handle === "bottomLeft" || handle === "bottomRight") {
+                            if (originalBounds.height > 0) {
+                                anchorY = top;
+                                scaleY = (mouse.y - top) / originalBounds.height;
+                            }
+                        }
+                        scaleX = Math.max(0.05, scaleX);
+                        scaleY = Math.max(0.05, scaleY);
                         for (var p = 0; p < drawingCanvas.originalPoints.length; ++p) {
                             var original = drawingCanvas.originalPoints[p];
-                            resizedPoints.push(Qt.point(anchorX + (original.x - anchorX) * scale,
-                                                        anchorY + (original.y - anchorY) * scale));
+                            resizedPoints.push(Qt.point(anchorX + (original.x - anchorX) * scaleX,
+                                                        anchorY + (original.y - anchorY) * scaleY));
                         }
                     }
                     var resized = Object.assign({}, selected, { points: resizedPoints });
@@ -721,7 +760,7 @@ Item {
                         editCanvas.effectRequested(editCanvas.blurMode,
                                                    Qt.rect(left / editCanvas.width, top / editCanvas.height,
                                                            effectWidth / editCanvas.width, effectHeight / editCanvas.height),
-                                                   editCanvas.thickness);
+                                                   editCanvas.effectStrength);
                     }
                     drawingCanvas.interaction = "";
                     drawingCanvas.activePoints = [];

--- a/src/qml/EditPropertyPanel.qml
+++ b/src/qml/EditPropertyPanel.qml
@@ -13,22 +13,29 @@ DTK.Control {
     property string currentTool: "pen"
     property string blurMode: "gaussian"
     property color currentColor: "#f82a2a"
+    property int effectStrength: 15
     property string textMode: "plain"
     property int thickness: 2
     readonly property color themeTextColor: Qt.rgba(0, 0, 0, 0.7)
 
     signal blurModeSelected(string mode)
     signal colorSelected(color value)
+    signal effectStrengthSelected(int value)
     signal textModeSelected(string mode)
     signal thicknessSelected(int value)
 
     readonly property bool isTextTool: currentTool === "text"
     readonly property bool isEffectTool: currentTool === "blur"
 
+    onBlurModeChanged: {
+        effectStrength = blurMode === "gaussian" ? 15 : 16;
+        effectStrengthSelected(effectStrength);
+    }
+
     Accessible.name: qsTr("Tool properties")
     Accessible.role: Accessible.Pane
     implicitHeight: 56
-    implicitWidth: isEffectTool ? 349 : isTextTool ? 229 : 311
+    implicitWidth: isEffectTool ? 367 : isTextTool ? 265 : 333
     padding: 0
 
     background: Rectangle {
@@ -66,6 +73,34 @@ DTK.Control {
         }
     }
 
+    component ThicknessDot: Item {
+        height: 36
+        width: 36
+
+        Rectangle {
+            anchors.centerIn: parent
+            color: propertyPanel.currentColor
+            height: 2 + (propertyPanel.thickness - 1) * 12 / 49
+            radius: height / 2
+            width: height
+        }
+    }
+
+    component EffectIcon: DTK.ToolButton {
+        required property int iconSize
+
+        display: AbstractButton.IconOnly
+        height: 36
+        icon.color: propertyPanel.themeTextColor
+        icon.height: iconSize
+        icon.name: propertyPanel.blurMode === "mosaic" ? "edit_mosaic"
+                  : propertyPanel.blurMode === "graffiti" ? "edit_graffiti"
+                  : "edit_blur"
+        icon.width: iconSize
+        padding: 0
+        width: iconSize
+    }
+
     component Separator: Item {
         height: 36
         width: 13
@@ -82,18 +117,18 @@ DTK.Control {
 
     component ColorPalette: Item {
         height: 36
-        width: 114
+        width: 136
 
         Grid {
             anchors.left: parent.left
             anchors.verticalCenter: parent.verticalCenter
-            columns: 5
+            columns: 6
             columnSpacing: 6
             rowSpacing: 6
 
             Repeater {
-                model: ["#000000", "#7d7d7d", "#ffffff", "#f82a2a", "#ff8100",
-                        "#fff100", "#1ee9a8", "#006d06", "#0089f7", "#7600ac"]
+                model: ["#000000", "#7d7d7d", "#ffffff", "#f82a2a", "#ff8100", "#fff100",
+                        "#99e338", "#006d06", "#00b7c3", "#0089f7", "#7600ac", "#003781"]
 
                 delegate: Rectangle {
                     id: swatch
@@ -126,19 +161,6 @@ DTK.Control {
                 }
             }
         }
-
-        Rectangle {
-            anchors.right: parent.right
-            anchors.verticalCenter: parent.verticalCenter
-            border.color: "white"
-            border.width: 2
-            color: propertyPanel.currentColor
-            height: 18
-            radius: 9
-            width: 18
-
-            TapHandler { onTapped: colorDialog.open() }
-        }
     }
 
     contentItem: Item {
@@ -148,6 +170,7 @@ DTK.Control {
             anchors.leftMargin: 10
             anchors.top: parent.top
             anchors.topMargin: 10
+            spacing: 8
             visible: propertyPanel.isTextTool
 
             ModeButton {
@@ -178,28 +201,22 @@ DTK.Control {
             anchors.leftMargin: 10
             anchors.top: parent.top
             anchors.topMargin: 10
+            spacing: 8
             visible: propertyPanel.isEffectTool
 
             ModeButton { iconPath: "edit_blur"; selected: propertyPanel.blurMode === "gaussian"; DTK.ToolTip.text: qsTr("Gaussian Blur"); onClicked: { propertyPanel.blurMode = "gaussian"; propertyPanel.blurModeSelected("gaussian"); } }
             ModeButton { iconPath: "edit_mosaic"; selected: propertyPanel.blurMode === "mosaic"; DTK.ToolTip.text: qsTr("Mosaic"); onClicked: { propertyPanel.blurMode = "mosaic"; propertyPanel.blurModeSelected("mosaic"); } }
             ModeButton { iconPath: "edit_graffiti"; selected: propertyPanel.blurMode === "graffiti"; DTK.ToolTip.text: qsTr("Graffiti"); onClicked: { propertyPanel.blurMode = "graffiti"; propertyPanel.blurModeSelected("graffiti"); } }
             Separator { }
-            DTK.Label {
-                color: propertyPanel.themeTextColor
-                height: 36
-                horizontalAlignment: Text.AlignHCenter
-                text: "Aa"
-                verticalAlignment: Text.AlignVCenter
-                width: 36
-            }
+            EffectIcon { iconSize: 12 }
             DTK.Slider {
                 id: effectSlider
 
-                from: 1
+                from: propertyPanel.blurMode === "gaussian" ? 5 : 8
                 height: 36
                 stepSize: 1
-                to: 50
-                value: propertyPanel.thickness
+                to: propertyPanel.blurMode === "gaussian" ? 30 : 32
+                value: propertyPanel.effectStrength
                 width: 120
                 background: Rectangle {
                     color: Qt.rgba(propertyPanel.themeTextColor.r,
@@ -229,10 +246,11 @@ DTK.Control {
                     y: effectSlider.topPadding + effectSlider.availableHeight / 2 - height / 2
                 }
                 onMoved: {
-                    propertyPanel.thickness = Math.round(value);
-                    propertyPanel.thicknessSelected(propertyPanel.thickness);
+                    propertyPanel.effectStrength = Math.round(value);
+                    propertyPanel.effectStrengthSelected(propertyPanel.effectStrength);
                 }
             }
+            EffectIcon { iconSize: 24 }
         }
 
         Row {
@@ -241,16 +259,10 @@ DTK.Control {
             anchors.leftMargin: 10
             anchors.top: parent.top
             anchors.topMargin: 10
+            spacing: 8
             visible: !propertyPanel.isTextTool && !propertyPanel.isEffectTool
 
-            DTK.Label {
-                color: propertyPanel.themeTextColor
-                height: 36
-                horizontalAlignment: Text.AlignHCenter
-                text: "Aa"
-                verticalAlignment: Text.AlignVCenter
-                width: 36
-            }
+            ThicknessDot { }
             DTK.Slider {
                 id: strokeSlider
 

--- a/src/qml/EditToolbar.qml
+++ b/src/qml/EditToolbar.qml
@@ -19,6 +19,7 @@ DTK.Control {
 
     signal closeRequested
     signal redoRequested
+    signal rotateRequested
     signal saveRequested
     signal toolSelected(string tool)
     signal undoRequested
@@ -118,6 +119,7 @@ DTK.Control {
         }
 
         Separator { }
+        ToolbarButton { iconPath: "edit_rotate"; DTK.ToolTip.text: qsTr("Rotate"); onClicked: editToolbar.rotateRequested() }
         ToolSelectButton { tool: "crop"; iconPath: "edit_crop"; DTK.ToolTip.text: qsTr("Crop") + " (X)" }
         ToolbarButton { enabled: editToolbar.canUndo; iconPath: "edit_undo"; DTK.ToolTip.text: qsTr("Undo") + " (Ctrl+Z)"; onClicked: editToolbar.undoRequested() }
         ToolbarButton { enabled: editToolbar.canRedo; iconPath: "edit_redo"; DTK.ToolTip.text: qsTr("Redo") + " (Ctrl+Y)"; onClicked: editToolbar.redoRequested() }

--- a/src/qml/FullImageView.qml
+++ b/src/qml/FullImageView.qml
@@ -226,6 +226,7 @@ Item {
         blurMode: editToolbar.blurMode
         currentColor: editPropertyPanel.currentColor
         currentTool: editToolbar.currentTool
+        effectStrength: editPropertyPanel.effectStrength
         height: imageViewer.targetImageReady
                 ? imageViewer.targetImage.paintedHeight * imageViewer.targetImage.scale : 0
         textMode: editToolbar.textMode
@@ -529,6 +530,7 @@ Item {
             if (IV.ImageEditor.redo() && editCanvas.redoHistory())
                 IV.GStatus.editModified = IV.ImageEditor.modified;
         }
+        onRotateRequested: editCanvas.rotateSelected()
         onSaveRequested: fullThumbnail.openSaveDialog(false)
         onUndoRequested: {
             if (IV.ImageEditor.undo() && editCanvas.undoHistory())


### PR DESCRIPTION
Add corner resize handles (topLeft/topRight/bottomLeft/bottomRight) on selected annotations in addition to the four edge midpoints, and support object rotation via a new Rotate toolbar button placed left of Crop. Adjust the property panel to a 12-color palette with the product order, a thickness dot preview beside the stroke slider, effect-strength icons flanking the effects slider, and per-submode strength ranges (gaussian 5-30, mosaic/graffiti 8-32) wired through ImageEditController without the previous strength/2 scaling.

选中标注新增四角缩放控制点（左上/右上/左下/右下），并在裁剪左侧
新增旋转按钮支持对象旋转；属性面板调整为产品顺序的 12 色色板、
笔画滑块圆点预览、特效滑块左右强度图标，以及按子模式的强度区间
（高斯 5-30，马赛克/涂鸦 8-32），后端不再对强度做减半换算。

Log: 编辑对象四角控制点、旋转与特效强度调节
task: TASK-393981
Influence: 编辑画布与属性面板交互增强；不影响浏览模式。

## Summary by Sourcery

Enhance editor annotation manipulation and styling controls with corner resizing, rotation, and more precise effect-strength adjustment.

New Features:
- Add corner resize handles for selected annotations and enable rotating the selected object from the editor toolbar.

Enhancements:
- Refresh the property panel with a product-ordered 12-color palette, stroke thickness preview, and effect-strength controls with mode-specific ranges.
- Pass effect strength directly through the image editor without the previous strength scaling.