### PR TITLE
feat(editor): add rule-of-thirds grid to crop selection

### DIFF
--- a/src/qml/EditCanvas.qml
+++ b/src/qml/EditCanvas.qml
@@ -525,6 +525,20 @@ Item {
                 context.strokeStyle = "#ffffff";
                 context.lineWidth = 1;
                 context.strokeRect(crop.x, crop.y, crop.width, crop.height);
+                context.strokeStyle = Qt.rgba(palette.light.r,
+                                              palette.light.g,
+                                              palette.light.b, 0.5);
+                context.lineWidth = 1;
+                context.beginPath();
+                context.moveTo(crop.x, crop.y + crop.height / 3);
+                context.lineTo(crop.x + crop.width, crop.y + crop.height / 3);
+                context.moveTo(crop.x, crop.y + crop.height / 3 * 2);
+                context.lineTo(crop.x + crop.width, crop.y + crop.height / 3 * 2);
+                context.moveTo(crop.x + crop.width / 3, crop.y);
+                context.lineTo(crop.x + crop.width / 3, crop.y + crop.height);
+                context.moveTo(crop.x + crop.width / 3 * 2, crop.y);
+                context.lineTo(crop.x + crop.width / 3 * 2, crop.y + crop.height);
+                context.stroke();
                 var cropHandles = [
                     [crop.x, crop.y], [crop.x + crop.width, crop.y],
                     [crop.x + crop.width, crop.y + crop.height], [crop.x, crop.y + crop.height]


### PR DESCRIPTION
Draw two horizontal and two vertical semi-transparent white lines inside the crop rectangle, dividing it into a 3x3 grid for composition guidance, matching the reference drawing application's trisector lines.

裁剪选框内绘制三等分线（九宫格辅助线），提供构图参考。

Log: 裁剪选框九宫格辅助线
task: TASK-393981
Influence: 裁剪视觉增强；不影响功能逻辑。

## Summary by Sourcery

New Features:
- Add a semi-transparent rule-of-thirds grid inside the crop selection to provide composition guidance.