### PR TITLE
fix(editor): fit toolbar width and pin thickness dot color

### DIFF
--- a/src/qml/EditPropertyPanel.qml
+++ b/src/qml/EditPropertyPanel.qml
@@ -79,7 +79,7 @@ DTK.Control {
 
         Rectangle {
             anchors.centerIn: parent
-            color: propertyPanel.currentColor
+            color: propertyPanel.themeTextColor
             height: 2 + (propertyPanel.thickness - 1) * 12 / 49
             radius: height / 2
             width: height

--- a/src/qml/EditToolbar.qml
+++ b/src/qml/EditToolbar.qml
@@ -32,7 +32,7 @@ DTK.Control {
     Accessible.name: qsTr("Edit toolbar")
     Accessible.role: Accessible.ToolBar
     implicitHeight: 56
-    implicitWidth: 478
+    implicitWidth: 514
     padding: 0
 
     background: Rectangle {


### PR DESCRIPTION
Widen the edit toolbar implicit width to 514px so the close button stays inside the rounded panel after adding the rotate button. Pin the thickness preview dot to the fixed text color instead of following the palette.

编辑工具栏宽度调整至 514px，关闭按钮不再溢出圆角面板；
粗细预览圆点改为固定主题色，不再跟随调色板颜色变化。

Log: 修复编辑工具栏宽度与圆点颜色
task: TASK-393981
Influence: 工具栏布局与属性面板视觉微调；不影响功能逻辑。

## Summary by Sourcery

Fix edit toolbar sizing and thickness preview color consistency.

Bug Fixes:
- Keep the edit toolbar’s close button within its rounded panel by increasing the toolbar width.
- Keep the thickness preview dot using the fixed theme text color instead of the selected palette color.