### PR TITLE
fix(editor): use DTK confirmation dialogs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -97,6 +97,7 @@ else()
             qml/ToolbarIconButton.qml
             qml/ViewRightMenu.qml
             qml/ViewTopTitle.qml
+            qml/Dialog/EditConfirmDialog.qml
             qml/Dialog/RemoveDialog.qml
             qml/ImageDelegate/BaseImageDelegate.qml
             qml/ImageDelegate/DamagedImageDelegate.qml

--- a/src/qml/Dialog/EditConfirmDialog.qml
+++ b/src/qml/Dialog/EditConfirmDialog.qml
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Window
+import org.deepin.dtk 1.0
+
+DialogWindow {
+    id: dialog
+
+    property var actions: []
+    property string message: ""
+    property var parentWindow: null
+    property string secondaryMessage: ""
+
+    signal actionTriggered(string action)
+
+    function centerInParent() {
+        const targetWindow = parentWindow || Window.window;
+        if (!targetWindow)
+            return;
+        setX(targetWindow.x + targetWindow.width / 2 - width / 2);
+        setY(targetWindow.y + targetWindow.height / 2 - height / 2);
+    }
+
+    function open() {
+        centerInParent();
+        show();
+        requestActivate();
+    }
+
+    flags: Qt.Dialog | Qt.WindowCloseButtonHint
+    color: palette.window
+    DWindow.enableBlurWindow: false
+    DWindow.windowRadius: 16
+    height: 180
+    maximumHeight: 180
+    maximumWidth: 400
+    minimumHeight: 180
+    minimumWidth: 400
+    modality: Qt.ApplicationModal
+    visible: false
+    width: 400
+
+    header: DialogTitleBar {
+        enableInWindowBlendBlur: false
+        icon.mode: DTK.NormalState
+        icon.name: "deepin-image-viewer"
+        content: Item { }
+    }
+
+    onVisibleChanged: {
+        if (visible)
+            centerInParent();
+    }
+
+    Item {
+        height: 130
+        width: parent.width
+
+        Item {
+            id: textBlock
+
+            anchors.left: parent.left
+            anchors.leftMargin: 24
+            anchors.right: parent.right
+            anchors.rightMargin: 24
+            anchors.top: parent.top
+            anchors.topMargin: 3
+            height: 46
+
+            Label {
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.top: parent.top
+                height: dialog.secondaryMessage === "" ? parent.height : 26
+                color: dialog.palette.windowText
+                font: DTK.fontManager.t5
+                horizontalAlignment: Text.AlignHCenter
+                text: dialog.message
+                verticalAlignment: Text.AlignVCenter
+                wrapMode: Text.WordWrap
+            }
+
+            Label {
+                anchors.bottom: parent.bottom
+                anchors.left: parent.left
+                anchors.right: parent.right
+                height: 20
+                color: dialog.palette.windowText
+                font: DTK.fontManager.t7
+                horizontalAlignment: Text.AlignHCenter
+                opacity: 0.7
+                text: dialog.secondaryMessage
+                verticalAlignment: Text.AlignVCenter
+                visible: text !== ""
+            }
+        }
+
+        Row {
+            anchors.bottom: parent.bottom
+            anchors.bottomMargin: 10
+            anchors.horizontalCenter: parent.horizontalCenter
+            height: 36
+            spacing: 10
+
+            Repeater {
+                model: dialog.actions
+
+                Item {
+                    required property var modelData
+
+                    property int buttonWidth: dialog.actions.length > 2 ? 100 : 155
+
+                    height: 36
+                    width: buttonWidth
+
+                    Button {
+                        anchors.fill: parent
+                        text: parent.modelData.text
+                        visible: !Boolean(parent.modelData.recommended)
+
+                        Accessible.name: text
+                        Accessible.role: Accessible.Button
+
+                        onClicked: {
+                            dialog.actionTriggered(parent.modelData.action);
+                            dialog.close();
+                        }
+                    }
+
+                    RecommandButton {
+                        anchors.fill: parent
+                        text: parent.modelData.text
+                        visible: Boolean(parent.modelData.recommended)
+
+                        Accessible.name: text
+                        Accessible.role: Accessible.Button
+
+                        onClicked: {
+                            dialog.actionTriggered(parent.modelData.action);
+                            dialog.close();
+                        }
+                    }
+
+                }
+            }
+        }
+    }
+}

--- a/src/qml/FullImageView.qml
+++ b/src/qml/FullImageView.qml
@@ -10,6 +10,7 @@ import Qt5Compat.GraphicalEffects
 import org.deepin.dtk 1.0
 import org.deepin.dtk.style 1.0 as DS
 import org.deepin.image.viewer 1.0 as IV
+import "./Dialog"
 import "./Utils"
 
 Item {
@@ -558,20 +559,21 @@ Item {
         }
     }
 
-    Dialog {
+    EditConfirmDialog {
         id: overwriteDialog
 
-        anchors.centerIn: parent
-        modal: true
-        standardButtons: Dialog.Yes | Dialog.No
-        title: qsTr("Overwrite Original Image")
+        title: ""
+        message: qsTr("This will overwrite the original image. This action cannot be undone. Continue?")
+        parentWindow: Window.window
+        actions: [
+            { "text": qsTr("Cancel"), "action": "cancel" },
+            { "text": qsTr("Confirm"), "action": "confirm", "recommended": true }
+        ]
 
-        contentItem: Label {
-            text: qsTr("This operation will overwrite the original image and cannot be undone. Continue?")
-            wrapMode: Text.WordWrap
+        onActionTriggered: function(action) {
+            if (action === "confirm")
+                fullThumbnail.saveTo(fullThumbnail.pendingSaveUrl);
         }
-
-        onAccepted: fullThumbnail.saveTo(fullThumbnail.pendingSaveUrl)
     }
 
     Dialog {

--- a/src/qml/MainStack.qml
+++ b/src/qml/MainStack.qml
@@ -5,8 +5,10 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Dialogs
+import QtQuick.Window
 import org.deepin.dtk 1.0 as DTK
 import org.deepin.image.viewer 1.0 as IV
+import "./Dialog"
 
 Item {
     id: stackView
@@ -211,47 +213,25 @@ Item {
         onActivated: requestExitEditMode()
     }
 
-    Dialog {
+    EditConfirmDialog {
         id: unsavedEditDialog
 
-        modal: true
-        standardButtons: Dialog.NoButton
-        title: qsTr("Image Modified")
+        title: ""
+        message: qsTr("The current image has unsaved changes. Save?")
+        parentWindow: Window.window
+        secondaryMessage: qsTr("Image Modified")
+        actions: [
+            { "text": qsTr("Cancel"), "action": "cancel" },
+            { "text": qsTr("Don't Save"), "action": "discard" },
+            { "text": qsTr("Save Copy"), "action": "save", "recommended": true }
+        ]
 
-        anchors.centerIn: parent
-
-        contentItem: Column {
-            spacing: 16
-
-            Label {
-                text: qsTr("The current image has unsaved changes. Save?")
-                wrapMode: Text.WordWrap
-            }
-
-            Row {
-                spacing: 8
-
-                Button {
-                    text: qsTr("Cancel")
-                    onClicked: unsavedEditDialog.close()
-                }
-
-                Button {
-                    text: qsTr("Don't Save")
-                    onClicked: {
-                        IV.GStatus.editModified = false;
-                        IV.GStatus.editMode = false;
-                        unsavedEditDialog.close();
-                    }
-                }
-
-                Button {
-                    text: qsTr("Save Copy")
-                    onClicked: {
-                        stackView.saveEditCopyAndExit();
-                        unsavedEditDialog.close();
-                    }
-                }
+        onActionTriggered: function(action) {
+            if (action === "discard") {
+                IV.GStatus.editModified = false;
+                IV.GStatus.editMode = false;
+            } else if (action === "save") {
+                stackView.saveEditCopyAndExit();
             }
         }
     }

--- a/src/translations/deepin-image-viewer_zh_CN.ts
+++ b/src/translations/deepin-image-viewer_zh_CN.ts
@@ -296,8 +296,8 @@
     </message>
     <message>
         <location filename="../qml/FullImageView.qml" line="537"/>
-        <source>This operation will overwrite the original image and cannot be undone. Continue?</source>
-        <translation>此操作将覆盖原图且无法撤销，是否继续？</translation>
+        <source>This will overwrite the original image. This action cannot be undone. Continue?</source>
+        <translation>此操作将覆盖原图，不可恢复，是否继续？</translation>
     </message>
     <message>
         <location filename="../qml/FullImageView.qml" line="552"/>
@@ -470,7 +470,7 @@
     <message>
         <location filename="../qml/MainStack.qml" line="227"/>
         <source>The current image has unsaved changes. Save?</source>
-        <translation>当前图片有未保存的更改，是否保存？</translation>
+        <translation>当前图片有未保存的修改，是否保存？</translation>
     </message>
     <message>
         <location filename="../qml/MainStack.qml" line="235"/>


### PR DESCRIPTION
Replace native edit confirmation dialogs with a reusable DTK window.

Align icon, rounded corners, text order, buttons and translations.

使用可复用的 DTK 窗口替换编辑模式原生确认弹窗。

统一应用图标、圆角、文案顺序、按钮布局和中文翻译。

Log: 编辑确认弹窗改用DTK样式

task: TASK-393981

Influence: 编辑退出和覆盖原图确认弹窗；不影响保存处理逻辑。

## Summary by Sourcery

Replace native edit confirmation prompts with reusable DTK-styled dialogs while preserving existing save and edit workflows.

New Features:
- Add a reusable DTK-styled confirmation dialog for edit-related actions.

Bug Fixes:
- Replace native edit exit and original-image overwrite confirmations with consistent DTK dialogs.

Enhancements:
- Standardize confirmation dialog layout, branding, button emphasis, text presentation, and application-modal behavior.
- Update Chinese translations for the revised confirmation messages.

Build:
- Include the reusable edit confirmation dialog in the QML build sources.