### PR TITLE
fix(editor): align text fonts and number reuse

### DIFF
--- a/src/qml/EditCanvas.qml
+++ b/src/qml/EditCanvas.qml
@@ -214,7 +214,9 @@ Item {
     function nextNumber() {
         var used = {};
         for (var i = 0; i < strokes.length; ++i) {
-            if (strokes[i].type === "number") used[strokes[i].number] = true;
+            if (strokes[i].type !== "number") continue;
+            var value = Number(strokes[i].number);
+            if (Number.isInteger(value) && value > 0) used[value] = true;
         }
         var number = 1;
         while (used[number]) ++number;
@@ -230,6 +232,7 @@ Item {
             points: [Qt.point(x - diameter / 2, y - diameter / 2),
                      Qt.point(x + diameter / 2, y + diameter / 2)],
             color: currentColor.toString(),
+            fontFamily: textEditor.font.family,
             width: thickness,
             baseWidth: diameter,
             baseHeight: diameter
@@ -253,6 +256,7 @@ Item {
                 points: [Qt.point(textEditor.x, textEditor.y),
                          Qt.point(textEditor.x + textWidth, textEditor.y + textHeight)],
                 color: currentColor.toString(),
+                fontFamily: textEditor.font.family,
                 width: thickness,
                 baseWidth: textWidth,
                 baseHeight: textHeight
@@ -408,7 +412,8 @@ Item {
                     context.strokeStyle = stroke.color;
                     context.textAlign = stroke.type === "number" ? "center" : "left";
                     context.textBaseline = "middle";
-                    context.font = "20px sans-serif";
+                    var fontFamily = stroke.fontFamily || textEditor.font.family;
+                    context.font = "20px \"" + fontFamily.replace(/"/g, "\\\"") + "\"";
                     if (stroke.type === "number") {
                         var radius = stroke.baseWidth / 2 - Math.max(1, stroke.width / 2);
                         context.lineWidth = stroke.width;

--- a/src/src/imageeditcontroller.cpp
+++ b/src/src/imageeditcontroller.cpp
@@ -155,6 +155,7 @@ bool ImageEditController::saveComposite(const QUrl &destination, const QVariantL
 
     QPainter painter(&result);
     painter.setRenderHint(QPainter::Antialiasing);
+    const QFont defaultFont = painter.font();
     for (const QVariant &annotationValue : annotations) {
         const QVariantMap annotation = annotationValue.toMap();
         const QString type = annotation.value(QStringLiteral("type")).toString();
@@ -180,7 +181,10 @@ bool ImageEditController::saveComposite(const QUrl &destination, const QVariantL
             painter.drawEllipse(bounds.normalized());
         } else if (type == QLatin1String("text") || type == QLatin1String("number")) {
             const QRectF textBounds = bounds.normalized();
-            QFont font = painter.font();
+            QFont font = defaultFont;
+            const QString fontFamily = annotation.value(QStringLiteral("fontFamily")).toString();
+            if (!fontFamily.isEmpty())
+                font.setFamily(fontFamily);
             font.setPixelSize(qMax(8, qRound(textBounds.height() * 0.8)));
             painter.setFont(font);
             if (type == QLatin1String("number")) {

--- a/tests/src/ut_imageeditcontroller.cpp
+++ b/tests/src/ut_imageeditcontroller.cpp
@@ -6,6 +6,8 @@
 
 #include <QSignalSpy>
 #include <QElapsedTimer>
+#include <QFont>
+#include <QGuiApplication>
 #include <QImageWriter>
 #include <QTemporaryDir>
 #include <gtest/gtest.h>
@@ -382,8 +384,10 @@ TEST(ut_imageeditcontroller, SaveComposite_AllAnnotationTypes_Rasterized)
     };
     QVariantMap text = annotation("text", QPointF(0.05, 0.65), QPointF(0.4, 0.9));
     text.insert("text", "Edit");
+    text.insert("fontFamily", QGuiApplication::font().family());
     QVariantMap number = annotation("number", QPointF(0.65, 0.65), QPointF(0.9, 0.95));
     number.insert("number", 2);
+    number.insert("fontFamily", QGuiApplication::font().family());
     const QVariantList annotations {
         annotation("rect", QPointF(0.05, 0.05), QPointF(0.3, 0.35)),
         annotation("ellipse", QPointF(0.35, 0.05), QPointF(0.6, 0.35)),


### PR DESCRIPTION
Use the system font consistently for text and numbered annotations.

Allocate the smallest unused positive number after annotation deletion.

统一普通文字与序号标注的系统默认字体。

删除序号后优先复用最小的空缺正整数编号。

Log: 补全文本字体和序号复用逻辑

task: TASK-393981

Influence: 文本与序号标注的预览、保存及编号分配行为。

## Summary by Sourcery

Align text and numbered annotations with the system font and improve reuse of deleted annotation numbers.

Bug Fixes:
- Use the system font consistently when previewing and saving text and numbered annotations.
- Reuse the smallest available positive annotation number after numbered annotations are deleted.

Tests:
- Update rasterization coverage to include annotation font families.