### PR TITLE
fix(editor): correct ellipse drawing lifecycle

### DIFF
--- a/src/qml/EditCanvas.qml
+++ b/src/qml/EditCanvas.qml
@@ -453,8 +453,7 @@ Item {
                     if (stroke.type === "rect") {
                         context.rect(left, top, shapeWidth, shapeHeight);
                     } else {
-                        context.ellipse(left + shapeWidth / 2, top + shapeHeight / 2,
-                                        shapeWidth / 2, shapeHeight / 2, 0, 0, Math.PI * 2);
+                        context.ellipse(left, top, shapeWidth, shapeHeight);
                     }
                     context.stroke();
                     return;
@@ -746,7 +745,7 @@ Item {
                     drawingCanvas.requestPaint();
                     return;
                 }
-                if (editCanvas.currentTool === "rect" || editCanvas.currentTool === "ellipse") {
+                if (editCanvas.currentTool === "rect") {
                     var start = points[0];
                     var deltaX = mouse.x - start.x;
                     var deltaY = mouse.y - start.y;
@@ -754,6 +753,13 @@ Item {
                     var endX = start.x + (deltaX < 0 ? -side : side);
                     var endY = start.y + (deltaY < 0 ? -side : side);
                     drawingCanvas.activePoints = [start, Qt.point(endX, endY)];
+                    drawingCanvas.requestPaint();
+                    return;
+                }
+                if (editCanvas.currentTool === "ellipse") {
+                    var ellipseStart = points[0];
+                    drawingCanvas.activePoints = [ellipseStart,
+                                                  Qt.point(mouse.x, mouse.y)];
                     drawingCanvas.requestPaint();
                     return;
                 }


### PR DESCRIPTION
Use bounding-box points for independent ellipse drawing operations.

使用外接矩形双点并复用通用绘制生命周期。

Log: 修复圆形连续绘制状态异常
task: TASK-393981
Influence: 圆形预览、边框贴合及连续绘制交互。

## Summary by Sourcery

Fix ellipse drawing lifecycle to ensure previews, border alignment, and consecutive drawing interactions remain consistent.

Bug Fixes:
- Correct ellipse preview and continuous drawing behavior by preserving independent bounding-box start and end points throughout the drawing lifecycle.

Enhancements:
- Align ellipse rendering with the shared bounding-box drawing model used by the editor.