### PR TITLE
fix(editor): complete edit mode copy text

### DIFF
--- a/src/qml/EditPropertyPanel.qml
+++ b/src/qml/EditPropertyPanel.qml
@@ -36,7 +36,7 @@ DTK.Control {
     Accessible.name: qsTr("Tool properties")
     Accessible.role: Accessible.Pane
     implicitHeight: 56
-    implicitWidth: isEffectTool ? 367 : isTextTool ? 265 : 333
+    implicitWidth: isEffectTool ? 367 : isTextTool ? 299 : 383
     padding: 0
 
     background: Rectangle {
@@ -52,6 +52,8 @@ DTK.Control {
         required property string iconPath
         property bool selected: false
 
+        Accessible.name: DTK.ToolTip.text
+        Accessible.role: Accessible.Button
         display: AbstractButton.IconOnly
         checked: selected
         height: 36
@@ -72,11 +74,18 @@ DTK.Control {
                   : "transparent"
             radius: 8
         }
+
+        DTK.ToolTip.delay: 500
+        DTK.ToolTip.timeout: 5000
+        DTK.ToolTip.visible: hovered
     }
 
     component ThicknessDot: Item {
         height: 36
         width: 36
+
+        Accessible.name: qsTr("Thickness")
+        Accessible.role: Accessible.Indicator
 
         Rectangle {
             anchors.centerIn: parent
@@ -119,6 +128,9 @@ DTK.Control {
     component ColorPalette: Item {
         height: 36
         width: 136
+
+        Accessible.name: qsTr("Color")
+        Accessible.role: Accessible.Grouping
 
         Grid {
             anchors.left: parent.left
@@ -164,6 +176,21 @@ DTK.Control {
         }
     }
 
+    component MoreColorsButton: DTK.ToolButton {
+        Accessible.name: DTK.ToolTip.text
+        Accessible.role: Accessible.Button
+        display: AbstractButton.TextOnly
+        height: 36
+        text: "..."
+        width: 36
+
+        DTK.ToolTip.delay: 500
+        DTK.ToolTip.text: qsTr("More Colors…")
+        DTK.ToolTip.timeout: 5000
+        DTK.ToolTip.visible: hovered
+        onClicked: colorDialog.open()
+    }
+
     contentItem: Item {
         Row {
             id: textControls
@@ -194,6 +221,7 @@ DTK.Control {
             }
             Separator { }
             ColorPalette { }
+            MoreColorsButton { }
         }
 
         Row {
@@ -307,6 +335,7 @@ DTK.Control {
             }
             Separator { }
             ColorPalette { }
+            MoreColorsButton { }
         }
     }
 

--- a/src/qml/EditToolbar.qml
+++ b/src/qml/EditToolbar.qml
@@ -115,7 +115,7 @@ DTK.Control {
             iconPath: editToolbar.blurMode === "mosaic" ? "edit_mosaic"
                     : editToolbar.blurMode === "graffiti" ? "edit_graffiti"
                     : "edit_blur"
-            DTK.ToolTip.text: qsTr("Effects") + " (B)"
+            DTK.ToolTip.text: qsTr("Blur") + " (B)"
         }
 
         Separator { }

--- a/src/qml/ThumbnailListView.qml
+++ b/src/qml/ThumbnailListView.qml
@@ -549,12 +549,12 @@ Control {
 
         ToolbarIconButton {
             id: editButton
-            Accessible.name: qsTr("Edit")
+            Accessible.name: qsTr("Edit Mode")
             Accessible.role: Accessible.Button
 
             ToolTip.delay: 500
             ToolTip.text: IV.ImageEditor.canEdit(IV.GControl.currentSource)
-                          ? qsTr("Edit") : qsTr("This image format cannot be edited")
+                          ? qsTr("Edit Mode") : qsTr("This image format cannot be edited")
             ToolTip.timeout: 5000
             ToolTip.visible: hovered
             enabled: !imageIsNull && !IV.GStatus.editMode

--- a/src/translations/deepin-image-viewer_zh_CN.ts
+++ b/src/translations/deepin-image-viewer_zh_CN.ts
@@ -16,13 +16,38 @@
     </message>
     <message>
         <location filename="../qml/EditPropertyPanel.qml" line="63"/>
-        <source>More Colors...</source>
-        <translation>更多颜色...</translation>
+        <source>More Colors…</source>
+        <translation>更多颜色…</translation>
     </message>
     <message>
         <location filename="../qml/EditPropertyPanel.qml" line="68"/>
         <source>Thickness</source>
         <translation>粗细</translation>
+    </message>
+    <message>
+        <location filename="../qml/EditPropertyPanel.qml" line="180"/>
+        <source>Plain Text</source>
+        <translation>普通文字</translation>
+    </message>
+    <message>
+        <location filename="../qml/EditPropertyPanel.qml" line="189"/>
+        <source>Numbered Step</source>
+        <translation>序号标注</translation>
+    </message>
+    <message>
+        <location filename="../qml/EditPropertyPanel.qml" line="208"/>
+        <source>Gaussian Blur</source>
+        <translation>高斯模糊</translation>
+    </message>
+    <message>
+        <location filename="../qml/EditPropertyPanel.qml" line="209"/>
+        <source>Mosaic</source>
+        <translation>马赛克</translation>
+    </message>
+    <message>
+        <location filename="../qml/EditPropertyPanel.qml" line="210"/>
+        <source>Graffiti</source>
+        <translation>涂鸦</translation>
     </message>
 </context>
 <context>
@@ -88,6 +113,11 @@
         <location filename="../qml/EditToolbar.qml" line="141"/>
         <source>Effects</source>
         <translation>特效</translation>
+    </message>
+    <message>
+        <location filename="../qml/EditToolbar.qml" line="118"/>
+        <source>Blur</source>
+        <translation>模糊</translation>
     </message>
     <message>
         <location filename="../qml/EditToolbar.qml" line="155"/>
@@ -666,8 +696,8 @@
     <message>
         <location filename="../qml/ThumbnailListView.qml" line="529"/>
         <location filename="../qml/ThumbnailListView.qml" line="534"/>
-        <source>Edit</source>
-        <translation>编辑</translation>
+        <source>Edit Mode</source>
+        <translation>编辑模式</translation>
     </message>
     <message>
         <location filename="../qml/ThumbnailListView.qml" line="534"/>


### PR DESCRIPTION
Add missing tooltips and Chinese translations for edit controls.

补齐编辑控件悬浮文案与中文翻译。

Log: 补齐编辑模式文案
task: TASK-393981
Influence: 编辑工具栏、子模式和属性面板文案显示。

## Summary by Sourcery

Complete edit-mode control labeling, tooltips, accessibility information, and Chinese localization across the editor interface.

New Features:
- Add hover tooltips and accessibility metadata for edit-mode controls, including a dedicated More Colors action.

Bug Fixes:
- Correct the blur tool label and distinguish the image entry action as Edit Mode.
- Complete Chinese translations for edit-mode tools and controls.

Enhancements:
- Adjust edit property panel sizing to accommodate the completed controls.