### PR TITLE
fix(editor): add edit mode translations

### DIFF
--- a/src/translations/deepin-image-viewer_ja.ts
+++ b/src/translations/deepin-image-viewer_ja.ts
@@ -250,11 +250,172 @@
     </message>
 </context>
 <context>
+    <name>EditPropertyPanel</name>
+    <message>
+        <source>Tool properties</source>
+        <translation>ツールのプロパティ</translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation>色</translation>
+    </message>
+    <message>
+        <source>More Colors…</source>
+        <translation>その他の色…</translation>
+    </message>
+    <message>
+        <source>Thickness</source>
+        <translation>太さ</translation>
+    </message>
+    <message>
+        <source>Plain Text</source>
+        <translation>通常テキスト</translation>
+    </message>
+    <message>
+        <source>Numbered Step</source>
+        <translation>番号付きステップ</translation>
+    </message>
+    <message>
+        <source>Gaussian Blur</source>
+        <translation>ガウスぼかし</translation>
+    </message>
+    <message>
+        <source>Mosaic</source>
+        <translation>モザイク</translation>
+    </message>
+    <message>
+        <source>Graffiti</source>
+        <translation>手描き</translation>
+    </message>
+</context>
+<context>
+    <name>EditToolbar</name>
+    <message>
+        <source>Edit toolbar</source>
+        <translation>編集ツールバー</translation>
+    </message>
+    <message>
+        <source>Draw</source>
+        <translation>描画</translation>
+    </message>
+    <message>
+        <source>Pen</source>
+        <translation>ペン</translation>
+    </message>
+    <message>
+        <source>Line</source>
+        <translation>直線</translation>
+    </message>
+    <message>
+        <source>Arrow</source>
+        <translation>矢印</translation>
+    </message>
+    <message>
+        <source>Shape</source>
+        <translation>図形</translation>
+    </message>
+    <message>
+        <source>Rect</source>
+        <translation>四角形</translation>
+    </message>
+    <message>
+        <source>Ellipse</source>
+        <translation>楕円</translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation>テキスト</translation>
+    </message>
+    <message>
+        <source>Effects</source>
+        <translation>効果</translation>
+    </message>
+    <message>
+        <source>Blur</source>
+        <translation>ぼかし</translation>
+    </message>
+    <message>
+        <source>Actions</source>
+        <translation>操作</translation>
+    </message>
+    <message>
+        <source>Crop</source>
+        <translation>トリミング</translation>
+    </message>
+    <message>
+        <source>Undo</source>
+        <translation>元に戻す</translation>
+    </message>
+    <message>
+        <source>Redo</source>
+        <translation>やり直す</translation>
+    </message>
+    <message>
+        <source>Save Copy</source>
+        <translation>コピーを保存</translation>
+    </message>
+    <message>
+        <source>Close Edit</source>
+        <translation>編集を閉じる</translation>
+    </message>
+</context>
+<context>
+    <name>FullImageView</name>
+    <message>
+        <source>Save</source>
+        <translation>保存</translation>
+    </message>
+    <message>
+        <source>Save Copy</source>
+        <translation>コピーを保存</translation>
+    </message>
+    <message>
+        <source>This will overwrite the original image. This action cannot be undone. Continue?</source>
+        <translation>元の画像を上書きします。この操作は元に戻せません。続行しますか？</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>キャンセル</translation>
+    </message>
+    <message>
+        <source>Confirm</source>
+        <translation>確認</translation>
+    </message>
+    <message>
+        <source>Save Failed</source>
+        <translation>保存に失敗しました</translation>
+    </message>
+    <message>
+        <source>Close Edit</source>
+        <translation>編集を閉じる</translation>
+    </message>
+</context>
+<context>
     <name>MainStack</name>
     <message>
         <location filename="../qml/MainStack.qml" line="129"/>
         <source>Select pictures</source>
         <translation>画像を選択</translation>
+    </message>
+    <message>
+        <source>Image Modified</source>
+        <translation>画像が変更されています</translation>
+    </message>
+    <message>
+        <source>The current image has unsaved changes. Save?</source>
+        <translation>現在の画像には未保存の変更があります。保存しますか？</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>キャンセル</translation>
+    </message>
+    <message>
+        <source>Don&apos;t Save</source>
+        <translation>保存しない</translation>
+    </message>
+    <message>
+        <source>Save Copy</source>
+        <translation>コピーを保存</translation>
     </message>
 </context>
 <context>
@@ -407,6 +568,14 @@
         <location filename="../qml/ThumbnailListView.qml" line="517"/>
         <source>Extract text</source>
         <translation>文字を認識</translation>
+    </message>
+    <message>
+        <source>Edit Mode</source>
+        <translation>編集モード</translation>
+    </message>
+    <message>
+        <source>This image format cannot be edited</source>
+        <translation>この画像形式は編集できません</translation>
     </message>
     <message>
         <location filename="../qml/ThumbnailListView.qml" line="536"/>

--- a/src/translations/deepin-image-viewer_lo.ts
+++ b/src/translations/deepin-image-viewer_lo.ts
@@ -251,11 +251,172 @@
     </message>
 </context>
 <context>
+    <name>EditPropertyPanel</name>
+    <message>
+        <source>Tool properties</source>
+        <translation>ຄຸນສົມບັດເຄື່ອງມື</translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation>ສີ</translation>
+    </message>
+    <message>
+        <source>More Colors…</source>
+        <translation>ສີເພີ່ມເຕີມ…</translation>
+    </message>
+    <message>
+        <source>Thickness</source>
+        <translation>ຄວາມໜາ</translation>
+    </message>
+    <message>
+        <source>Plain Text</source>
+        <translation>ຂໍ້ຄວາມທຳມະດາ</translation>
+    </message>
+    <message>
+        <source>Numbered Step</source>
+        <translation>ປ້າຍໝາຍເລກຂັ້ນຕອນ</translation>
+    </message>
+    <message>
+        <source>Gaussian Blur</source>
+        <translation>ເບລີ Gaussian</translation>
+    </message>
+    <message>
+        <source>Mosaic</source>
+        <translation>ໂມເຊອິກ</translation>
+    </message>
+    <message>
+        <source>Graffiti</source>
+        <translation>ຂີດຂຽນ</translation>
+    </message>
+</context>
+<context>
+    <name>EditToolbar</name>
+    <message>
+        <source>Edit toolbar</source>
+        <translation>ແຖບເຄື່ອງມືແກ້ໄຂ</translation>
+    </message>
+    <message>
+        <source>Draw</source>
+        <translation>ແຕ້ມ</translation>
+    </message>
+    <message>
+        <source>Pen</source>
+        <translation>ປາກກາ</translation>
+    </message>
+    <message>
+        <source>Line</source>
+        <translation>ເສັ້ນຊື່</translation>
+    </message>
+    <message>
+        <source>Arrow</source>
+        <translation>ລູກສອນ</translation>
+    </message>
+    <message>
+        <source>Shape</source>
+        <translation>ຮູບຊົງ</translation>
+    </message>
+    <message>
+        <source>Rect</source>
+        <translation>ສີ່ຫຼ່ຽມ</translation>
+    </message>
+    <message>
+        <source>Ellipse</source>
+        <translation>ວົງມົນ</translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation>ຂໍ້ຄວາມ</translation>
+    </message>
+    <message>
+        <source>Effects</source>
+        <translation>ເອັບເຟັກ</translation>
+    </message>
+    <message>
+        <source>Blur</source>
+        <translation>ເບລີ</translation>
+    </message>
+    <message>
+        <source>Actions</source>
+        <translation>ການກະທຳ</translation>
+    </message>
+    <message>
+        <source>Crop</source>
+        <translation>ຕັດຮູບ</translation>
+    </message>
+    <message>
+        <source>Undo</source>
+        <translation>ຍ້ອນກັບ</translation>
+    </message>
+    <message>
+        <source>Redo</source>
+        <translation>ເຮັດຊ້ຳ</translation>
+    </message>
+    <message>
+        <source>Save Copy</source>
+        <translation>ບັນທຶກສຳເນົາ</translation>
+    </message>
+    <message>
+        <source>Close Edit</source>
+        <translation>ປິດການແກ້ໄຂ</translation>
+    </message>
+</context>
+<context>
+    <name>FullImageView</name>
+    <message>
+        <source>Save</source>
+        <translation>ບັນທຶກ</translation>
+    </message>
+    <message>
+        <source>Save Copy</source>
+        <translation>ບັນທຶກສຳເນົາ</translation>
+    </message>
+    <message>
+        <source>This will overwrite the original image. This action cannot be undone. Continue?</source>
+        <translation>ການດຳເນີນການນີ້ຈະຂຽນທັບຮູບຕົ້ນສະບັບ ແລະບໍ່ສາມາດຍ້ອນກັບໄດ້. ຕ້ອງການດຳເນີນຕໍ່ບໍ?</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>ຍົກເລີກ</translation>
+    </message>
+    <message>
+        <source>Confirm</source>
+        <translation>ຢືນຢັນ</translation>
+    </message>
+    <message>
+        <source>Save Failed</source>
+        <translation>ບັນທຶກບໍ່ສຳເລັດ</translation>
+    </message>
+    <message>
+        <source>Close Edit</source>
+        <translation>ປິດການແກ້ໄຂ</translation>
+    </message>
+</context>
+<context>
     <name>MainStack</name>
     <message>
         <location filename="../qml/MainStack.qml" line="127"/>
         <source>Select pictures</source>
-        <translation>ເລືອກຮູປື່</translation>
+        <translation>ເລືອກຮູບພາບ</translation>
+    </message>
+    <message>
+        <source>Image Modified</source>
+        <translation>ຮູບພາບຖືກແກ້ໄຂແລ້ວ</translation>
+    </message>
+    <message>
+        <source>The current image has unsaved changes. Save?</source>
+        <translation>ຮູບພາບປັດຈຸບັນມີການແກ້ໄຂທີ່ຍັງບໍ່ໄດ້ບັນທຶກ. ຕ້ອງການບັນທຶກບໍ?</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>ຍົກເລີກ</translation>
+    </message>
+    <message>
+        <source>Don&apos;t Save</source>
+        <translation>ບໍ່ບັນທຶກ</translation>
+    </message>
+    <message>
+        <source>Save Copy</source>
+        <translation>ບັນທຶກສຳເນົາ</translation>
     </message>
 </context>
 <context>
@@ -405,6 +566,14 @@
         <location filename="../qml/ThumbnailListView.qml" line="519"/>
         <source>Extract text</source>
         <translation>ດົນງານຂແ້ນເອົາຂໍ້alm</translation>
+    </message>
+    <message>
+        <source>Edit Mode</source>
+        <translation>ໂໝດແກ້ໄຂ</translation>
+    </message>
+    <message>
+        <source>This image format cannot be edited</source>
+        <translation>ຮູບແບບຮູບພາບນີ້ບໍ່ສາມາດແກ້ໄຂໄດ້</translation>
     </message>
     <message>
         <location filename="../qml/ThumbnailListView.qml" line="538"/>

--- a/src/translations/deepin-image-viewer_zh_HK.ts
+++ b/src/translations/deepin-image-viewer_zh_HK.ts
@@ -252,11 +252,172 @@
     </message>
 </context>
 <context>
+    <name>EditPropertyPanel</name>
+    <message>
+        <source>Tool properties</source>
+        <translation>工具屬性</translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation>顏色</translation>
+    </message>
+    <message>
+        <source>More Colors…</source>
+        <translation>更多顏色…</translation>
+    </message>
+    <message>
+        <source>Thickness</source>
+        <translation>粗細</translation>
+    </message>
+    <message>
+        <source>Plain Text</source>
+        <translation>普通文字</translation>
+    </message>
+    <message>
+        <source>Numbered Step</source>
+        <translation>序號標註</translation>
+    </message>
+    <message>
+        <source>Gaussian Blur</source>
+        <translation>高斯模糊</translation>
+    </message>
+    <message>
+        <source>Mosaic</source>
+        <translation>馬賽克</translation>
+    </message>
+    <message>
+        <source>Graffiti</source>
+        <translation>塗鴉</translation>
+    </message>
+</context>
+<context>
+    <name>EditToolbar</name>
+    <message>
+        <source>Edit toolbar</source>
+        <translation>編輯工具列</translation>
+    </message>
+    <message>
+        <source>Draw</source>
+        <translation>繪製</translation>
+    </message>
+    <message>
+        <source>Pen</source>
+        <translation>畫筆</translation>
+    </message>
+    <message>
+        <source>Line</source>
+        <translation>直線</translation>
+    </message>
+    <message>
+        <source>Arrow</source>
+        <translation>箭頭</translation>
+    </message>
+    <message>
+        <source>Shape</source>
+        <translation>形狀</translation>
+    </message>
+    <message>
+        <source>Rect</source>
+        <translation>矩形</translation>
+    </message>
+    <message>
+        <source>Ellipse</source>
+        <translation>圓形</translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation>文字</translation>
+    </message>
+    <message>
+        <source>Effects</source>
+        <translation>特效</translation>
+    </message>
+    <message>
+        <source>Blur</source>
+        <translation>模糊</translation>
+    </message>
+    <message>
+        <source>Actions</source>
+        <translation>操作</translation>
+    </message>
+    <message>
+        <source>Crop</source>
+        <translation>裁剪</translation>
+    </message>
+    <message>
+        <source>Undo</source>
+        <translation>撤銷</translation>
+    </message>
+    <message>
+        <source>Redo</source>
+        <translation>重做</translation>
+    </message>
+    <message>
+        <source>Save Copy</source>
+        <translation>儲存副本</translation>
+    </message>
+    <message>
+        <source>Close Edit</source>
+        <translation>關閉編輯</translation>
+    </message>
+</context>
+<context>
+    <name>FullImageView</name>
+    <message>
+        <source>Save</source>
+        <translation>儲存</translation>
+    </message>
+    <message>
+        <source>Save Copy</source>
+        <translation>儲存副本</translation>
+    </message>
+    <message>
+        <source>This will overwrite the original image. This action cannot be undone. Continue?</source>
+        <translation>此操作將覆蓋原圖，不可復原，是否繼續？</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Confirm</source>
+        <translation>確定</translation>
+    </message>
+    <message>
+        <source>Save Failed</source>
+        <translation>儲存失敗</translation>
+    </message>
+    <message>
+        <source>Close Edit</source>
+        <translation>關閉編輯</translation>
+    </message>
+</context>
+<context>
     <name>MainStack</name>
     <message>
         <location filename="../qml/MainStack.qml" line="129"/>
         <source>Select pictures</source>
         <translation>選擇圖片</translation>
+    </message>
+    <message>
+        <source>Image Modified</source>
+        <translation>圖片已修改</translation>
+    </message>
+    <message>
+        <source>The current image has unsaved changes. Save?</source>
+        <translation>目前圖片有未儲存的修改，是否儲存？</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Don&apos;t Save</source>
+        <translation>不儲存</translation>
+    </message>
+    <message>
+        <source>Save Copy</source>
+        <translation>儲存副本</translation>
     </message>
 </context>
 <context>
@@ -409,6 +570,14 @@
         <location filename="../qml/ThumbnailListView.qml" line="517"/>
         <source>Extract text</source>
         <translation>識別文字</translation>
+    </message>
+    <message>
+        <source>Edit Mode</source>
+        <translation>編輯模式</translation>
+    </message>
+    <message>
+        <source>This image format cannot be edited</source>
+        <translation>此圖片格式無法編輯</translation>
     </message>
     <message>
         <location filename="../qml/ThumbnailListView.qml" line="536"/>

--- a/src/translations/deepin-image-viewer_zh_TW.ts
+++ b/src/translations/deepin-image-viewer_zh_TW.ts
@@ -252,11 +252,172 @@
     </message>
 </context>
 <context>
+    <name>EditPropertyPanel</name>
+    <message>
+        <source>Tool properties</source>
+        <translation>工具屬性</translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation>顏色</translation>
+    </message>
+    <message>
+        <source>More Colors…</source>
+        <translation>更多顏色…</translation>
+    </message>
+    <message>
+        <source>Thickness</source>
+        <translation>粗細</translation>
+    </message>
+    <message>
+        <source>Plain Text</source>
+        <translation>一般文字</translation>
+    </message>
+    <message>
+        <source>Numbered Step</source>
+        <translation>序號標註</translation>
+    </message>
+    <message>
+        <source>Gaussian Blur</source>
+        <translation>高斯模糊</translation>
+    </message>
+    <message>
+        <source>Mosaic</source>
+        <translation>馬賽克</translation>
+    </message>
+    <message>
+        <source>Graffiti</source>
+        <translation>塗鴉</translation>
+    </message>
+</context>
+<context>
+    <name>EditToolbar</name>
+    <message>
+        <source>Edit toolbar</source>
+        <translation>編輯工具列</translation>
+    </message>
+    <message>
+        <source>Draw</source>
+        <translation>繪製</translation>
+    </message>
+    <message>
+        <source>Pen</source>
+        <translation>畫筆</translation>
+    </message>
+    <message>
+        <source>Line</source>
+        <translation>直線</translation>
+    </message>
+    <message>
+        <source>Arrow</source>
+        <translation>箭頭</translation>
+    </message>
+    <message>
+        <source>Shape</source>
+        <translation>形狀</translation>
+    </message>
+    <message>
+        <source>Rect</source>
+        <translation>矩形</translation>
+    </message>
+    <message>
+        <source>Ellipse</source>
+        <translation>圓形</translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation>文字</translation>
+    </message>
+    <message>
+        <source>Effects</source>
+        <translation>特效</translation>
+    </message>
+    <message>
+        <source>Blur</source>
+        <translation>模糊</translation>
+    </message>
+    <message>
+        <source>Actions</source>
+        <translation>操作</translation>
+    </message>
+    <message>
+        <source>Crop</source>
+        <translation>裁切</translation>
+    </message>
+    <message>
+        <source>Undo</source>
+        <translation>復原</translation>
+    </message>
+    <message>
+        <source>Redo</source>
+        <translation>重做</translation>
+    </message>
+    <message>
+        <source>Save Copy</source>
+        <translation>儲存副本</translation>
+    </message>
+    <message>
+        <source>Close Edit</source>
+        <translation>關閉編輯</translation>
+    </message>
+</context>
+<context>
+    <name>FullImageView</name>
+    <message>
+        <source>Save</source>
+        <translation>儲存</translation>
+    </message>
+    <message>
+        <source>Save Copy</source>
+        <translation>儲存副本</translation>
+    </message>
+    <message>
+        <source>This will overwrite the original image. This action cannot be undone. Continue?</source>
+        <translation>此操作將覆蓋原圖，且無法復原。是否繼續？</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Confirm</source>
+        <translation>確定</translation>
+    </message>
+    <message>
+        <source>Save Failed</source>
+        <translation>儲存失敗</translation>
+    </message>
+    <message>
+        <source>Close Edit</source>
+        <translation>關閉編輯</translation>
+    </message>
+</context>
+<context>
     <name>MainStack</name>
     <message>
         <location filename="../qml/MainStack.qml" line="129"/>
         <source>Select pictures</source>
         <translation>選擇圖片</translation>
+    </message>
+    <message>
+        <source>Image Modified</source>
+        <translation>圖片已修改</translation>
+    </message>
+    <message>
+        <source>The current image has unsaved changes. Save?</source>
+        <translation>目前圖片有未儲存的修改。是否儲存？</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Don&apos;t Save</source>
+        <translation>不儲存</translation>
+    </message>
+    <message>
+        <source>Save Copy</source>
+        <translation>儲存副本</translation>
     </message>
 </context>
 <context>
@@ -409,6 +570,14 @@
         <location filename="../qml/ThumbnailListView.qml" line="517"/>
         <source>Extract text</source>
         <translation>識別文字</translation>
+    </message>
+    <message>
+        <source>Edit Mode</source>
+        <translation>編輯模式</translation>
+    </message>
+    <message>
+        <source>This image format cannot be edited</source>
+        <translation>此圖片格式無法編輯</translation>
     </message>
     <message>
         <location filename="../qml/ThumbnailListView.qml" line="536"/>


### PR DESCRIPTION
task: TASK-393981

Log: 补齐编辑模式多语言文案

PMS: TASK-393981

Influence: 补齐日语、老挝语、香港繁中、台湾繁中的编辑模式界面文案。

## Summary by Sourcery

Complete localized edit-mode interface text across the supported Japanese, Lao, Hong Kong Traditional Chinese, and Taiwan Traditional Chinese translations.

Bug Fixes:
- Complete edit-mode translations for Japanese, Lao, Hong Kong Traditional Chinese, and Taiwan Traditional Chinese locales.

Chores:
- Correct an existing Lao translation for the picture selection label.