### PR TITLE
fix(editor): preserve state across image operations

### DIFF
--- a/src/qml/EditCanvas.qml
+++ b/src/qml/EditCanvas.qml
@@ -20,6 +20,8 @@ Item {
     property rect cropRect: Qt.rect(0, 0, 0, 0)
     property real previousCanvasHeight: 0
     property real previousCanvasWidth: 0
+    readonly property real stableCanvasHeight: height > 0 ? height : previousCanvasHeight
+    readonly property real stableCanvasWidth: width > 0 ? width : previousCanvasWidth
     property string textMode: "plain"
     property int thickness: 5
     property var vectorHistory: []
@@ -47,8 +49,10 @@ Item {
             for (var p = 0; p < source[i].points.length; ++p) {
                 var pointX = source[i].points[p].x;
                 var pointY = source[i].points[p].y;
-                points.push(normalize ? Qt.point(pointX / Math.max(1, width), pointY / Math.max(1, height))
-                                      : Qt.point(pointX * width, pointY * height));
+                points.push(normalize ? Qt.point(pointX / Math.max(1, stableCanvasWidth),
+                                                 pointY / Math.max(1, stableCanvasHeight))
+                                      : Qt.point(pointX * stableCanvasWidth,
+                                                 pointY * stableCanvasHeight));
             }
             result.push(Object.assign({}, source[i], { points: points }));
         }
@@ -187,20 +191,27 @@ Item {
         drawingCanvas.requestPaint();
     }
 
-    function rotateSelected() {
-        if (selectedIndex < 0 || selectedIndex >= strokes.length) return;
-        var stroke = strokes[selectedIndex];
-        var bounds = boundsFor(stroke);
-        var centerX = (bounds.left + bounds.right) / 2;
-        var centerY = (bounds.top + bounds.bottom) / 2;
-        var rotated = [];
-        for (var i = 0; i < stroke.points.length; ++i) {
-            var dx = stroke.points[i].x - centerX;
-            var dy = stroke.points[i].y - centerY;
-            rotated.push(Qt.point(centerX - dy, centerY + dx));
+    function rotateClockwise() {
+        // Rotate normalized coordinates here; the canvas resize handlers scale them
+        // into the image's swapped dimensions after the rotated image is reloaded.
+        var canvasWidth = stableCanvasWidth;
+        var canvasHeight = stableCanvasHeight;
+        if (canvasWidth <= 0 || canvasHeight <= 0) return;
+        var updated = [];
+        for (var i = 0; i < strokes.length; ++i) {
+            var points = [];
+            for (var p = 0; p < strokes[i].points.length; ++p) {
+                var normalizedX = strokes[i].points[p].x / canvasWidth;
+                var normalizedY = strokes[i].points[p].y / canvasHeight;
+                points.push(Qt.point((1 - normalizedY) * canvasWidth,
+                                     normalizedX * canvasHeight));
+            }
+            updated.push(Object.assign({}, strokes[i], { points: points }));
         }
-        replaceStroke(selectedIndex, Object.assign({}, stroke, { points: rotated }));
+        strokes = updated;
+        selectedIndex = -1;
         strokeCommitted();
+        drawingCanvas.requestPaint();
     }
 
     function updateSelectedStyle(color, width) {
@@ -280,12 +291,12 @@ Item {
         for (var i = 0; i < strokes.length; ++i) {
             var points = [];
             for (var p = 0; p < strokes[i].points.length; ++p) {
-                points.push(Qt.point(strokes[i].points[p].x / Math.max(1, width),
-                                     strokes[i].points[p].y / Math.max(1, height)));
+                points.push(Qt.point(strokes[i].points[p].x / Math.max(1, stableCanvasWidth),
+                                     strokes[i].points[p].y / Math.max(1, stableCanvasHeight)));
             }
             annotations.push(Object.assign({}, strokes[i], {
                 points: points,
-                width: strokes[i].width / Math.max(1, width)
+                width: strokes[i].width / Math.max(1, stableCanvasWidth)
             }));
         }
         return annotations;
@@ -370,12 +381,14 @@ Item {
         if (currentTool === "crop") resetCrop();
     }
     onWidthChanged: {
+        if (width <= 0) return;
         if (previousCanvasWidth > 0) scaleStrokes(width / previousCanvasWidth, 1);
         previousCanvasWidth = width;
         if (currentTool === "crop") resetCrop();
         drawingCanvas.requestPaint();
     }
     onHeightChanged: {
+        if (height <= 0) return;
         if (previousCanvasHeight > 0) scaleStrokes(1, height / previousCanvasHeight);
         previousCanvasHeight = height;
         if (currentTool === "crop") resetCrop();

--- a/src/qml/FullImageView.qml
+++ b/src/qml/FullImageView.qml
@@ -30,12 +30,19 @@ Item {
     }
 
     function saveTo(destination) {
-        if (!IV.ImageEditor.saveComposite(destination, editCanvas.collectAnnotations()))
+        if (!IV.ImageEditor.saveComposite(destination, editCanvas.collectAnnotations())) {
+            if (exitAfterSave)
+                stackView.cancelPendingSourceChange();
+            exitAfterSave = false;
             return;
+        }
         IV.ImageEditor.markSaved();
         IV.GStatus.editModified = false;
-        if (exitAfterSave)
+        if (exitAfterSave) {
+            exitAfterSave = false;
             IV.GStatus.editMode = false;
+            stackView.completePendingSourceChange();
+        }
     }
 
     // 鼠标是否进入当前的视图
@@ -533,7 +540,10 @@ Item {
             if (IV.ImageEditor.redo() && editCanvas.redoHistory())
                 IV.GStatus.editModified = IV.ImageEditor.modified;
         }
-        onRotateRequested: editCanvas.rotateSelected()
+        onRotateRequested: {
+            if (IV.ImageEditor.rotateClockwise())
+                editCanvas.rotateClockwise();
+        }
         onSaveRequested: fullThumbnail.openSaveDialog(false)
         onUndoRequested: {
             if (IV.ImageEditor.undo() && editCanvas.undoHistory())
@@ -559,6 +569,11 @@ Item {
             else
                 fullThumbnail.saveTo(selectedFile);
         }
+        onRejected: {
+            if (fullThumbnail.exitAfterSave)
+                stackView.cancelPendingSourceChange();
+            fullThumbnail.exitAfterSave = false;
+        }
     }
 
     EditConfirmDialog {
@@ -575,6 +590,16 @@ Item {
         onActionTriggered: function(action) {
             if (action === "confirm")
                 fullThumbnail.saveTo(fullThumbnail.pendingSaveUrl);
+            else if (fullThumbnail.exitAfterSave) {
+                stackView.cancelPendingSourceChange();
+                fullThumbnail.exitAfterSave = false;
+            }
+        }
+        onClosing: function(close) {
+            if (fullThumbnail.exitAfterSave) {
+                stackView.cancelPendingSourceChange();
+                fullThumbnail.exitAfterSave = false;
+            }
         }
     }
 

--- a/src/qml/MainStack.qml
+++ b/src/qml/MainStack.qml
@@ -17,6 +17,40 @@ Item {
 
     signal saveEditCopyRequested
 
+    property url pendingSourcePath: ""
+
+    function cancelPendingSourceChange() {
+        pendingSourcePath = "";
+    }
+
+    function completePendingSourceChange() {
+        if (pendingSourcePath.toString() === "") return;
+        var path = pendingSourcePath;
+        pendingSourcePath = "";
+        setSourcePath(path);
+    }
+
+    function requestSourcePath(path) {
+        if (path.toString() === IV.GControl.currentSource.toString()) return;
+        if (!IV.GStatus.editMode) {
+            setSourcePath(path);
+            return;
+        }
+
+        if (pendingSourcePath.toString() !== "") {
+            pendingSourcePath = path;
+            return;
+        }
+
+        pendingSourcePath = path;
+        if (IV.GStatus.editModified) {
+            unsavedEditDialog.open();
+        } else {
+            IV.GStatus.editMode = false;
+            completePendingSourceChange();
+        }
+    }
+
     function requestExitEditMode() {
         if (!IV.GStatus.editMode) {
             return;
@@ -102,7 +136,7 @@ Item {
     Connections {
         // 关联外部通过 DBus 等方式触发调用看图
         function onOpenImageFile(fileName) {
-            setSourcePath(fileName);
+            requestSourcePath(fileName);
         }
 
         target: IV.FileControl
@@ -133,7 +167,7 @@ Item {
         onDropped: {
             if (drop.hasUrls && drop.urls.length !== 0
                     && IV.FileControl.isImage(drop.urls[0].toString())) {
-                setSourcePath(drop.urls[0]);
+                requestSourcePath(drop.urls[0]);
             }
         }
         onEntered: {
@@ -164,7 +198,7 @@ Item {
                 fileDialog.open();
             }
             onAccepted: {
-                stackView.setSourcePath(fileDialog.selectedFiles[0]);
+                stackView.requestSourcePath(fileDialog.selectedFiles[0]);
             }
         }
     }
@@ -216,6 +250,8 @@ Item {
     EditConfirmDialog {
         id: unsavedEditDialog
 
+        property bool preservePendingSource: false
+
         title: ""
         message: qsTr("The current image has unsaved changes. Save?")
         parentWindow: Window.window
@@ -230,9 +266,18 @@ Item {
             if (action === "discard") {
                 IV.GStatus.editModified = false;
                 IV.GStatus.editMode = false;
+                stackView.completePendingSourceChange();
             } else if (action === "save") {
+                preservePendingSource = true;
                 stackView.saveEditCopyAndExit();
+            } else {
+                stackView.cancelPendingSourceChange();
             }
+        }
+        onClosing: function(close) {
+            if (!preservePendingSource)
+                stackView.cancelPendingSourceChange();
+            preservePendingSource = false;
         }
     }
 

--- a/src/src/imageeditcontroller.cpp
+++ b/src/src/imageeditcontroller.cpp
@@ -321,6 +321,21 @@ bool ImageEditController::crop(const QRectF &normalizedRect)
     return true;
 }
 
+bool ImageEditController::rotateClockwise()
+{
+    QWriteLocker locker(&m_lock);
+    if (m_image.isNull())
+        return false;
+
+    QTransform transform;
+    transform.rotate(90);
+    m_image = m_image.transformed(transform);
+    ++m_revision;
+    locker.unlock();
+    Q_EMIT revisionChanged();
+    return true;
+}
+
 void ImageEditController::commitHistory()
 {
     QWriteLocker locker(&m_lock);
@@ -358,10 +373,15 @@ bool ImageEditController::undo()
     if (m_historyIndex <= 0)
         return false;
     --m_historyIndex;
-    m_image = m_history[m_historyIndex];
-    ++m_revision;
+    const QImage &target = m_history[m_historyIndex];
+    const bool imageChanged = target.cacheKey() != m_image.cacheKey();
+    if (imageChanged) {
+        m_image = target;
+        ++m_revision;
+    }
     locker.unlock();
-    Q_EMIT revisionChanged();
+    if (imageChanged)
+        Q_EMIT revisionChanged();
     Q_EMIT historyChanged();
     return true;
 }
@@ -372,10 +392,15 @@ bool ImageEditController::redo()
     if (m_historyIndex < 0 || m_historyIndex + 1 >= m_history.size())
         return false;
     ++m_historyIndex;
-    m_image = m_history[m_historyIndex];
-    ++m_revision;
+    const QImage &target = m_history[m_historyIndex];
+    const bool imageChanged = target.cacheKey() != m_image.cacheKey();
+    if (imageChanged) {
+        m_image = target;
+        ++m_revision;
+    }
     locker.unlock();
-    Q_EMIT revisionChanged();
+    if (imageChanged)
+        Q_EMIT revisionChanged();
     Q_EMIT historyChanged();
     return true;
 }

--- a/src/src/imageeditcontroller.h
+++ b/src/src/imageeditcontroller.h
@@ -39,6 +39,7 @@ public:
     Q_INVOKABLE bool isEditing(const QUrl &source, int frameIndex) const;
     Q_INVOKABLE bool applyEffect(const QString &effect, const QRectF &normalizedRect, int strength);
     Q_INVOKABLE bool crop(const QRectF &normalizedRect);
+    Q_INVOKABLE bool rotateClockwise();
     Q_INVOKABLE void commitHistory();
     Q_INVOKABLE bool redo();
     Q_INVOKABLE bool undo();

--- a/tests/src/ut_imageeditcontroller.cpp
+++ b/tests/src/ut_imageeditcontroller.cpp
@@ -270,6 +270,31 @@ TEST(ut_imageeditcontroller, Crop_FullImage_ReturnsFalse)
     EXPECT_FALSE(controller.crop(QRectF(0, 0, 1, 1)));
 }
 
+TEST(ut_imageeditcontroller, RotateClockwise_SwapsDimensionsAndSupportsHistory)
+{
+    QTemporaryDir directory;
+    ASSERT_TRUE(directory.isValid());
+    ImageEditController controller;
+    ASSERT_TRUE(controller.beginEdit(QUrl::fromLocalFile(createTestImage(directory))));
+    const QImage original = controller.image();
+
+    ASSERT_TRUE(controller.rotateClockwise());
+    EXPECT_EQ(controller.image().size(), QSize(60, 80));
+    controller.commitHistory();
+    const QImage rotated = controller.image();
+
+    ASSERT_TRUE(controller.undo());
+    EXPECT_EQ(controller.image(), original);
+    ASSERT_TRUE(controller.redo());
+    EXPECT_EQ(controller.image(), rotated);
+}
+
+TEST(ut_imageeditcontroller, RotateClockwise_NoActiveSession_ReturnsFalse)
+{
+    ImageEditController controller;
+    EXPECT_FALSE(controller.rotateClockwise());
+}
+
 TEST(ut_imageeditcontroller, UndoRedo_PixelHistory_RestoresAndReapplies)
 {
     QTemporaryDir directory;
@@ -321,6 +346,23 @@ TEST(ut_imageeditcontroller, Redo_NoRedoAvailable_ReturnsFalse)
     ImageEditController controller;
     ASSERT_TRUE(controller.beginEdit(QUrl::fromLocalFile(createTestImage(directory))));
     EXPECT_FALSE(controller.redo());
+}
+
+TEST(ut_imageeditcontroller, UndoRedo_IdenticalSnapshotDoesNotReloadImage)
+{
+    QTemporaryDir directory;
+    ASSERT_TRUE(directory.isValid());
+    ImageEditController controller;
+    ASSERT_TRUE(controller.beginEdit(QUrl::fromLocalFile(createTestImage(directory))));
+    QSignalSpy revisionSpy(&controller, &ImageEditController::revisionChanged);
+
+    controller.commitHistory();
+    const int revision = controller.revision();
+    ASSERT_TRUE(controller.undo());
+    ASSERT_TRUE(controller.redo());
+
+    EXPECT_EQ(controller.revision(), revision);
+    EXPECT_EQ(revisionSpy.count(), 0);
 }
 
 TEST(ut_imageeditcontroller, History_KeepsAtMost50Steps)


### PR DESCRIPTION
Log: 修复编辑画布状态及图片切换问题
PMS: TASK-393981
Influence: 修复特效、旋转、撤销重做、窗口缩放及切图时的状态异常。

## Summary by Sourcery

Preserve editing state and safely coordinate image operations with unsaved-edit navigation.

New Features:
- Add clockwise image rotation with synchronized annotation transformation and history support.

Bug Fixes:
- Preserve canvas annotations across resizing, rotation, undo/redo, and image switching, including zero-sized canvas transitions.
- Prevent unnecessary image reloads and revision changes when restoring identical history snapshots.
- Handle pending image changes safely when edits are saved, discarded, cancelled, or saving fails.

Tests:
- Add controller coverage for rotation dimensions and history behavior, inactive-session handling, and redundant undo/redo snapshots.