### PR TITLE
chore: update version to 6.0.49

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-image-viewer (6.0.49) unstable; urgency=medium
+
+  * feat(editor): add image editing support
+
+ -- Tian Shilin <tianshilin@uniontech.com>  Wed, 26 Aug 2026 17:07:43 +0800
+
 deepin-image-viewer (6.0.48) unstable; urgency=medium
 
   * fix: eliminate position jitter at end of rotation animation

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.image.viewer
   name: deepin-image-viewer
-  version: 6.0.48.1
+  version: 6.0.49.1
   kind: app
   description: |
     view images for deepin os.


### PR DESCRIPTION
Log: 更新版本至 6.0.49
Influence: 更新 Debian 变更记录和玲珑包版本。

## Summary by Sourcery

Bump the project packaging metadata to the 6.0.49 release.

Build:
- Update the Linglong package version to 6.0.49.1.

Chores:
- Update the Debian changelog for the 6.0.49 release.