### PR TITLE
fix(editor): correct toolbar background and annotation defaults

### DIFF
--- a/src/qml/EditCanvas.qml
+++ b/src/qml/EditCanvas.qml
@@ -29,6 +29,7 @@ Item {
     property var vectorHistory: []
     property int vectorHistoryIndex: -1
     readonly property real numberTextContrastThreshold: 170
+    readonly property real numberTextHorizontalOffsetRatio: -0.025
     readonly property string numberFontFamily: Qt.fontFamilies().indexOf("Source Han Sans SC") >= 0
                                                ? "Source Han Sans SC" : textEditor.font.family
 
@@ -378,7 +379,10 @@ Item {
     }
 
     function resetCrop() {
-        cropRect = Qt.rect(0, 0, width, height);
+        var marginX = width * 0.1;
+        var marginY = height * 0.1;
+        cropRect = Qt.rect(marginX, marginY, Math.max(2, width - marginX * 2),
+                          Math.max(2, height - marginY * 2));
         drawingCanvas.requestPaint();
     }
 
@@ -589,7 +593,8 @@ Item {
                         context.fill();
                         context.fillStyle = editCanvas.numberTextColor(stroke.color);
                         context.font = "500 12px \"" + fontFamily.replace(/"/g, "\\\"") + "\"";
-                        context.fillText(stroke.number.toString(), stroke.baseWidth / 2,
+                        context.fillText(stroke.number.toString(),
+                                         stroke.baseWidth * (0.5 + numberTextHorizontalOffsetRatio),
                                          stroke.baseHeight / 2);
                     } else {
                         context.fillStyle = stroke.color;

--- a/src/qml/EditPropertyPanel.qml
+++ b/src/qml/EditPropertyPanel.qml
@@ -41,8 +41,33 @@ DTK.Control {
     implicitWidth: isEffectTool ? 381 : isTextTool ? 255 : 339
     padding: 0
 
-    background: DTK.FloatingPanel {
-        radius: 18
+    // uos-design: allow-manual-blur-overlay See EditToolbar.qml. Keep both edit
+    // surfaces on the same live, theme-aware translucent treatment.
+    background: Item {
+        DTK.BoxShadow {
+            anchors.fill: panelBackground
+            cornerRadius: panelBackground.radius
+            hollow: true
+            shadowBlur: 20
+            shadowColor: Qt.rgba(propertyPanel.palette.shadow.r,
+                                 propertyPanel.palette.shadow.g,
+                                 propertyPanel.palette.shadow.b, 0.24)
+            shadowOffsetY: 6
+        }
+
+        Rectangle {
+            id: panelBackground
+
+            anchors.fill: parent
+            border.color: Qt.rgba(propertyPanel.themeTextColor.r,
+                                  propertyPanel.themeTextColor.g,
+                                  propertyPanel.themeTextColor.b, 0.12)
+            border.width: 1
+            color: Qt.rgba(propertyPanel.palette.window.r,
+                           propertyPanel.palette.window.g,
+                           propertyPanel.palette.window.b, 0.72)
+            radius: 18
+        }
     }
 
     component ModeButton: DTK.ToolButton {

--- a/src/qml/EditToolbar.qml
+++ b/src/qml/EditToolbar.qml
@@ -35,8 +35,34 @@ DTK.Control {
     implicitWidth: 514
     padding: 0
 
-    background: DTK.FloatingPanel {
-        radius: 18
+    // uos-design: allow-manual-blur-overlay DTK 6.7.44 FloatingPanel retains stale
+    // backdrop textures after the editing canvas is scaled. A themed translucent
+    // surface preserves live image underlay without relying on that cached texture.
+    background: Item {
+        DTK.BoxShadow {
+            anchors.fill: panelBackground
+            cornerRadius: panelBackground.radius
+            hollow: true
+            shadowBlur: 20
+            shadowColor: Qt.rgba(editToolbar.palette.shadow.r,
+                                 editToolbar.palette.shadow.g,
+                                 editToolbar.palette.shadow.b, 0.24)
+            shadowOffsetY: 6
+        }
+
+        Rectangle {
+            id: panelBackground
+
+            anchors.fill: parent
+            border.color: Qt.rgba(editToolbar.themeTextColor.r,
+                                  editToolbar.themeTextColor.g,
+                                  editToolbar.themeTextColor.b, 0.12)
+            border.width: 1
+            color: Qt.rgba(editToolbar.palette.window.r,
+                           editToolbar.palette.window.g,
+                           editToolbar.palette.window.b, 0.72)
+            radius: 18
+        }
     }
 
     component ToolbarButton: DTK.ToolButton {

--- a/src/src/imageeditcontroller.cpp
+++ b/src/src/imageeditcontroller.cpp
@@ -22,6 +22,8 @@
 namespace {
 // Keep synchronized with EditCanvas.numberTextContrastThreshold.
 constexpr qreal kNumberTextContrastThreshold = 170.0;
+// Compensate for the visual right bias of numerals in the annotation font.
+constexpr qreal kNumberTextHorizontalOffsetRatio = -0.025;
 }
 
 ImageEditController::ImageEditController(QObject *parent)
@@ -216,7 +218,9 @@ bool ImageEditController::saveComposite(const QUrl &destination, const QVariantL
                         + color.blue() * 0.114;
                 painter.setPen(luminance > kNumberTextContrastThreshold ? Qt::black : Qt::white);
                 painter.setFont(font);
-                painter.drawText(textBounds, Qt::AlignCenter,
+                painter.drawText(textBounds.translated(textBounds.width()
+                                                       * kNumberTextHorizontalOffsetRatio, 0),
+                                 Qt::AlignCenter,
                                  QString::number(annotation.value(QStringLiteral("number")).toInt()));
             } else {
                 font.setPixelSize(qMax(1, qRound(textBounds.height() * 0.8)));


### PR DESCRIPTION
Log: 修复编辑工具栏背景及标注默认显示
PMS: TASK-393981
Influence: 修复工具栏背景残色、序号偏移及裁剪框默认范围。

## Summary by Sourcery

Correct editor panel rendering and annotation defaults for consistent appearance and positioning.

Bug Fixes:
- Fix stale toolbar and property-panel backgrounds after canvas scaling by using themed translucent surfaces.
- Correct annotation number positioning in the editor and saved composites.
- Set the default crop area to leave a 10% margin around the image.