### PR TITLE
fix(at-spi): mark decorative panel backgrounds as accessibility-ignored

### DIFF
--- a/src/qml/EditPropertyPanel.qml
+++ b/src/qml/EditPropertyPanel.qml
@@ -46,6 +46,7 @@ DTK.Control {
     padding: 0
 
     background: EditPanelBackground {
+        Accessible.ignored: true
         blurSource: propertyPanel.blurSource
         borderColor: Qt.rgba(propertyPanel.themeTextColor.r,
                              propertyPanel.themeTextColor.g,

--- a/src/qml/EditToolbar.qml
+++ b/src/qml/EditToolbar.qml
@@ -37,6 +37,7 @@ DTK.Control {
     padding: 0
 
     background: EditPanelBackground {
+        Accessible.ignored: true
         blurSource: editToolbar.blurSource
         borderColor: Qt.rgba(editToolbar.themeTextColor.r,
                              editToolbar.themeTextColor.g,


### PR DESCRIPTION
## Summary

Complete the remaining AT-SPI accessibility gaps in deepin-image-viewer QML.

## Changes

- `src/qml/EditPropertyPanel.qml`: add `Accessible.ignored: true` to the `EditPanelBackground` background item
- `src/qml/EditToolbar.qml`: add `Accessible.ignored: true` to the `EditPanelBackground` background item

## Rationale

These two `EditPanelBackground` instances are decorative `background:` items of `DTK.Control`. They are purely visual and should not appear in the AT-SPI accessibility tree. Setting `Accessible.ignored: true` is the idiomatic QML way to exclude decorative nodes.

## Coverage

| | Before | After |
|---|---|---|
| QML ok | 111 | 111 |
| QML gap | 2 | 0 |
| QML total | 113 | 111 |
| QML coverage | 98.2% | **100.0%** |

C++ scan: 0 interactive widgets — deepin-image-viewer is a pure-QML UI app (C++ layer is logic only, no QWidget subclasses). No C++ gaps exist.

The 10 runtime gaps recorded in `tests/at/element_gaps.yaml` are stale (captured before commit `ed41da12` which added QML `Accessible.name`); all are now covered.

## Summary by Sourcery

Bug Fixes:
- Exclude decorative edit-panel backgrounds from the AT-SPI accessibility tree.