### PR TITLE
fix(qml): mark decorative EditPanelBackground as Accessible.ignored

### DIFF
--- a/src/qml/EditPropertyPanel.qml
+++ b/src/qml/EditPropertyPanel.qml
@@ -46,6 +46,7 @@ DTK.Control {
     padding: 0
 
     background: EditPanelBackground {
+        Accessible.ignored: true
         blurSource: propertyPanel.blurSource
         borderColor: Qt.rgba(propertyPanel.themeTextColor.r,
                              propertyPanel.themeTextColor.g,

--- a/src/qml/EditToolbar.qml
+++ b/src/qml/EditToolbar.qml
@@ -37,6 +37,7 @@ DTK.Control {
     padding: 0
 
     background: EditPanelBackground {
+        Accessible.ignored: true
         blurSource: editToolbar.blurSource
         borderColor: Qt.rgba(editToolbar.themeTextColor.r,
                              editToolbar.themeTextColor.g,


### PR DESCRIPTION
## AT-SPI 无障碍补全

### 扫描结果
- 工具：at-spi-coverage (scan_qml.py)
- 补全前覆盖率：98.2%（107/109，2 gaps）
- 补全后覆盖率：100.0%（107/107，0 gaps）

### 补全内容
为 `EditPanelBackground` 背景面板添加 `Accessible.ignored: true`：

| 文件 | 行 | 改动 |
|------|-----|------|
| `src/qml/EditPropertyPanel.qml` | 49 | +`Accessible.ignored: true` |
| `src/qml/EditToolbar.qml` | 40 | +`Accessible.ignored: true` |

`EditPanelBackground` 是纯装饰性背景组件（渲染阴影、模糊、边框、着色），
不应暴露给 AT-SPI。父级 `DTK.Control` 已具备完整的无障碍名称和角色。

### 验证
重新扫描确认 QML 覆盖率达到 100%，0 gaps。

## Summary by Sourcery

Mark decorative edit-panel background components as ignored by accessibility tooling.

Bug Fixes:
- Exclude decorative edit-panel backgrounds from the accessibility tree by marking them as ignored.

Tests:
- Verify that QML accessibility coverage reaches 100% with no remaining gaps.