### PR TITLE
fix(editor): reduce edit entry icon size to 16px

### DIFF
--- a/src/qml/ThumbnailListView.qml
+++ b/src/qml/ThumbnailListView.qml
@@ -563,9 +563,9 @@ Control {
             enabled: !imageIsNull && !IV.GStatus.editMode
                      && IV.ImageEditor.canEdit(IV.GControl.currentSource)
             height: 50
-            icon.height: 18
+            icon.height: 16
             icon.name: "edit_entry"
-            icon.width: 18
+            icon.width: 16
             width: 50
 
             onClicked: IV.GStatus.editMode = true


### PR DESCRIPTION
图片编辑入口图标从 18px 调整为 16px。

Log: 调整图片编辑入口图标尺寸
PMS: TASK-393981
Influence: 仅影响编辑入口图标显示尺寸。

## Summary by Sourcery

Enhancements:
- Reduce the image edit entry icon size from 18px to 16px.