### PR TITLE
chore: update version to 6.1.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-image-viewer (6.1.1) unstable; urgency=medium
+
+  * chore: update version to 6.1.1
+
+ -- Tian Shilin <tianshilin@uniontech.com>  Thu, 03 Sep 2026 14:16:28 +0800
+
 deepin-image-viewer (6.0.50) unstable; urgency=medium
 
   * fix(editor): refine crop workflow and toolbar blur

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: '1'
 package:
   id: org.deepin.image.viewer
   name: deepin-image-viewer
-  version: 6.0.50.1
+  version: 6.1.1.1
   kind: app
   description: |
     view images for deepin os.


### PR DESCRIPTION
Log: 更新版本至 6.1.1
Influence: 更新 Debian 变更记录和玲珑包版本。

## Summary by Sourcery

Chores:
- Update the Debian changelog and Linglong package metadata for the 6.1.1 release.