### PR TITLE
fix: resolve 13 scan defects in control and config modules

### DIFF
--- a/src/src/configsetter.cpp
+++ b/src/src/configsetter.cpp
@@ -24,6 +24,10 @@ LibConfigSetter::LibConfigSetter(QObject *parent)
 
 LibConfigSetter::~LibConfigSetter() {
     qCDebug(logImageViewer) << "LibConfigSetter destructor called.";
+    // 仅当销毁的是单例本身时重置静态指针，避免悬垂指针
+    if (m_setter == this) {
+        m_setter = nullptr;
+    }
 }
 
 LibConfigSetter *LibConfigSetter::m_setter = nullptr;

--- a/src/src/filecontrol.cpp
+++ b/src/src/filecontrol.cpp
@@ -139,7 +139,10 @@ QStringList FileControl::getDirImagePath(const QString &path)
     }
 
     QStringList image_list;
-    QString DirPath = QFileInfo(QUrl(path).toLocalFile()).dir().path();
+    const QUrl url(path);
+    const QString localPath = url.isLocalFile() ? url.toLocalFile() : path;
+    QFileInfo pathInfo(localPath);
+    QString DirPath = pathInfo.isDir() ? pathInfo.absoluteFilePath() : pathInfo.dir().path();
     qCDebug(logImageViewer) << "Directory path:" << DirPath;
 
     QDir _dirinit(DirPath);
@@ -194,7 +197,7 @@ QString FileControl::getNamePath(const QString &oldPath, const QString &newName)
     QFileInfo info(old);
     QString path = info.path();
     QString suffix = info.suffix();
-    QString newPath = path + "/" + newName + "." + suffix;
+    QString newPath = path + "/" + now + "." + suffix;
     qCDebug(logImageViewer) << "Constructed new path:" << newPath;
     return QUrl::fromLocalFile(newPath).toString();
 }
@@ -270,7 +273,12 @@ void FileControl::setWallpaper(const QString &imgPath)
                             }
                         } else {
                             qCDebug(logImageViewer) << "Attempting to get primary screen for X11.";
-                            screenname = QGuiApplication::primaryScreen()->name();
+                            QScreen *screen = QGuiApplication::primaryScreen();
+                            if (!screen) {
+                                qCWarning(logImageViewer) << "Primary screen not found, skip setting wallpaper.";
+                                return;
+                            }
+                            screenname = screen->name();
                             qCDebug(logImageViewer) << "Got primary screen from X11:" << screenname;
                         }
 
@@ -408,7 +416,8 @@ bool FileControl::isRotatable(const QString &path)
 {
     qCDebug(logImageViewer) << "Checking if image is rotatable:" << path;
     bool bRet = false;
-    QString localPath = QUrl(path).toLocalFile();
+    const QUrl url(path);
+    const QString localPath = url.isLocalFile() ? url.toLocalFile() : path;
     QFileInfo info(localPath);
     if (!info.isFile() || !info.exists() || !info.isWritable()) {
         qCDebug(logImageViewer) << "Image is not rotatable: Not a file, does not exist, or not writable.";
@@ -423,7 +432,8 @@ bool FileControl::isRotatable(const QString &path)
 bool FileControl::isCanWrite(const QString &path)
 {
     qCDebug(logImageViewer) << "Checking if path is writable:" << path;
-    QString localPath = QUrl(path).toLocalFile();
+    const QUrl url(path);
+    const QString localPath = url.isLocalFile() ? url.toLocalFile() : path;
     QFileInfo info(localPath);
     bool bRet = info.isWritable() && QFileInfo(info.dir(), info.dir().path()).isWritable();   // 是否可写
     qCDebug(logImageViewer) << "Path writable check result: " << bRet;
@@ -434,14 +444,14 @@ bool FileControl::isCanDelete(const QString &path)
 {
     qCDebug(logImageViewer) << "Checking if path is deletable:" << path;
     bool bRet = false;
-    bool isAlbum = false;
-    QString localPath = QUrl(path).toLocalFile();
+    const QUrl url(path);
+    const QString localPath = url.isLocalFile() ? url.toLocalFile() : path;
     QFileInfo info(localPath);
     bool isWritable = info.isWritable() && QFileInfo(info.dir(), info.dir().path()).isWritable();   // 是否可写
     bool isReadable = info.isReadable();   // 是否可读
     imageViewerSpace::PathType pathType = LibUnionImage_NameSpace::getPathType(localPath);
     qCDebug(logImageViewer) << "Path type: " << pathType << ", isWritable: " << isWritable << ", isReadable: " << isReadable;
-    if ((imageViewerSpace::PathTypeAPPLE != pathType && imageViewerSpace::PathTypeSAFEBOX != pathType && imageViewerSpace::PathTypeRECYCLEBIN != pathType && imageViewerSpace::PathTypeMTP != pathType && imageViewerSpace::PathTypePTP != pathType && isWritable && isReadable) || (isAlbum && isWritable)) {
+    if (imageViewerSpace::PathTypeAPPLE != pathType && imageViewerSpace::PathTypeSAFEBOX != pathType && imageViewerSpace::PathTypeRECYCLEBIN != pathType && imageViewerSpace::PathTypeMTP != pathType && imageViewerSpace::PathTypePTP != pathType && isWritable && isReadable) {
         qCDebug(logImageViewer) << "Path is deletable based on conditions.";
         bRet = true;
     } else {
@@ -509,12 +519,8 @@ QString FileControl::parseCommandlineGetPath()
 QString FileControl::slotGetFileName(const QString &path)
 {
     qCDebug(logImageViewer) << "Getting file name for path: " << path;
-    QString tmppath = path;
-
-    if (path.startsWith("file://")) {
-        qCDebug(logImageViewer) << "Path starts with file://, converting to local file.";
-        tmppath = QUrl(tmppath).toLocalFile();
-    }
+    const QUrl url(path);
+    QString tmppath = url.isLocalFile() ? url.toLocalFile() : path;
 
     QFileInfo info(tmppath);
     qCDebug(logImageViewer) << "Returning complete base name: " << info.completeBaseName();
@@ -524,12 +530,8 @@ QString FileControl::slotGetFileName(const QString &path)
 QString FileControl::slotGetFileNameSuffix(const QString &path)
 {
     qCDebug(logImageViewer) << "Getting file name with suffix for path: " << path;
-    QString tmppath = path;
-
-    if (path.startsWith("file://")) {
-        qCDebug(logImageViewer) << "Path starts with file://, converting to local file.";
-        tmppath = QUrl(tmppath).toLocalFile();
-    }
+    const QUrl url(path);
+    QString tmppath = url.isLocalFile() ? url.toLocalFile() : path;
 
     QFileInfo info(tmppath);
     qCDebug(logImageViewer) << "Returning file name with suffix: " << info.fileName();
@@ -829,16 +831,17 @@ bool FileControl::isCheckOnly()
     std::string path = tdir.filePath("single").toStdString();
     qCDebug(logImageViewer) << "Attempting to open lockfile: " << QString::fromStdString(path);
     int fd = open(path.c_str(), O_WRONLY | O_CREAT, 0644);
-    int flock = lockf(fd, F_TLOCK, 0);
-
     if (fd == -1) {
         perror("open lockfile/n");
         qCWarning(logImageViewer) << "Failed to open lockfile.";
         return false;
     }
+
+    int flock = lockf(fd, F_TLOCK, 0);
     if (flock == -1) {
         perror("lock file error/n");
         qCWarning(logImageViewer) << "Failed to lock file.";
+        close(fd);
         return false;
     }
     qCDebug(logImageViewer) << "Lock file opened and locked successfully.";
@@ -848,7 +851,8 @@ bool FileControl::isCheckOnly()
 bool FileControl::isCanSupportOcr(const QString &path)
 {
     qCDebug(logImageViewer) << "FileControl::isCanSupportOcr() called for path: " << path;
-    QString localPath = QUrl(path).toLocalFile();
+    const QUrl url(path);
+    const QString localPath = url.isLocalFile() ? url.toLocalFile() : path;
     QFileInfo info(localPath);
     imageViewerSpace::ImageType type = LibUnionImage_NameSpace::getImageType(localPath);
     qCDebug(logImageViewer) << "Image type: " << type << ", isReadable: " << info.isReadable();
@@ -866,7 +870,8 @@ bool FileControl::isCanRename(const QString &path)
 {
     qCDebug(logImageViewer) << "FileControl::isCanRename() called for path: " << path;
     bool bRet = false;
-    QString localPath = QUrl(path).toLocalFile();
+    const QUrl url(path);
+    const QString localPath = url.isLocalFile() ? url.toLocalFile() : path;
     imageViewerSpace::PathType pathType = LibUnionImage_NameSpace::getPathType(localPath);   // 路径类型
     QFileInfo info(localPath);
     bool isWritable = info.isWritable() && QFileInfo(info.dir(), info.dir().path()).isWritable();   // 是否可写
@@ -883,7 +888,8 @@ bool FileControl::isCanReadable(const QString &path)
 {
     qCDebug(logImageViewer) << "FileControl::isCanReadable() called for path: " << path;
     bool bRet = false;
-    QString localPath = QUrl(path).toLocalFile();
+    const QUrl url(path);
+    const QString localPath = url.isLocalFile() ? url.toLocalFile() : path;
     QFileInfo info(localPath);
     if (info.isReadable()) {
         qCDebug(logImageViewer) << "Path is readable. Returning true.";

--- a/src/src/globalcontrol.cpp
+++ b/src/src/globalcontrol.cpp
@@ -357,6 +357,7 @@ bool GlobalControl::setImageFiles(const QStringList &filePaths, const QString &o
 
     Q_ASSERT(sourceModel);
     // 优先更新数据源
+    const int countBeforeSet = sourceModel->rowCount();
     sourceModel->setImageFiles(QUrl::fromStringList(filePaths));
     qCDebug(logImageViewer) << "Source model image files set.";
 
@@ -367,13 +368,16 @@ bool GlobalControl::setImageFiles(const QStringList &filePaths, const QString &o
     if (currentImage.source() != currentSource) {
         qCDebug(logImageViewer) << "Updating current image source to:" << currentSource;
         currentImage.setSource(currentSource);
+        Q_EMIT currentSourceChanged();
+        qCDebug(logImageViewer) << "Emitted currentSourceChanged signal.";
     }
-    Q_EMIT currentSourceChanged();
-    qCDebug(logImageViewer) << "Emitted currentSourceChanged signal.";
 
     checkSwitchEnable();
-    Q_EMIT imageCountChanged();
-    qCDebug(logImageViewer) << "Emitted imageCountChanged signal.";
+    // 仅当图片数量实际变化时才提示
+    if (sourceModel->rowCount() != countBeforeSet) {
+        Q_EMIT imageCountChanged();
+        qCDebug(logImageViewer) << "Emitted imageCountChanged signal.";
+    }
 
     // 更新视图展示模型
     viewSourceModel->resetModel(index, 0);
@@ -434,12 +438,15 @@ void GlobalControl::removeImage(const QUrl &removeImage)
     }
 
     // 移除当前图片，默认将后续图片前移，currentIndex将不会变更，手动提示更新
-    bool atEnd = (curIndex >= sourceModel->rowCount() - 1);
+    const int countBeforeRemove = sourceModel->rowCount();
+    bool atEnd = (curIndex >= countBeforeRemove - 1);
     qCDebug(logImageViewer) << "Image is at end of list:" << atEnd;
 
     // 模型更新后将自动触发QML切换当前显示图片
     sourceModel->removeImage(removeImage);
     qCDebug(logImageViewer) << "Image removed from source model.";
+    // 仅当图片实际从模型删除时才提示数量变更
+    const bool imageRemoved = (sourceModel->rowCount() != countBeforeRemove);
 
     // NOTE：viewModel依赖源数据模型更新
     if (removeImage == currentImage.source()) {
@@ -471,10 +478,19 @@ void GlobalControl::removeImage(const QUrl &removeImage)
         qCDebug(logImageViewer) << "Emitted currentSourceChanged and currentIndexChanged signals.";
     } else {
         qCDebug(logImageViewer) << "No images left in the model after removal.";
+        // 模型已清空，同步清空当前图片信息，避免 currentSource() 返回已删除路径
+        currentImage.setSource(QUrl(""));
+        curIndex = 0;
+        Q_EMIT currentSourceChanged();
+        Q_EMIT currentIndexChanged();
+        qCDebug(logImageViewer) << "Cleared current image and reset current index.";
     }
 
     checkSwitchEnable();
-    Q_EMIT imageCountChanged();
+    if (imageRemoved) {
+        Q_EMIT imageCountChanged();
+        qCDebug(logImageViewer) << "Emitted imageCountChanged signal.";
+    }
     qCDebug(logImageViewer) << "Image removal complete";
 }
 
@@ -617,7 +633,7 @@ void GlobalControl::setIndexAndFrameIndex(int index, int frameIndex)
         Q_EMIT currentSourceChanged();
         qCDebug(logImageViewer) << "Emitted currentSourceChanged signal.";
 
-        this->curIndex = index;
+        this->curIndex = validIndex;
         Q_EMIT currentIndexChanged();
         qCDebug(logImageViewer) << "Emitted currentIndexChanged signal.";
     }

--- a/src/src/utils/eventlogutils.cpp
+++ b/src/src/utils/eventlogutils.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/src/utils/eventlogutils.cpp
+++ b/src/src/utils/eventlogutils.cpp
@@ -39,17 +39,22 @@ Eventlogutils::Eventlogutils()
     qCDebug(logImageViewer) << "Initializing Eventlogutils.";
     QLibrary library("libdeepin-event-log.so");
     initFunc = reinterpret_cast<bool (*)(const std::string &, bool)>(library.resolve("Initialize"));
-    writeEventLogFunc = reinterpret_cast<void (*)(const std::string &)>(library.resolve("WriteEventLog"));
-
     if (!initFunc) {
         qCWarning(logImageViewer) << "Failed to resolve Initialize function from libdeepin-event-log.so.";
         return;
     }
+
+    // Initialize 解析成功后再解析写入函数，保证 writeEventLogFunc 就绪时事件库必然可用
+    writeEventLogFunc = reinterpret_cast<void (*)(const std::string &)>(library.resolve("WriteEventLog"));
     if (!writeEventLogFunc) {
         qCWarning(logImageViewer) << "Failed to resolve WriteEventLog function from libdeepin-event-log.so.";
         return;
     }
 
-    initFunc("deepin-image-viewer", true);
+    if (!initFunc("deepin-image-viewer", true)) {
+        qCWarning(logImageViewer) << "Failed to initialize libdeepin-event-log.so, event logging disabled.";
+        writeEventLogFunc = nullptr;
+        return;
+    }
     qCDebug(logImageViewer) << "Event logging initialized for deepin-image-viewer.";
 }

--- a/tests/src/test_configsetter.cpp
+++ b/tests/src/test_configsetter.cpp
@@ -5,7 +5,7 @@
 // | method | level | factors | min | actual |
 // |--------|-------|---------|-----|--------|
 // | LibConfigSetter(QObject *) ctor | low | - | 1 | 1 |
-// | ~LibConfigSetter | low | - | 1 | 1 |
+// | ~LibConfigSetter | low | - | 1 | 2 |
 // | instance | mid | - | 2 | 2 |
 // | setValue | low | - | 1 | 7 |
 // | value | mid | - | 2 | 6 |
@@ -38,11 +38,13 @@
 // LibConfigSetter(QObject*)（17-23）→ LibConfigSetter_Constructor_WithParent_CreatesOwnedSettingsObject
 // setValue(group,key,value)（41-53）→ SetValue_NewGroupKey / SetValue_OverwriteExistingKey / Value_AfterSetValue(TEST_P)
 // value(group,key,default)（55-71）→ Value_MissingKey / Value_AfterSetValue(TEST_P)
-// ~LibConfigSetter()（25-27）→ LibConfigSetter_Destructor_DirectDelete_DestroysChildSettingsAndKeepsSingleton
 //
-// 疑似缺陷（只标红不修）：
-// D1: ~LibConfigSetter 不重置静态指针 m_setter（configsetter.cpp:25-27）——若单例被外部
-//     delete，后续 instance() 将返回悬垂指针。
+// 分支清单（来源：LibConfigSetter::~LibConfigSetter，修复后含 2 分支）
+// B1: m_setter == this（销毁的是单例本身）→ m_setter = nullptr（原 D1 缺陷已修复：
+//     析构不重置静态指针，外部 delete 单例后 instance() 将返回悬垂指针）
+// B2: m_setter != this（直接构造的普通对象）→ 静态指针保持不变
+// 映射：LibConfigSetter_Destructor_SingletonDeleted_ResetsStaticPointerForRecreation → B1
+//       LibConfigSetter_Destructor_DirectDelete_DestroysChildSettingsAndKeepsSingleton → B2
 
 #include <gtest/gtest.h>
 
@@ -146,7 +148,27 @@ TEST_F(LibConfigSetterTest, LibConfigSetter_Destructor_DirectDelete_DestroysChil
 
     // Assert
     EXPECT_EQ(settingsDestroyedSpy.count(), 1);          // 子 QSettings 随父析构（QObject 父子机制）
-    EXPECT_EQ(LibConfigSetter::m_setter, savedSetter);   // 析构未重置单例指针（缺陷 D1 行为记录）
+    EXPECT_EQ(LibConfigSetter::m_setter, savedSetter);   // B2: 非单例对象析构不影响静态指针
+}
+
+TEST_F(LibConfigSetterTest, LibConfigSetter_Destructor_SingletonDeleted_ResetsStaticPointerForRecreation)
+{
+    // Arrange：独立构造对象并让其充当单例（m_setter 指向它），QSettings 隔离到临时文件
+    LibConfigSetter *cs = new LibConfigSetter();
+    delete cs->m_settings;
+    cs->m_settings = new QSettings(tmpDir.filePath(QStringLiteral("ut_cs_singleton.ini")),
+                                   QSettings::IniFormat, cs);
+    LibConfigSetter::m_setter = cs;
+
+    // Act：以单例身份销毁
+    delete cs;
+
+    // Assert（原 D1 修复语义）：析构重置静态指针，无悬垂；instance() 可安全重建
+    EXPECT_EQ(LibConfigSetter::m_setter, nullptr);
+    LibConfigSetter *fresh = LibConfigSetter::instance();
+    EXPECT_NE(fresh, nullptr);
+    EXPECT_EQ(LibConfigSetter::m_setter, fresh);
+    // 新建单例由 TearDown 统一识别（m_setter != savedSetter）销毁并恢复
 }
 
 TEST_F(LibConfigSetterTest, Instance_FirstCallWhenNull_CreatesNewSingleton)

--- a/tests/src/test_eventlogutils.cpp
+++ b/tests/src/test_eventlogutils.cpp
@@ -4,18 +4,19 @@
 // 用例计数声明（self-check-structural 验证此块）：
 // | method | level | factors | min | actual |
 // |--------|-------|---------|-----|--------|
-// | Eventlogutils() ctor | low | - | 1 | 3 |
+// | Eventlogutils() ctor | low | - | 1 | 4 |
 // | GetInstance | low | - | 1 | 2 |
 // | writeLogs | mid | - | 2 | 4 |
 // ─── actual 均不低于 min ───
 //
 // 最小清单完成情况（test-code-gen §最小清单）：
 // 1. 每个公开方法 ≥ 1 用例: [x]（inventory 3 个方法全覆盖；私有构造经 -fno-access-control 直接构造）
-// 2. 每个输入维度按等价类划分 ≥ 1 用例/类: [x]（resolve：成功/Initialize 缺失/WriteEventLog 缺失/全缺失；payload：空/单键/嵌套）
+// 2. 每个输入维度按等价类划分 ≥ 1 用例/类: [x]（resolve：成功/Initialize 缺失/WriteEventLog 缺失/全缺失/
+//    Initialize 调用返回失败；payload：空/单键/嵌套）
 // 3. 每个等价类的边界值显式覆盖: [x]（空 QJsonObject payload、单键对象、含嵌套子对象）
 // 4. 同质 ≥ 3 组用 TEST_P: [x]（WriteLogs_FuncResolved 3 组 payload）
 // 5. 分支清单 → 用例映射已列出: [x]（见下方分支清单块）
-// 6. 每条 if/switch/throw/early-return 有触发用例: [x]（ctor B1/B2/B3、GetInstance B1/B2、writeLogs B1/B2 全覆盖）
+// 6. 每条 if/switch/throw/early-return 有触发用例: [x]（ctor B1/B2/B3/B4、GetInstance B1/B2、writeLogs B1/B2 全覆盖）
 // 7. 异常路径 EXPECT_THROW 精确匹配: [x]（本类无显式 throw；符号缺失路径以提前 return + 桩计数/指针断言覆盖）
 // 8. 负面场景有专门用例: [x]（InitializeUnresolved / WriteEventLogUnresolved / WriteFuncNull）
 // 9. 负面用例验证强异常安全: [x]（WriteFuncNull 提前返回后入参 QJsonObject 未被改动断言）
@@ -26,13 +27,16 @@
 // 分支清单 → 用例映射（来源：get_code_snippet 真实源码）
 // ─────────────────────────────────────────────────────────────
 
-// 分支清单（来源：Eventlogutils::Eventlogutils 构造函数 eventlogutils.cpp:37-55）
-// B1: !initFunc → qCWarning + return（不调用 Initialize）
-// B2: !writeEventLogFunc → qCWarning + return（不调用 Initialize）
-// B3: 两个函数指针就绪 → initFunc("deepin-image-viewer", true)
-// 映射：Eventlogutils_Constructor_InitializeUnresolved_SkipsInitButKeepsWriteFunc → B1
+// 分支清单（来源：Eventlogutils::Eventlogutils 构造函数，修复后 eventlogutils.cpp:37-61）
+// B1: !initFunc → qCWarning + return（writeEventLogFunc 不被赋值，保持 nullptr；
+//     原 D1 缺陷已修复：Initialize 解析失败时 writeEventLogFunc 不再残留非空）
+// B2: !writeEventLogFunc（Initialize 解析成功后才解析 WriteEventLog）→ qCWarning + return
+// B3: initFunc("deepin-image-viewer", true) 返回 false → 清空 writeEventLogFunc 并 return
+// B4: Initialize 调用成功 → 事件库初始化完成
+// 映射：Eventlogutils_Constructor_InitializeUnresolved_SkipsInitAndWriteFuncStaysNull → B1
 //       Eventlogutils_Constructor_WriteEventLogUnresolved_SkipsInit → B2
-//       Eventlogutils_Constructor_LibraryResolved_InitializesWithAppNameAndEnableSig → B3
+//       Eventlogutils_Constructor_InitializeFails_ClearsWriteFuncAndDropsLogs → B3
+//       Eventlogutils_Constructor_LibraryResolved_InitializesWithAppNameAndEnableSig → B4
 
 // 分支清单（来源：Eventlogutils::GetInstance eventlogutils.cpp:15-23）
 // B1: m_pInstance == nullptr → new Eventlogutils()
@@ -45,11 +49,6 @@
 // B2: 就绪 → writeEventLogFunc(QJsonDocument(data).toJson(Compact).toStdString())
 // 映射：WriteLogs_WriteFuncNull_DropsLogsWithoutCrash → B1
 //       WriteLogs_FuncResolved_WritesCompactJsonPayload（TEST_P）→ B2
-//
-// 疑似缺陷（只标红不修）：
-// D1: 构造函数中 writeEventLogFunc 在 initFunc 判空之前已被赋值（eventlogutils.cpp:42-45）——
-//     当 Initialize 解析失败走 B1 提前 return 时，writeEventLogFunc 仍为非空，后续 writeLogs
-//     会在事件库未初始化的状态下调用 WriteEventLog，存在未定义行为风险。
 
 #include <gtest/gtest.h>
 
@@ -76,13 +75,15 @@ std::string lastPayload;
 
 // resolve 桩模式：0=全部解析成功 1=Initialize 缺失 2=WriteEventLog 缺失 3=全部缺失
 int resolveMode = 0;
+// fakeInitialize 的返回值：true=初始化成功 false=初始化失败（覆盖 B3 分支）
+bool initReturn = true;
 
 bool fakeInitialize(const std::string &packagename, bool enable_sig)
 {
     ++initCalls;
     lastAppName = packagename;
     lastEnableSig = enable_sig;
-    return true;
+    return initReturn;
 }
 
 void fakeWriteEventLog(const std::string &eventdata)
@@ -109,6 +110,7 @@ void resetEventlogCounters()
     lastAppName.clear();
     lastEnableSig = false;
     lastPayload.clear();
+    initReturn = true;
 }
 
 QJsonObject makeFlatObject()
@@ -182,7 +184,7 @@ TEST_F(EventlogutilsTest, Eventlogutils_Constructor_LibraryResolved_InitializesW
     EXPECT_NE(utils.writeEventLogFunc, nullptr);
 }
 
-TEST_F(EventlogutilsTest, Eventlogutils_Constructor_InitializeUnresolved_SkipsInitButKeepsWriteFunc)
+TEST_F(EventlogutilsTest, Eventlogutils_Constructor_InitializeUnresolved_SkipsInitAndWriteFuncStaysNull)
 {
     // Arrange
     resolveMode = 1;  // Initialize 解析失败
@@ -190,10 +192,11 @@ TEST_F(EventlogutilsTest, Eventlogutils_Constructor_InitializeUnresolved_SkipsIn
     // Act
     Eventlogutils utils;
 
-    // Assert
-    EXPECT_EQ(initCalls, 0);                     // B1: 提前 return，Initialize 未被调用
-    EXPECT_EQ(utils.initFunc, nullptr);          // initFunc 保持为空
-    EXPECT_NE(utils.writeEventLogFunc, nullptr); // 缺陷 D1：WriteEventLog 指针仍被赋值
+    // Assert（原 D1 修复语义）：提前 return 时 writeEventLogFunc 未被赋值，
+    // 保持 nullptr，writeLogs 不会在未初始化的事件库上调用 WriteEventLog
+    EXPECT_EQ(initCalls, 0);                      // B1: 提前 return，Initialize 未被调用
+    EXPECT_EQ(utils.initFunc, nullptr);           // initFunc 保持为空
+    EXPECT_EQ(utils.writeEventLogFunc, nullptr);  // writeEventLogFunc 不再残留非空
 }
 
 TEST_F(EventlogutilsTest, Eventlogutils_Constructor_WriteEventLogUnresolved_SkipsInit)
@@ -208,6 +211,26 @@ TEST_F(EventlogutilsTest, Eventlogutils_Constructor_WriteEventLogUnresolved_Skip
     EXPECT_EQ(initCalls, 0);                      // B2: 提前 return，Initialize 未被调用
     EXPECT_EQ(utils.writeEventLogFunc, nullptr);  // writeEventLogFunc 保持为空
     EXPECT_NE(utils.initFunc, nullptr);           // Initialize 已解析但因 B2 未被调用
+}
+
+TEST_F(EventlogutilsTest, Eventlogutils_Constructor_InitializeFails_ClearsWriteFuncAndDropsLogs)
+{
+    // Arrange：两个符号均解析成功，但 Initialize 调用返回失败
+    initReturn = false;
+    Eventlogutils utils;
+    QJsonObject data;
+    data.insert(QStringLiteral("tid"), QJsonValue(1000000003));
+
+    // Act
+    utils.writeLogs(data);
+
+    // Assert（原 D1 修复语义）：初始化失败清空 writeEventLogFunc，
+    // writeLogs 直接丢弃日志，不在未初始化的库上调用 WriteEventLog
+    EXPECT_EQ(initCalls, 1);                      // Initialize 恰被调用一次
+    EXPECT_EQ(utils.writeEventLogFunc, nullptr);  // B3: 失败后清空
+    EXPECT_EQ(writeCalls, 0);                     // 日志被安全丢弃
+    EXPECT_EQ(data.value(QStringLiteral("tid")).toInt(),
+              1000000003);  // 入参未被改动（强异常安全）
 }
 
 TEST_F(EventlogutilsTest, GetInstance_FirstCall_CreatesInitializedSingleton)

--- a/tests/src/test_filecontrol.cpp
+++ b/tests/src/test_filecontrol.cpp
@@ -153,8 +153,8 @@
 //
 // QString FileControl::getNamePath(oldPath,newName)
 // B1: old.startsWith("file://") → 转 localFile
-// B2: now(newName) startsWith("file://") → 转 localFile（结果被丢弃，
-//     newPath 仍拼 newName 原串——疑似缺陷 D2，按现状断言并标红）
+// B2: now(newName) startsWith("file://") → 转 localFile（转换结果参与拼接，
+//     newPath 拼 now——D2 已修复，file:// 新名按转换后的本地名拼接）
 // 映射： GetNamePath_ParamSet（TEST_P）→B1/B2 组合 3 组
 //
 // int FileControl::getPrimaryScreenCenterX(windowWidth)
@@ -187,7 +187,7 @@
 // bool FileControl::isCanDelete(path)
 // B1: 非特殊 PathType && isWritable && isReadable → true
 // B2: 特殊 PathType（MTP 等）→ false
-// B3: 不可写 → false（isAlbum 恒 false，第二短路分支永不生效——疑似缺陷 D4）
+// B3: 不可写 → false（isAlbum 恒 false 死分支已删除——D4 已修复）
 // 映射： IsCanDelete_LocalWritableFile_ReturnsTrue→B1
 //        IsCanDelete_MtpPathType_ReturnsFalse→B2
 //        IsCanDelete_ReadOnlyFile_ReturnsFalse→B3
@@ -223,9 +223,9 @@
 // 分支清单（来源：FileControl::isCheckOnly）
 // B1: 锁目录不存在 → mkpath
 // B2: open 锁文件 → 返回 fd（fd==-1 见 B5）
-// B3: lockf 失败(flock==-1) → return false（同进程二次加锁触发）
-// B4: 成功 → return true（fd 未 close、锁未释放——疑似缺陷 D3，行为按现状断言）
-// B5: open 失败(fd==-1) → return false（环境异常分支，无法稳定注入，note）
+// B3: lockf 失败(flock==-1) → close(fd) 后 return false（跨进程持锁时触发）
+// B4: 成功 → return true（持有 fd 与锁至进程退出——单实例检测设计意图，D3 失败路径已修复）
+// B5: open 失败(fd==-1) → return false（fd 检查已前移至 lockf 之前；环境异常分支，无法稳定注入，note）
 // 映射： IsCheckOnly_RepeatedLockAttempts_BothSucceed→B4（B3 仅跨进程触发，单进程内不可达）
 //
 // bool FileControl::isCurrentWatcherDir(path)
@@ -313,7 +313,7 @@
 // B3: interfaceV23/V20 均 !isValid() → 仅告警不调用
 // B4: 会话判定（XDG_SESSION_TYPE/WAYLAND_DISPLAY 是否含 wayland）
 // B5: isWayland=true → Wayland Display 接口取主屏名（V23 valid 走 property / else V20）
-// B6: isWayland=false（X11）→ primaryScreen()->name()（未判空——疑似缺陷 D1）
+// B6: isWayland=false（X11）→ primaryScreen() 判空后取 name()（D1 已修复，空屏安全返回）
 // B7: 三元日志描述（isWayland ? "Wayland" : "X11"）
 // B8: interfaceV23.isValid() → SetMonitorBackground
 // B9: V23 应答 error → settingSucc=false
@@ -350,7 +350,7 @@
 // 映射： SlotFileSuffix_ParamSet→B1+B2+B3（TEST_P 4 组）
 //
 // QString FileControl::slotGetFileName(path)
-// B1: startsWith("file://") → toLocalFile
+// B1: QUrl::isLocalFile() → toLocalFile（否则回退原串——D5 已修复）
 // B2: completeBaseName
 // 映射： SlotGetFileName_PlainPath_ReturnsBaseName→B2
 //        SlotGetFileName_FileUrl_ReturnsBaseName→B1+B2
@@ -1048,8 +1048,8 @@ TEST_F(FileControlTest, GetDirImagePath_EmptyPath_ReturnsEmptyList)
 
 TEST_F(FileControlTest, GetDirImagePath_NoImageFiles_ReturnsEmptyList)
 {
-    // Arrange：目录内只有文本文件；入参传目录内文件 URL（源码按"文件所在目录"解析，
-    // 直接传目录 URL 会取到父目录——疑似缺陷 D6，见文末）
+    // Arrange：目录内只有文本文件；入参传目录内文件 URL（按"文件所在目录"解析；
+    // 目录入参已改为扫描目录自身——D6 已修复）
     const QString txt = makeTextFile(tmpDir.path(), "note.txt");
     makeTextFile(tmpDir.path(), "readme.md");
 
@@ -1099,7 +1099,7 @@ namespace {
 struct GetNamePathCase {
     bool oldAsUrl;
     QString newNameInput;  // 传给方法的原始参数
-    QString expectedNewName;  // 拼入新路径的名字（按当前实现：原样 newName）
+    QString expectedNewName;  // 拼入新路径的名字（file:// 输入时为转换后的本地名）
 };
 }  // namespace
 
@@ -1114,7 +1114,7 @@ TEST_P(GetNamePathParamTest, GetNamePath_ParamSet_BuildsNewPathInSameDir)
     const QString oldFile = makePngFile(tmpDir.path(), "origin.png");
     const QString oldInput = c.oldAsUrl ? localUrl(oldFile) : oldFile;
     const QString expectUrl = QUrl::fromLocalFile(
-            QDir(tmpDir.path()).filePath(c.expectedNewName + QStringLiteral(".png")))
+            tmpDir.path() + QLatin1Char('/') + c.expectedNewName + QStringLiteral(".png"))
                                       .toString();
 
     // Act
@@ -1132,11 +1132,9 @@ INSTANTIATE_TEST_SUITE_P(
                 GetNamePathCase{false, QStringLiteral("renamed"), QStringLiteral("renamed")},
                 // file:// 旧路径 + 普通名
                 GetNamePathCase{true, QStringLiteral("b"), QStringLiteral("b")},
-                // file:// 旧路径 + file:// 新名：入参与期望均用字面量构造。
-                // 注意不可用 localUrl("c") 生成——QUrl::fromLocalFile 对相对路径返回
-                // "file:c"（无 authority），与实现的拼接产物不一致；当前实现拼接的是
-                // newName 原串（now 转换结果被丢弃，疑似缺陷 D2），期望按现状锁定
-                GetNamePathCase{true, QStringLiteral("file:///c"), QStringLiteral("file:///c")}));
+                // file:// 旧路径 + file:// 新名：修复后拼接的是转换后的 now
+                // （"file:///c" → "/c"），期望路径为 "<tmp>//c.png"（与实现拼接方式一致）
+                GetNamePathCase{true, QStringLiteral("file:///c"), QStringLiteral("/c")}));
 
 // ═════════════════ getPrimaryScreenCenterX / Y ═════════════════
 
@@ -1320,10 +1318,9 @@ TEST_F(FileControlTest, IsCanDelete_LocalWritableFile_ReturnsTrue)
     // Act
     const bool can = obj->isCanDelete(localUrl(png));
 
-    // Assert（B1：URL 输入判 true；裸路径无 scheme → toLocalFile 为空 → false，输入约定为
-    // file:// URL 形式（与 isImage 的 fallback 不一致——疑似缺陷 D7，按真实行为锁定）
+    // Assert（B1：URL 输入判 true；裸路径经 isLocalFile 回退后同样判 true（D7 已修复）
     EXPECT_EQ(can, true);
-    EXPECT_EQ(obj->isCanDelete(png), false);
+    EXPECT_EQ(obj->isCanDelete(png), true);
 }
 
 TEST_F(FileControlTest, IsCanDelete_MtpPathType_ReturnsFalse)
@@ -1370,9 +1367,9 @@ TEST_F(FileControlTest, IsCanReadable_ExistingFile_ReturnsTrue)
     // Act
     const bool can = obj->isCanReadable(localUrl(png));
 
-    // Assert（B1：URL 输入判 true；裸路径无 scheme → toLocalFile 为空 → false（D7）
+    // Assert（B1：URL 输入判 true；裸路径经回退后同样判 true（D7 已修复）
     EXPECT_EQ(can, true);
-    EXPECT_EQ(obj->isCanReadable(png), false);
+    EXPECT_EQ(obj->isCanReadable(png), true);
 }
 
 TEST_F(FileControlTest, IsCanReadable_MissingFile_ReturnsFalse)
@@ -1399,9 +1396,9 @@ TEST_F(FileControlTest, IsCanRename_LocalWritableFile_ReturnsTrue)
     // Act
     const bool can = obj->isCanRename(localUrl(png));
 
-    // Assert（B1：URL 输入判 true；裸路径无 scheme → false（D7）
+    // Assert（B1：URL 输入判 true；裸路径经回退后同样判 true（D7 已修复）
     EXPECT_EQ(can, true);
-    EXPECT_EQ(obj->isCanRename(png), false);
+    EXPECT_EQ(obj->isCanRename(png), true);
 }
 
 TEST_F(FileControlTest, IsCanRename_MtpPathType_ReturnsFalse)
@@ -1447,9 +1444,9 @@ TEST_F(FileControlTest, IsCanSupportOcr_StaticImageReadable_ReturnsTrue)
     // Act
     const bool can = obj->isCanSupportOcr(localUrl(png));
 
-    // Assert（B1：URL 输入判 true；裸路径无 scheme → false（D7）
+    // Assert（B1：URL 输入判 true；裸路径经回退后同样判 true（D7 已修复）
     EXPECT_EQ(can, true);
-    EXPECT_EQ(obj->isCanSupportOcr(png), false);
+    EXPECT_EQ(obj->isCanSupportOcr(png), true);
 }
 
 TEST_F(FileControlTest, IsCanSupportOcr_DynamicImageType_ReturnsFalse)
@@ -1495,9 +1492,9 @@ TEST_F(FileControlTest, IsCanWrite_WritableFileAndDir_ReturnsTrue)
     // Act
     const bool can = obj->isCanWrite(localUrl(png));
 
-    // Assert（B1：URL 输入判 true；裸路径无 scheme → false（D7）
+    // Assert（B1：URL 输入判 true；裸路径经回退后同样判 true（D7 已修复）
     EXPECT_EQ(can, true);
-    EXPECT_EQ(obj->isCanWrite(png), false);
+    EXPECT_EQ(obj->isCanWrite(png), true);
 }
 
 TEST_F(FileControlTest, IsCanWrite_ReadOnlyFile_ReturnsFalse)
@@ -1518,7 +1515,8 @@ TEST_F(FileControlTest, IsCanWrite_ReadOnlyFile_ReturnsFalse)
 
 TEST_F(FileControlTest, IsCheckOnly_RepeatedLockAttempts_BothSucceed)
 {
-    // Arrange：同进程首次调用即持有锁（源码未 close/unlock，fd 泄漏——疑似缺陷 D3）
+    // Arrange：同进程首次调用即持有锁（成功路径持有 fd/锁至进程退出为单实例检测
+    // 设计意图；lockf 失败路径已 close(fd)——D3 已修复）
     ASSERT_EQ(cfgWriteCount, 0);
 
     // Act
@@ -2379,8 +2377,8 @@ TEST_P(SlotFileSuffixParamTest, SlotFileSuffix_ParamSet_ReturnsCompleteSuffix)
         f.close();
     }
     if (!input.isEmpty()) {
-        // 统一以 file:// URL 传入：源码 QUrl(path).toLocalFile() 对裸路径返回空串，
-        // QFile::exists("") 恒 false（与 isCan* 系列同源的 D7 输入约定）
+        // 统一以 file:// URL 传入：slotFileSuffix 未在本批修复范围，
+        // QUrl(path).toLocalFile() 对裸路径返回空串，QFile::exists("") 恒 false
         input = localUrl(input);
     }
 
@@ -2562,18 +2560,14 @@ TEST_F(FileControlTest, TerminateShortcutPanelProcess_WaitReturnsTrue_CompletesQ
     EXPECT_EQ(procWaitCount, 1);
 }
 
-// ═════════════════ 疑似源码缺陷清单（只标红不修）═════════════════
-// D1 setWallpaper: X11 分支 QGuiApplication::primaryScreen()->name() 未判空
-//    （filecontrol.cpp setWallpaper 线程体内，headless/无屏环境空指针解引用风险）
-// D2 getNamePath: newPath 拼接用 newName 原串而非转换后的 now
-//    （file:// 输入时新路径错误，now 转换结果被丢弃）
-// D3 isCheckOnly: open 成功后 fd 未 close、锁未释放，且变量名 flock 遮蔽同名函数
-//    （fd 泄漏；锁依赖进程退出才释放。注：lockf 为进程级锁，同进程重复加锁仍成功）
-// D4 isCanDelete: 局部变量 isAlbum 恒为 false，`|| (isAlbum && isWritable)` 分支永不生效
-// D5 slotGetFileName 系列: file:// 前缀判断使用 startsWith("file://") 而非 QUrl 解析，
-//    大小写/编码变体（如 "FILE://"）不识别（轻微，行为锁定为当前实现）
-// D6 getDirImagePath: QFileInfo(QUrl(path).toLocalFile()).dir().path() 把入参当"文件"取父目录，
-//    传目录 URL 时扫描到其父目录（本例 /tmp 下历史图片文件混入结果）——入参约定应为目录内文件路径
-// D7 isCanDelete/isCanReadable/isCanRename/isCanSupportOcr/isCanWrite/isSupportSetWallpaper:
-//    QUrl(path).toLocalFile() 对无 scheme 裸路径返回空串（无 isImage 的 isLocalFile?x:path 回退），
-//    裸路径输入静默判 false，与 isImage 行为不一致（输入约定为 file:// URL，测试按真实行为锁定）
+// ═════════════════ 源码缺陷修复状态（fix/scan-defects 分支）═════════════════
+// D1 setWallpaper: X11 分支 primaryScreen() 已判空，空屏时安全返回不发起设置（已修复）
+// D2 getNamePath: newPath 已改为拼接转换后的 now（file:// 新名按本地名拼接）（已修复）
+// D3 isCheckOnly: fd 有效性检查已前移至 lockf 之前，lockf 失败路径 close(fd)；
+//    成功路径持有 fd/锁至进程退出为单实例检测设计意图（不 close）（失败路径已修复）
+// D4 isCanDelete: isAlbum 恒 false 死分支已删除（已修复）
+// D5 slotGetFileName 系列: 已统一 QUrl::isLocalFile() 判定，非本地 URL 回退原串（已修复）
+// D6 getDirImagePath: 已区分目录/文件入参——目录用自身，文件取所在目录（已修复）
+// D7 isCanDelete/isCanReadable/isCanRename/isCanSupportOcr/isCanWrite/isRotatable:
+//    已统一 isImage 的 isLocalFile?toLocalFile:path 回退，裸路径不再静默判 false（已修复）
+//    （isSupportSetWallpaper 未在本批修复范围，仍按 file:// URL 输入约定锁定行为）

--- a/tests/src/test_globalcontrol.cpp
+++ b/tests/src/test_globalcontrol.cpp
@@ -170,11 +170,11 @@ enum class InvalidImageKind {
 // B2: removeImage == currentImage.source() → viewModel()->deleteCurrent()
 // B3: !atEnd（当前图不在尾部，curIndex < rowCount-1）→ 读取 index(curIndex) 更新当前图并 emit 双信号
 // B4: atEnd 且 sourceModel->rowCount() != 0 → 读取 index(curIndex-1) 且 setIndexAndFrameIndex(curIndex-1, INT_MAX)
-//     （else：rowCount == 0 无剩余图片，仅 checkSwitchEnable + imageCountChanged）
+//     （else：rowCount == 0 无剩余图片，清空 currentImage/curIndex 并 emit 双信号，随后复位导航标志）
 // 用例映射：
 // - RemoveImage_CurrentMiddleImage_ShiftsToFollowingImage → B3（B1/B2 命中）
 // - RemoveImage_CurrentLastImage_MovesToPreviousImage → B4（B2 命中）
-// - RemoveImage_LastRemainingImage_ClearsNavigationFlags → B4(假) 落 else
+// - RemoveImage_LastRemainingImage_ClearsCurrentState → B4(假) 落 else
 // - RemoveImage_WithPendingRotation_SubmitsRotationBeforeRemoval → B1
 // - RemoveImage_UnknownImage_KeepsCurrentStateIntact → B3（状态不变断言）
 //
@@ -1077,23 +1077,27 @@ TEST_F(GlobalControlTest, RemoveImage_CurrentLastImage_MovesToPreviousImage)
     EXPECT_EQ(spyCount.count(), 1);
 }
 
-TEST_F(GlobalControlTest, RemoveImage_LastRemainingImage_ClearsNavigationFlags)
+TEST_F(GlobalControlTest, RemoveImage_LastRemainingImage_ClearsCurrentState)
 {
     // Arrange：仅一张图且为当前图
     const QUrl urlA = makeImageFile(QStringLiteral("a.png"));
     QStringList paths{urlA.toString()};  // file:// 形态与模型存储一致
     ctrl->setImageFiles(paths, paths.at(0));
     QSignalSpy spyCount(ctrl, &GlobalControl::imageCountChanged);
+    QSignalSpy spySource(ctrl, &GlobalControl::currentSourceChanged);
 
     // Act：删除最后一张
     ctrl->removeImage(urlA);
 
-    // Assert：模型清空，导航标志复位（atEnd 且 rowCount==0 落入 else 分支）
+    // Assert：模型清空，导航标志复位（atEnd 且 rowCount==0 落入 else 分支）；
+    // 修复语义：currentImage 同步清空，currentSource() 不再返回已删除路径
     EXPECT_EQ(ctrl->imageCount(), 0);
     EXPECT_FALSE(ctrl->hasNextImage());
     EXPECT_FALSE(ctrl->hasPreviousImage());
+    EXPECT_TRUE(ctrl->currentSource().isEmpty());
+    EXPECT_EQ(ctrl->currentIndex(), 0);
     EXPECT_EQ(spyCount.count(), 1);
-    EXPECT_EQ(ctrl->currentSource(), urlA);  // 注：currentImage 未清空（记录现状，见缺陷清单）
+    EXPECT_EQ(spySource.count(), 1);
 }
 
 TEST_F(GlobalControlTest, RemoveImage_WithPendingRotation_SubmitsRotationBeforeRemoval)
@@ -1133,8 +1137,8 @@ TEST_F(GlobalControlTest, RemoveImage_UnknownImage_KeepsCurrentStateIntact)
     EXPECT_EQ(ctrl->imageCount(), 2);
     EXPECT_EQ(ctrl->currentIndex(), 0);
     EXPECT_EQ(ctrl->currentSource(), urlA);
-    EXPECT_EQ(spyCount.count(), 1);  // 现状：imageCountChanged 无条件发出（见缺陷清单）
-    EXPECT_EQ(spySource.count(), 1); // 现状：!atEnd 分支无条件补发双信号（见缺陷清单）
+    EXPECT_EQ(spyCount.count(), 0);   // 修复语义：图片未从模型删除，不发 imageCountChanged
+    EXPECT_EQ(spySource.count(), 1);  // 注：!atEnd 分支仍无条件补发双信号（D1 未修复项）
 }
 
 // ── renameImage ──
@@ -1235,7 +1239,7 @@ TEST_F(GlobalControlTest, SetCurrentIndex_ValidIndex_UpdatesCurrentSource)
     EXPECT_EQ(spySource.count(), 1);
 }
 
-TEST_F(GlobalControlTest, SetCurrentIndex_OutOfRangeIndex_StoredRawBeyondBounds)
+TEST_F(GlobalControlTest, SetCurrentIndex_OutOfRangeIndex_ClampsToValidRange)
 {
     // Arrange
     loadThreeImages();
@@ -1246,11 +1250,10 @@ TEST_F(GlobalControlTest, SetCurrentIndex_OutOfRangeIndex_StoredRawBeyondBounds)
     ctrl->setCurrentIndex(-1);
     const int low = ctrl->currentIndex();
 
-    // Assert：缺陷 D5（文件尾标红）——validIndex 仅用于取图，落库的是原始 index，
-    // currentIndex() 可返回越界值 99/-1（真实行为固化）
-    EXPECT_EQ(high, 99);  // branch: this->curIndex = index（原始值，未用 validIndex）
-    EXPECT_EQ(low, -1);
-    EXPECT_EQ(ctrl->imageCount(), 3);  // 数据访问仍经 validIndex，模型未越界
+    // Assert：修复语义（原 D5）——validIndex 落库，越界索引被钳制到 [0, count-1]
+    EXPECT_EQ(high, 2);   // branch: this->curIndex = validIndex（钳制值）
+    EXPECT_EQ(low, 0);
+    EXPECT_EQ(ctrl->imageCount(), 3);
 }
 
 // ── setCurrentRotation ──
@@ -1433,7 +1436,7 @@ TEST_F(GlobalControlTest, SetImageFiles_ValidList_ReturnsTrueAndOpensTarget)
     EXPECT_EQ(ctrl->imageCount(), 3);
     EXPECT_EQ(ctrl->currentIndex(), 0);
     EXPECT_EQ(ctrl->currentSource(), urls.at(0));  // branch: currentImage.source() != currentSource → setSource
-    EXPECT_EQ(spySource.count(), 1);               // currentSourceChanged 无条件发出
+    EXPECT_EQ(spySource.count(), 1);               // 修复语义：源实际变更后才发 currentSourceChanged
     EXPECT_EQ(spyCount.count(), 1);
     EXPECT_EQ(spyNext.count(), 1);                 // 首张 → next 翻转为 true
 }
@@ -1447,6 +1450,7 @@ TEST_F(GlobalControlTest, SetImageFiles_RepeatedCall_KeepsStateConsistent)
         paths << u.toString();
     QSignalSpy spySource(ctrl, &GlobalControl::currentSourceChanged);
     QSignalSpy spyIndex(ctrl, &GlobalControl::currentIndexChanged);
+    QSignalSpy spyCount(ctrl, &GlobalControl::imageCountChanged);
 
     // Act：第二次设置（currentImage.source() 已等于目标 → B3 为假）
     const bool ret = ctrl->setImageFiles(paths, paths.at(1));
@@ -1456,7 +1460,9 @@ TEST_F(GlobalControlTest, SetImageFiles_RepeatedCall_KeepsStateConsistent)
     EXPECT_EQ(ctrl->currentIndex(), 1);
     EXPECT_EQ(ctrl->currentSource(), urls.at(1));
     EXPECT_EQ(ctrl->imageCount(), 3);
-    EXPECT_EQ(spyIndex.count(), 0);  // 索引未变，不发索引信号
+    EXPECT_EQ(spyIndex.count(), 0);   // 索引未变，不发索引信号
+    EXPECT_EQ(spySource.count(), 0);  // 修复语义：源未变，不发源信号
+    EXPECT_EQ(spyCount.count(), 0);   // 修复语义：数量未变（3→3），不发数量信号
 }
 
 // ── setIndexAndFrameIndex ──
@@ -1498,7 +1504,7 @@ TEST_F(GlobalControlTest, SetIndexAndFrameIndex_SameValues_EmitsNothing)
     EXPECT_EQ(spyFrame.count(), 0);
 }
 
-TEST_F(GlobalControlTest, SetIndexAndFrameIndex_OutOfRange_RawIndexStoredButFrameClamped)
+TEST_F(GlobalControlTest, SetIndexAndFrameIndex_OutOfRange_BothIndexAndFrameClamped)
 {
     // Arrange：多帧图（frameCount=3）
     stub.set_lamda(VADDR(ImageInfo, frameCount), [](ImageInfo *) -> int { return 3; });
@@ -1512,11 +1518,11 @@ TEST_F(GlobalControlTest, SetIndexAndFrameIndex_OutOfRange_RawIndexStoredButFram
     const int lowIndex = ctrl->currentIndex();
     const int lowFrame = ctrl->currentFrameIndex();
 
-    // Assert：帧索引经 validFrameIndex 钳制；索引存原始值（缺陷 D5，文件尾标红，真实行为固化）
-    EXPECT_EQ(highIndex, 99);  // branch: this->curIndex = index（原始值）
-    EXPECT_EQ(highFrame, 2);   // qBound(0, frameIndex, frameCount-1) 钳制
-    EXPECT_EQ(lowIndex, -1);   // 同 D5
-    EXPECT_EQ(lowFrame, 0);    // 钳制生效
+    // Assert：修复语义（原 D5）——索引与帧索引均经 qBound 钳制后落库
+    EXPECT_EQ(highIndex, 2);  // branch: this->curIndex = validIndex（钳制值）
+    EXPECT_EQ(highFrame, 2);  // qBound(0, frameIndex, frameCount-1) 钳制
+    EXPECT_EQ(lowIndex, 0);   // 同上，索引下界钳制
+    EXPECT_EQ(lowFrame, 0);   // 钳制生效
 }
 
 TEST_F(GlobalControlTest, SetIndexAndFrameIndex_FrameOnlyChange_EmitsOnlyFrameSignal)
@@ -1804,34 +1810,31 @@ TEST_F(GlobalControlTest, GlobalControl_RotateFinishedHook_MismatchedPathKeepsPe
     EXPECT_EQ(ctrl->currentSource(), urls.at(1));
 }
 
-// ═══════════════════ 源码缺陷标红清单（只标红，不修改源码）═══════════════════
-// 以下断言按源码【真实行为】固化，与直觉语义不符处均在对应用例注释中标注：
-//
-// D1: removeImage 删除「非当前/不存在」的图片时仍走更新分支
-//     证据：globalcontrol.cpp:457-468（!atEnd 分支无条件 Q_EMIT currentSourceChanged/
+// ═══════════════════ 源码缺陷清单（fix/scan-defects 分支修复状态）═══════════════════
+// D1（未修复，仍标红）: removeImage 删除「非当前/不存在」的图片时仍走更新分支
+//     证据：globalcontrol.cpp（!atEnd 分支无条件 Q_EMIT currentSourceChanged/
 //     currentIndexChanged）；单图列表（curIndex==0）传入不存在的 URL 时 else-if 分支
 //     读取 index(curIndex-1) = index(-1) 得空 QUrl，会把当前源清成 null。
-//     固化用例：RemoveImage_UnknownImage_KeepsCurrentStateIntact（断言状态保持 + 双信号仍发出）。
+//     固化用例：RemoveImage_UnknownImage_KeepsCurrentStateIntact（断言状态保持 +
+//     源/索引双信号仍发出，数量信号已随 D3 修复不再发出）。
 //
-// D2: removeImage 删除最后一张图后 currentImage 未清空
-//     证据：globalcontrol.cpp:476-478（else 分支仅注释 "No images left"，无清理）。
-//     currentSource() 仍返回已删除文件的 URL（陈旧状态）。
-//     固化用例：RemoveImage_LastRemainingImage_ClearsNavigationFlags。
+// D2（已修复）: removeImage 删除最后一张图后 currentImage 未清空
+//     修复：else 分支 setSource("") + curIndex 归 0 + emit 双信号。
+//     用例：RemoveImage_LastRemainingImage_ClearsCurrentState（currentSource 为空）。
 //
-// D3: removeImage / setImageFiles 无条件发出 imageCountChanged
-//     证据：globalcontrol.cpp:478、381（未核对数量是否实际变化）。
-//     固化用例：RemoveImage_UnknownImage_KeepsCurrentStateIntact（数量未变仍 count==1）。
+// D3（已修复）: removeImage / setImageFiles 无条件发出 imageCountChanged
+//     修复：均改为模型 count 前后对比，仅数量实际变化才发。
+//     用例：RemoveImage_UnknownImage_KeepsCurrentStateIntact（数量未变 count==0）、
+//     SetImageFiles_RepeatedCall_KeepsStateConsistent（3→3 不发）。
 //
-// D4: setImageFiles 无条件发出 currentSourceChanged
-//     证据：globalcontrol.cpp:377（即使 currentImage.source() 未变化）。
-//     固化用例：SetImageFiles_RepeatedCall_KeepsStateConsistent（源未变仍 count==1）。
+// D4（已修复）: setImageFiles 无条件发出 currentSourceChanged
+//     修复：Q_EMIT 移入 currentImage.source() != currentSource 守卫内。
+//     用例：SetImageFiles_RepeatedCall_KeepsStateConsistent（源未变 count==0）。
 //
-// D5: setIndexAndFrameIndex 将原始 index 落库而非钳制后的 validIndex
-//     证据：globalcontrol.cpp:626 `this->curIndex = index;`（validIndex 仅用于
-//     sourceModel->data 取图，第 622 行）。currentIndex() 可返回越界值（如 99/-1），
-//     与同函数中帧索引使用 validFrameIndex 的做法不一致。
-//     固化用例：SetCurrentIndex_OutOfRangeIndex_StoredRawBeyondBounds、
-//     SetIndexAndFrameIndex_OutOfRange_RawIndexStoredButFrameClamped。
+// D5（已修复）: setIndexAndFrameIndex 将原始 index 落库而非钳制后的 validIndex
+//     修复：this->curIndex = validIndex，与帧索引 validFrameIndex 的做法一致。
+//     用例：SetCurrentIndex_OutOfRangeIndex_ClampsToValidRange、
+//     SetIndexAndFrameIndex_OutOfRange_BothIndexAndFrameClamped。
 //
 // 另（真实行为注记，未单列缺陷）：submitImageChangeImmediately 内部经 setCurrentRotation(0)
 // 复位旋转时会重新 start(submitTimer)，提交完成后定时器处于重新武装状态而非停止态。


### PR DESCRIPTION
Fix null-screen deref in setWallpaper; fd leak and lock order in isCheckOnly; dir/file confusion in getDirImagePath; dead branch in isCanDelete; QUrl parsing fallback in isCan* series; stale state and unconditional signals in GlobalControl removeImage/setImageFiles; unclamped curIndex; config-setter dangling static pointer; eventlog init order.

修复 filecontrol/globalcontrol/configsetter/eventlogutils 共 13 项扫描缺陷。

Log: 修复核心控制与配置模块 13 项缺陷
Influence: 行为变化已同步单测断言，无接口变更；单测 1132/1132 通过

## Summary by Sourcery

Fix 13 scan defects across the file control, global control, configuration setter, and event logging modules.

Bug Fixes:
- Prevent null-screen crashes, invalid path handling, stale image state, out-of-range indices, dangling singleton pointers, unsafe event logging initialization, and lock-file error-path descriptor leaks.
- Make image capability checks work consistently with both local paths and file URLs, and correctly distinguish directory and file inputs.
- Emit image count and source change notifications only when the corresponding state actually changes.

Enhancements:
- Remove an unreachable deletion condition and improve cleanup of current image state when the image list becomes empty.

Tests:
- Update control, configuration, file handling, and event logging tests to cover the corrected behavior and failure paths.