### PR TITLE
fix: resolve 12 scan defects in unionimage base utils

### DIFF
--- a/src/src/unionimage/baseutils.cpp
+++ b/src/src/unionimage/baseutils.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/src/unionimage/baseutils.cpp
+++ b/src/src/unionimage/baseutils.cpp
@@ -135,9 +135,8 @@ void showInFileManager(const QString &path)
     qCDebug(logImageViewer) << "Opening file manager for:" << url.toString();
     QDesktopServices::openUrl(url);
 #else
-    QUrl url = QUrl::fromLocalFile(path);
+    QDesktopServices::openUrl(QUrl::fromLocalFile(path));
 #endif
-    QDesktopServices::openUrl(url);
     //    QUrl url = QUrl::fromLocalFile(QFileInfo(path).dir().absolutePath());
     //    QUrlQuery query;
     //    query.addQueryItem("selectUrl", QUrl::fromLocalFile(path).toString());
@@ -269,11 +268,11 @@ QString getNotExistsTrashFileName(const QString &fileName)
     name = name.left(200 - suffix.size());
     qCDebug(logImageViewer) << "Adjusted name size to:" << name.size();
 
-    QString trashpath = QStandardPaths::writableLocation(QStandardPaths::HomeLocation) + "/.local/share/Trash";
-    qCDebug(logImageViewer) << "Trash path determined as:" << trashpath;
+    QString trashpath = QStandardPaths::writableLocation(QStandardPaths::HomeLocation) + "/.local/share/Trash/files";
+    qCDebug(logImageViewer) << "Trash files path determined as:" << trashpath;
 
     while (true) {
-        QFileInfo info(trashpath + name + suffix);
+        QFileInfo info(trashpath + "/" + name + suffix);
         // QFile::exists ==> If the file is a symlink that points to a non-existing file, false is returned.
         if (!info.isSymLink() && !info.exists()) {
             qCDebug(logImageViewer) << "Generated unique trash filename:" << QString::fromUtf8(name + suffix);
@@ -435,10 +434,10 @@ QString SpliteText(const QString &text, const QFont &font, int nLabelSize, bool 
             qstrLeftData.replace(" ", "\n");
             qstrMidData.replace(" ", "\n");
             if (qstrLeftData != "")
-                return qstrLeftData + SpliteText(qstrMidData, font, nLabelSize);
+                return qstrLeftData + SpliteText(qstrMidData, font, nLabelSize, bReturn);
         } else {
             if (qstrLeftData != "")
-                return qstrLeftData + "\n" + SpliteText(qstrMidData, font, nLabelSize);
+                return qstrLeftData + "\n" + SpliteText(qstrMidData, font, nLabelSize, bReturn);
         }
         qCDebug(logImageViewer) << "Returning split text.";
     }

--- a/src/src/unionimage/imageutils.cpp
+++ b/src/src/unionimage/imageutils.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/src/unionimage/imageutils.cpp
+++ b/src/src/unionimage/imageutils.cpp
@@ -20,6 +20,7 @@
 #include <QPixmapCache>
 #include <QProcess>
 #include <QReadWriteLock>
+#include <QTemporaryFile>
 #include <QUrl>
 #include <QApplication>
 #include <QLoggingCategory>
@@ -67,13 +68,17 @@ const QImage scaleImage(const QString &path, const QSize &size)
         } else {
             qCDebug(logImageViewer) << "Image still too large after initial scaling, attempting save and rescale.";
             // Save as supported format and scale it again
-            const QString tmp = QDir::tempPath() + "/scale_tmp_image.png";
-            QFile::remove(tmp);
-            if (tImg.save(tmp, "png", 50)) {
+            QTemporaryFile tmpFile(QDir::tempPath() + "/scale_tmp_image_XXXXXX.png");
+            const QString tmp = tmpFile.open() ? tmpFile.fileName() : QString();
+            tmpFile.close();
+            if (!tmp.isEmpty() && tImg.save(tmp, "png", 50)) {
                 qCDebug(logImageViewer) << "Saved temporary PNG for rescaling:" << tmp;
-                return scaleImage(tmp, size);
+                const QImage rescaled = scaleImage(tmp, size);
+                QFile::remove(tmp);
+                return rescaled;
             } else {
                 qCWarning(logImageViewer) << "Failed to save temporary PNG for rescaling:" << tmp;
+                QFile::remove(tmp);
                 return QImage();
             }
         }
@@ -89,20 +94,18 @@ const QDateTime getCreateDateTime(const QString &path)
     QDateTime dt;
 
     // fallback to metadata.
-    if (!dt.isValid()) {
-        QString s;
-        s = getAllMetaData(path).value("DateTimeOriginal");
-        if (s.isEmpty()) {
-            qCDebug(logImageViewer) << "DateTimeOriginal metadata is empty, trying DateTimeDigitized.";
-            s = getAllMetaData(path).value("DateTimeDigitized");
-        }
-        if (s.isEmpty()) {
-            qCDebug(logImageViewer) << "DateTimeDigitized metadata is empty, falling back to current time string.";
-            s = QDateTime::currentDateTime().toString();
-        }
-        dt = QDateTime::fromString(s, "yyyy.MM.dd HH:mm:ss");
-        qCDebug(logImageViewer) << "Using metadata date:" << dt;
+    QString s;
+    s = getAllMetaData(path).value("DateTimeOriginal");
+    if (s.isEmpty()) {
+        qCDebug(logImageViewer) << "DateTimeOriginal metadata is empty, trying DateTimeDigitized.";
+        s = getAllMetaData(path).value("DateTimeDigitized");
     }
+    if (s.isEmpty()) {
+        qCDebug(logImageViewer) << "DateTimeDigitized metadata is empty, falling back to current time string.";
+        s = QDateTime::currentDateTime().toString();
+    }
+    dt = QDateTime::fromString(s, METADATA_DATETIME_FORMAT);
+    qCDebug(logImageViewer) << "Using metadata date:" << dt;
 
     // fallback to file create time.
     if (!dt.isValid()) {
@@ -343,19 +346,12 @@ const QMap<QString, QString> getAllMetaData(const QString &path)
 {
     qCDebug(logImageViewer) << "Getting metadata for:" << path;
     QMap<QString, QString> admMap;
-    // 移除秒　　2020/6/5 DJH
     // 需要转义才能读出：或者/　　2020/8/21 DJH
     QFileInfo info(path);
-    if (admMap.contains("DateTime")) {
-        qCDebug(logImageViewer) << "DateTime already in map, converting format.";
-        QDateTime time = QDateTime::fromString(admMap["DateTime"], "yyyy:MM:dd hh:mm:ss");
-        admMap["DateTimeOriginal"] = time.toString("yyyy/MM/dd hh:mm");
-    } else {
-        qCDebug(logImageViewer) << "DateTime not in map, using last modified time for DateTimeOriginal.";
-        admMap.insert("DateTimeOriginal", info.lastModified().toString("yyyy/MM/dd HH:mm"));
-    }
-    admMap.insert("DateTimeDigitized", info.lastModified().toString("yyyy/MM/dd HH:mm"));
-    qCDebug(logImageViewer) << "DateTimeDigitized set to last modified time.";
+    qCDebug(logImageViewer) << "Using last modified time for DateTimeOriginal.";
+    admMap.insert("DateTimeOriginal", info.lastModified().toString(METADATA_DATETIME_FORMAT));
+    admMap.insert("DateTimeDigitized", info.lastModified().toString(METADATA_DATETIME_FORMAT));
+    qCDebug(logImageViewer) << "DateTimeOriginal/DateTimeDigitized set to last modified time.";
     //    // The value of width and height might incorrect
     QImageReader reader(path);
     int w = reader.size().width();
@@ -434,9 +430,8 @@ const QString thumbnailCachePath()
 
     QStringList systemEnvs = QProcess::systemEnvironment();
     for (QString it : systemEnvs) {
-        QStringList el = it.split("=");
-        if (el.length() == 2 && el.first() == "XDG_CACHE_HOME") {
-            cacheP = el.last();
+        if (it.section('=', 0, 0) == "XDG_CACHE_HOME") {
+            cacheP = it.section('=', 1);
             qCDebug(logImageViewer) << "XDG_CACHE_HOME environment variable found:" << cacheP;
             break;
         }
@@ -717,7 +712,8 @@ bool isVaultFile(const QString &path)
         rootPath.chop(1);
     }
 
-    if (path.contains(rootPath) && path.left(6) != "search") {
+    QUrl url(path);
+    if (path.contains(rootPath) && url.scheme() != "search") {
         qCDebug(logImageViewer) << "File is in vault:" << path;
         bVaultFile = true;
     }

--- a/src/src/unionimage/imageutils.h
+++ b/src/src/unionimage/imageutils.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/src/unionimage/imageutils.h
+++ b/src/src/unionimage/imageutils.h
@@ -21,6 +21,9 @@ namespace image {
 const int THUMBNAIL_MAX_SIZE = 291 * 2;
 const int THUMBNAIL_NORMAL_SIZE = 128 * 2;
 
+//元数据时间格式，写入(getAllMetaData)与解析(getCreateDateTime)共用
+const QString METADATA_DATETIME_FORMAT = "yyyy/MM/dd HH:mm:ss";
+
 enum ThumbnailType {
     ThumbNormal,
     ThumbLarge,

--- a/src/src/unionimage/unionimage.cpp
+++ b/src/src/unionimage/unionimage.cpp
@@ -216,7 +216,6 @@ public:
         qCDebug(logImageViewer) << "UnionImage_Private destroyed.";
     }
     QStringList m_qtSupported;
-    QHash<QString, int> m_movie_formats;
     QStringList m_canSave;
     QStringList m_qtrotate;
 };
@@ -252,12 +251,6 @@ UNIONIMAGESHARED_EXPORT const QStringList supportStaticFormat()
 {
     qCDebug(logImageViewer) << "Getting supported static image formats.";
     return (union_image_private.m_qtSupported);
-}
-
-UNIONIMAGESHARED_EXPORT const QStringList supportMovieFormat()
-{
-    qCDebug(logImageViewer) << "Getting supported movie formats.";
-    return (union_image_private.m_movie_formats.keys());
 }
 
 /**
@@ -800,13 +793,14 @@ UNIONIMAGESHARED_EXPORT bool rotateImageFile(int angel, const QString &path, QSt
 UNIONIMAGESHARED_EXPORT bool rotateImageFIleWithImage(int angel, QImage &img, const QString &path, QString &erroMsg)
 {
     if (angel % 90 != 0) {
-        erroMsg = "unsupported angel";
+        erroMsg = "unsupported angle";
         return false;
     }
     QImage image_copy;
-    if (img.isNull())
+    if (img.isNull()) {
+        erroMsg = "image is null";
         return false;
-    else
+    } else
         image_copy = img;
 
     QString format = detectImageFormat(path);
@@ -987,12 +981,12 @@ imageViewerSpace::PathType getPathType(const QString &imagepath)
     } else if (imagepath.indexOf("mtp:host=") != -1) {
         qCDebug(logImageViewer) << "Detected MTP path type";
         type = imageViewerSpace::PathTypeMTP;
-    } else if (imagepath.indexOf("gphoto2:host=") != -1) {
-        qCDebug(logImageViewer) << "Detected PTP path type";
-        type = imageViewerSpace::PathTypePTP;
     } else if (imagepath.indexOf("gphoto2:host=Apple") != -1) {
         qCDebug(logImageViewer) << "Detected Apple path type";
         type = imageViewerSpace::PathTypeAPPLE;
+    } else if (imagepath.indexOf("gphoto2:host=") != -1) {
+        qCDebug(logImageViewer) << "Detected PTP path type";
+        type = imageViewerSpace::PathTypePTP;
     } else if (Libutils::image::isVaultFile(imagepath)) {
         qCDebug(logImageViewer) << "Detected safebox path type";
         type = imageViewerSpace::PathTypeSAFEBOX;

--- a/src/src/unionimage/unionimage.h
+++ b/src/src/unionimage/unionimage.h
@@ -53,7 +53,6 @@ UNIONIMAGESHARED_EXPORT QString unionImageVersion();
  */
 UNIONIMAGESHARED_EXPORT const QStringList unionImageSupportFormat();
 UNIONIMAGESHARED_EXPORT const QStringList supportStaticFormat();
-UNIONIMAGESHARED_EXPORT const QStringList supportMovieFormat();
 
 
 UNIONIMAGESHARED_EXPORT bool isDynamicFormat();

--- a/tests/src/test_free_baseutils.cpp
+++ b/tests/src/test_free_baseutils.cpp
@@ -26,7 +26,7 @@
 // | stringToDateTime         | low   | -                              | 1   | 3      |
 // | stringWidth              | low   | -                              | 1   | 1      |
 // | timeToString             | low   | -                              | 1   | 2      |
-// | trashFile                | high  | complexity:7,lines:81,in_degree:3 | 3 | 4    |
+// | trashFile                | high  | complexity:7,lines:81,in_degree:3 | 3 | 5    |
 //
 // 最小清单（test-types.md §8）：
 // [x] 1  每个函数 ≥ 1 用例（14/14）
@@ -46,9 +46,8 @@
 // B1: nTextSize > nLabelSize → 进入切分；否则原样返回（含明显富余的不切分侧）
 // B2: for 循环累计字符宽度，nOffset >= nLabelSize → 记录 nPos 并 break
 // B3: nPos-1 < 0 → nPos 归 0（首字符即超宽）
-// B4: bReturn=true 且 qstrLeftData != "" → 空格替换 \n 后拼接递归（顶层无分隔符，
-//     且递归按 3 参调用走 bReturn 默认值=false → 深层仍插 \n）
-//     → 无空格长文本无词边界，按宽度硬切在词中插 \n（D4 缺陷：无法整词换行）
+// B4: bReturn=true 且 qstrLeftData != "" → 空格替换 \n 后拼接递归（递归透传 bReturn，
+//     深层同样走 true 分支不再插 \n → 无空格长文本无词边界时不硬切，原样返回）
 // B5: bReturn=false 且 qstrLeftData != "" → left + "\n" + 递归
 // B6: qstrLeftData == ""（nPos==0）→ 落到末尾 return text 原样返回
 //
@@ -74,14 +73,17 @@
 // B1: trashFilesPath 不存在 → mkpath；B2: trashInfoPath 不存在 → mkpath
 // B3: originalInfo.exists() 为假 → return false（早退）
 // B4: while 候选 info/files 路径已存在 → nr++ 生成 baseName.nr[.suffix] 重试
+//     （files 冲突已由 getNotExistsTrashFileName 前置消解 → 实际由孤儿 trashinfo 触发）
 // B5: infoFile.open(WriteOnly) 失败 → return false（需权限注入，未覆盖）
 // B6: rename 失败 → return false（需跨设备/权限注入，未覆盖）
 // B7: 成功 → 写 trashinfo + rename + removeThumbnail + return true
 //
 // 用例映射：
-// - TrashFile_MissingSource_ReturnsFalseWithoutSideEffects  → B1+B2+B3
-// - TrashFile_ValidFile_MovesToTrashAndWritesInfo           → B7
-// - TrashFile_NameCollision_RetriesWithNumberedName         → B4（含无后缀变体）
+// - TrashFile_MissingSource_ReturnsFalseWithoutSideEffects       → B1+B2+B3
+// - TrashFile_ValidFile_MovesToTrashAndWritesInfo                → B7
+// - TrashFile_NameCollision_SecondFileUsesMd5Name                → B7(前置 md5 消解)
+// - TrashFile_OrphanedInfoConflict_RetriesWithNumberedName       → B4
+// - TrashFile_EmptySuffixFile_KeepsNameWithoutSuffixAddition     → B7(无后缀变体)
 // - 未覆盖：B5/B6（需把 info 目录改为只读/制造 rename 失败，CI 环境无法稳定注入）
 //
 // 分支清单（来源：baseutils.cpp 自由函数 copyImageToClipboard）
@@ -107,12 +109,12 @@
 // 分支清单（来源：baseutils.cpp 自由函数 showInFileManager）
 // B1: path 为空 → 早退不打开
 // B2: !QFile::exists(path) → 早退不打开
-// B3: 有效 → QDesktopServices::openUrl（源码连续调用两次，疑似缺陷只标红不修）
+// B3: 有效 → QDesktopServices::openUrl 恰好一次（重复调用缺陷已修复）
 //
 // 用例映射：
 // - ShowInFileManager_EmptyPath_SkipsOpenUrl            → B1
 // - ShowInFileManager_NonExistingPath_SkipsOpenUrl      → B2
-// - ShowInFileManager_ExistingFile_OpensAbsoluteUrlTwice→ B3
+// - ShowInFileManager_ExistingFile_OpensAbsoluteUrlOnce → B3
 //
 // 分支清单（来源：baseutils.cpp 自由函数 renderSVG）
 // B1: reader.canRead() → 按 scaledSize*size*ratio 渲染并设 devicePixelRatio
@@ -344,7 +346,7 @@ TEST_P(SpliteTextParamTest, SpliteText_VariousInputs_MatchExpectedSplitContract)
     const QString result = lb::SpliteText(text, font, labelSize, bReturn);
 
     // Assert（不变量：不超宽原样返回；超宽切分只插 \n 不丢字符（remove('\n') 可还原）；
-    //         bReturn=true 空格全部转 \n；无空格长文本被按宽度硬切在词中——D4 缺陷，
+    //         bReturn=true 空格全部转 \n，递归透传 bReturn 后无空格长文本不再按宽度硬切；
     //         期望值不依赖测试端字体度量，任何字体环境不变量恒成立）
     switch (c.kind) {
     case SpliteCase::Fits:
@@ -359,11 +361,8 @@ TEST_P(SpliteTextParamTest, SpliteText_VariousInputs_MatchExpectedSplitContract)
             EXPECT_LE(fm.horizontalAdvance(line), labelSize);        // 每行不再超宽
         break;
     case SpliteCase::NoSpaceReturnTrue:
-        EXPECT_NE(result, text);                                     // 超宽输入必被硬切（D4 实际行为）
-        EXPECT_EQ(QString(result).remove(QLatin1Char('\n')), text);  // D4: 硬切只插 \n，不丢字符
-        for (const QString &seg : result.split(QLatin1Char('\n')))
-            EXPECT_LE(fm.horizontalAdvance(seg),
-                      labelSize * 2);   // 宽松上界：顶层无分隔符至多合并两段，其余段均 < label
+        EXPECT_EQ(result, text);                                     // 递归透传 bReturn：true 模式仅按空格换行，无空格不硬切
+        EXPECT_FALSE(result.contains(QLatin1Char('\n')));
         break;
     case SpliteCase::SpacesReturnTrue:
         EXPECT_FALSE(result.contains(QLatin1Char(' ')));             // 空格全部替换为 \n
@@ -478,8 +477,8 @@ TEST_F(FreeBaseUtilsTest, GetFileContent_MissingAndEmptyFiles_ReturnEmptyString)
 
 TEST_F(FreeBaseUtilsTest, GetNotExistsTrashFileName_PlainNamesNoConflict_ReturnNamesUnchanged)
 {
-    // Arrange（隔离 HOME 下 Trash 无任何已有文件）
-    const QString trashProbe = m_home.path() + "/.local/share/Trashphoto.jpg";
+    // Arrange（隔离 HOME 下 Trash/files 无任何已有文件）
+    const QString trashProbe = m_home.path() + "/.local/share/Trash/files/photo.jpg";
     ASSERT_FALSE(QFile::exists(trashProbe));   // 前置：候选名未被占用
 
     // Act
@@ -506,10 +505,10 @@ TEST_F(FreeBaseUtilsTest, GetNotExistsTrashFileName_PathLikeInput_StripsDirector
 
 TEST_F(FreeBaseUtilsTest, GetNotExistsTrashFileName_ExistingCandidate_FallsBackToMd5Name)
 {
-    // Arrange：源码探测路径为 trashPath + name + suffix（缺少路径分隔符，见缺陷清单），
-    // 在该拼接连通处预置同名文件以触发 md5 重试
-    ASSERT_TRUE(QDir(m_home.path() + "/.local/share").mkpath(QStringLiteral(".")));
-    writeTextFile(m_home.path() + "/.local/share", "Trashphoto.jpg", "occupied");
+    // Arrange：源码探测路径为 Trash/files/ 内带分隔符的完整路径（与 trashFile 的
+    // 冲突判断基准一致），在该处预置同名文件以触发 md5 重试
+    ASSERT_TRUE(QDir(m_home.path() + "/.local/share/Trash/files").mkpath(QStringLiteral(".")));
+    writeTextFile(m_home.path() + "/.local/share/Trash/files", "photo.jpg", "occupied");
     const QString expectedMd5 =
             QString(QCryptographicHash::hash("photo", QCryptographicHash::Md5).toHex());
 
@@ -692,7 +691,7 @@ TEST_F(FreeBaseUtilsTest, ShowInFileManager_NonExistingPath_SkipsOpenUrl)
     EXPECT_FALSE(QFile::exists(missing));
 }
 
-TEST_F(FreeBaseUtilsTest, ShowInFileManager_ExistingFile_OpensAbsoluteUrlTwice)
+TEST_F(FreeBaseUtilsTest, ShowInFileManager_ExistingFile_OpensAbsoluteUrlOnce)
 {
     // Arrange
     int openCalls = 0;
@@ -709,7 +708,7 @@ TEST_F(FreeBaseUtilsTest, ShowInFileManager_ExistingFile_OpensAbsoluteUrlTwice)
     lb::showInFileManager(path);
 
     // Assert
-    EXPECT_EQ(openCalls, 2);    // B3: 源码 #if 1 分支与其后各调用一次 openUrl（疑似缺陷，只标红）
+    EXPECT_EQ(openCalls, 1);    // B3: 重复 openUrl 缺陷已修复，仅打开一次
     EXPECT_EQ(openedUrl, QUrl::fromLocalFile(QFileInfo(path).absoluteFilePath()));
 }
 
@@ -868,13 +867,16 @@ TEST_F(FreeBaseUtilsTest, TrashFile_ValidFile_MovesToTrashAndWritesInfo)
     EXPECT_EQ(m_removeThumbArg, src);                     // 参数：传入的是原路径
 }
 
-TEST_F(FreeBaseUtilsTest, TrashFile_NameCollision_RetriesWithNumberedName)
+TEST_F(FreeBaseUtilsTest, TrashFile_NameCollision_SecondFileUsesMd5Name)
 {
-    // Arrange：同名文件两次入回收站，第二次应走 nr++ 重试生成 baseName.2.suffix
+    // Arrange：同名文件两次入回收站。探测基准统一到 Trash/files 后，
+    // 第二次由 getNotExistsTrashFileName 直接给出 md5 主名（files 冲突在前置探测即消解）
     const QString first = writeTextFile(m_work.path(), "ut-b.jpg", "first");
     const QString secondDir = m_work.path() + "/second";
     ASSERT_TRUE(QDir().mkpath(secondDir));
     const QString second = writeTextFile(secondDir, "ut-b.jpg", "second");
+    const QString md5Name =
+            QString(QCryptographicHash::hash(QByteArray("ut-b"), QCryptographicHash::Md5).toHex());
 
     // Act
     const bool firstMoved = lb::trashFile(first);
@@ -882,20 +884,40 @@ TEST_F(FreeBaseUtilsTest, TrashFile_NameCollision_RetriesWithNumberedName)
 
     // Assert
     EXPECT_TRUE(firstMoved);    // B7: 第一次直接成功
-    EXPECT_TRUE(secondMoved);   // B4: 冲突重试后成功
+    EXPECT_TRUE(secondMoved);   // 冲突消解后成功
     EXPECT_TRUE(QFile::exists(m_home.path() + "/.local/share/Trash/files/ut-b.jpg"));
-    EXPECT_TRUE(QFile::exists(m_home.path() + "/.local/share/Trash/files/ut-b.2.jpg"));   // B4 编号名
-    EXPECT_TRUE(QFile::exists(m_home.path() + "/.local/share/Trash/info/ut-b.2.jpg.trashinfo"));
+    EXPECT_TRUE(QFile::exists(m_home.path() + "/.local/share/Trash/files/" + md5Name + ".jpg"));
+    EXPECT_TRUE(QFile::exists(m_home.path() + "/.local/share/Trash/info/" + md5Name + ".jpg.trashinfo"));
     EXPECT_EQ(m_removeThumbCalls, 2);   // 每次成功入站各移除一次缩略图
+}
+
+TEST_F(FreeBaseUtilsTest, TrashFile_OrphanedInfoConflict_RetriesWithNumberedName)
+{
+    // Arrange：预置孤儿 trashinfo（info 命中而 files 未占用）→ 前置探测直返原名，
+    // 触发 trashFile 内 while 的 nr++ 编号重试
+    ASSERT_TRUE(QDir(m_home.path() + "/.local/share/Trash/info").mkpath(QStringLiteral(".")));
+    writeTextFile(m_home.path() + "/.local/share/Trash/info", "ut-c.jpg.trashinfo", "orphan");
+    const QString src = writeTextFile(m_work.path(), "ut-c.jpg", "ccc");
+
+    // Act
+    const bool moved = lb::trashFile(src);
+
+    // Assert
+    EXPECT_TRUE(moved);                                                   // B4: 编号重试后成功
+    EXPECT_TRUE(QFile::exists(m_home.path() + "/.local/share/Trash/files/ut-c.2.jpg"));
+    EXPECT_TRUE(QFile::exists(m_home.path() + "/.local/share/Trash/info/ut-c.2.jpg.trashinfo"));
+    EXPECT_EQ(m_removeThumbCalls, 1);
 }
 
 TEST_F(FreeBaseUtilsTest, TrashFile_EmptySuffixFile_KeepsNameWithoutSuffixAddition)
 {
-    // Arrange：无后缀文件两次入回收站，重试名应为 README.2（无后缀拼接段）
+    // Arrange：无后缀文件两次入回收站，第二次主名换 md5（无后缀拼接段，无尾随点）
     const QString first = writeTextFile(m_work.path(), "README", "r1");
     const QString thirdDir = m_work.path() + "/third";
     ASSERT_TRUE(QDir().mkpath(thirdDir));
     const QString second = writeTextFile(thirdDir, "README", "r2");
+    const QString md5Name =
+            QString(QCryptographicHash::hash(QByteArray("README"), QCryptographicHash::Md5).toHex());
 
     // Act
     const bool firstMoved = lb::trashFile(first);
@@ -905,9 +927,9 @@ TEST_F(FreeBaseUtilsTest, TrashFile_EmptySuffixFile_KeepsNameWithoutSuffixAdditi
     EXPECT_TRUE(firstMoved);
     EXPECT_TRUE(secondMoved);
     EXPECT_TRUE(QFile::exists(m_home.path() + "/.local/share/Trash/files/README"));       // 首次原名
+    EXPECT_EQ(QFile::exists(m_home.path() + "/.local/share/Trash/files/" + md5Name),
+              true);                                                       // 第二次 md5 主名
     EXPECT_EQ(QFile::exists(m_home.path() + "/.local/share/Trash/files/README.2"),
-              true);                                                                      // B4: 无后缀编号名
-    EXPECT_EQ(QFile::exists(m_home.path() + "/.local/share/Trash/files/README.2."),
-              false);                                                                     // 不产生尾随点
-    EXPECT_EQ(m_removeThumbCalls, 2);                                                     // 两次均触发缩略图移除
+              false);                                                      // 不再走编号名
+    EXPECT_EQ(m_removeThumbCalls, 2);                                     // 两次均触发缩略图移除
 }

--- a/tests/src/test_free_imageutils.cpp
+++ b/tests/src/test_free_imageutils.cpp
@@ -73,7 +73,7 @@
 // - ScaleImage_LargerBoundingBox_ReturnsUpscaledImage              → B13(放大侧)/B12
 // - 未覆盖：B3/B5（需 canRead 为真但 reader.size() 无效的格式）、B6~B11（需不响应
 //   ScaledSize 的图像格式触发"落盘 PNG 重入"递归）——本运行环境无稳定构造方式，
-//   见最终汇报；递归临时文件路径为源码内建 QDir::tempPath 固定名，无法从外部注入
+//   见最终汇报；递归临时文件为 QDir::tempPath 下唯一名且在返回前删除
 //
 // 分支清单（来源：imageutils.cpp 自由函数 size2HumanT）
 // B1: bytes < 1024 → "N B"（含 0 与 1023 边界）
@@ -122,7 +122,7 @@
 // - GetThumbnail_NoCacheAllowed_GeneratesAndReturns      → B3(真)/B4/B7
 //
 // 分支清单（来源：imageutils.cpp 自由函数 getCreateDateTime）
-// B1: 初始 !dt.isValid()（恒真，进入元数据回退）
+// B1: 元数据 DateTimeOriginal 非空 → 按 METADATA_DATETIME_FORMAT 解析
 // B2: DateTimeOriginal 为空 → 改读 DateTimeDigitized
 // B3: 两者皆空 → 取当前时间字符串
 // B4: 元数据解析失败 → 回退 birthTime
@@ -130,8 +130,8 @@
 // B6: 最终 return dt
 //
 // 用例映射：
-// - GetCreateDateTime_ExistingFile_ReturnsBirthTimeFallback   → B1/B2(假)/B4
-// - GetCreateDateTime_MissingFile_ReturnsCurrentTimeFallback  → B2(真)/B3/B5
+// - GetCreateDateTime_ExistingFile_ReturnsMetadataDateTime   → B1/B2(假)
+// - GetCreateDateTime_MissingFile_ReturnsCurrentTimeFallback → B2(真)/B3/B5
 //
 // 分支清单（来源：imageutils.cpp 自由函数 getImagesInfo）
 // B1: !recursive → 非递归 entryInfoList(QDir::Files)
@@ -179,13 +179,14 @@
 // - ThumbnailPath_EachThumbnailType_ReturnsTypeSubdirPath（TEST_P 3 组）→ B1/B2/B3/B5
 //
 // 分支清单（来源：imageutils.cpp 自由函数 thumbnailCachePath）
-// B1: 环境变量命中 XDG_CACHE_HOME（el.length()==2）→ 使用该值
+// B1: 环境变量命中 XDG_CACHE_HOME（section 取键/值，值可含 '='）→ 使用该值
 // B2: 未命中 → home + "/.cache" 回退
 // B3: mkpath 创建 normal/large/fail 三个子目录
 //
 // 用例映射：
-// - ThumbnailCachePath_XdgCacheHomeSet_ReturnsIsolatedDir     → B1/B3
-// - ThumbnailCachePath_XdgCacheHomeMissing_FallsBackToHome    → B2/B3
+// - ThumbnailCachePath_XdgCacheHomeSet_ReturnsIsolatedDir          → B1/B3
+// - ThumbnailCachePath_XdgCacheHomeContainsEqualSign_UsesFullValue → B1(值含 '=')
+// - ThumbnailCachePath_XdgCacheHomeMissing_FallsBackToHome         → B2/B3
 //
 // 分支清单（来源：imageutils.cpp 自由函数 thumbnailExist）
 // B1: 对应类型缩略图文件存在 → true
@@ -197,8 +198,8 @@
 //
 // 分支清单（来源：imageutils.cpp 自由函数 isVaultFile）
 // B1: rootPath 以 '/' 结尾 → chop(1)
-// B2: path.contains(rootPath) && path.left(6)!="search" → true
-// B3: "search" 前缀路径 → 短路右侧为假 → false
+// B2: path.contains(rootPath) && QUrl(path).scheme()!="search" → true
+// B3: search 协议 URL（scheme=="search"）→ 短路右侧为假 → false
 //
 // 用例映射：
 // - IsVaultFile_VariousPaths_ReturnsExpectedFlag（TEST_P 4 组）→ B1/B2/B3
@@ -245,12 +246,12 @@
 // - ThumbnailAttribute_RemoteUrl_ReturnsEmptyMap      → B3
 //
 // 分支清单（来源：imageutils.cpp 自由函数 getAllMetaData）
-// B1: admMap.contains("DateTime")（新建空 map，恒假——疑似死代码）→ 走 else
-// B2: else → 以 lastModified 填 DateTimeOriginal/DateTimeDigitized
+// B1: 以 lastModified 按 METADATA_DATETIME_FORMAT 填 DateTimeOriginal/DateTimeDigitized
+//     （与 getCreateDateTime 解析格式一致，原恒假死分支已删除）
 //
 // 用例映射：
-// - GetAllMetaData_ValidPngFile_ReturnsExpectedFields   → B1(假)/B2
-// - GetAllMetaData_MissingFile_ReturnsFallbackFields    → B1(假)/B2
+// - GetAllMetaData_ValidPngFile_ReturnsExpectedFields   → B1
+// - GetAllMetaData_MissingFile_ReturnsFallbackFields    → B1
 //
 // 分支清单（来源：imageutils.cpp 自由函数 cachePixmap）
 // B1: QPixmapCache::find 未命中 → 从文件加载并 insert
@@ -350,7 +351,7 @@ struct BoolPathCase {
 // INSTANTIATE 的参数值在静态初始化期求值（早于 fixture 成员与 stub 生效），
 // 路径必须在测试体内构造，故参数只携带"路径种类"
 struct VaultFlagCase {
-    enum Kind { VaultFile, PlainFile, SearchPrefixed, EmptyPath };
+    enum Kind { VaultFile, PlainFile, SearchUrl, EmptyPath };
     Kind kind;
     bool expected;
 };
@@ -516,8 +517,8 @@ TEST_P(IsVaultFileParamTest, IsVaultFile_VariousPaths_ReturnsExpectedFlag)
     case VaultFlagCase::PlainFile:
         path = QDir(m_workDir.path()).filePath("plain.png");
         break;
-    case VaultFlagCase::SearchPrefixed:
-        path = QString("search") + liu::makeVaultLocalPath("", "");
+    case VaultFlagCase::SearchUrl:
+        path = QString("search://") + liu::makeVaultLocalPath("", "");
         break;
     case VaultFlagCase::EmptyPath:
         break;
@@ -537,7 +538,7 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::Values(
                 VaultFlagCase{VaultFlagCase::VaultFile, true},
                 VaultFlagCase{VaultFlagCase::PlainFile, false},
-                VaultFlagCase{VaultFlagCase::SearchPrefixed, false},
+                VaultFlagCase{VaultFlagCase::SearchUrl, false},
                 VaultFlagCase{VaultFlagCase::EmptyPath, false}));
 
 // ── isCanRemove ───────────────────────────────────────────────────────────────
@@ -765,6 +766,11 @@ TEST_F(FreeImageUtilsTest, GetAllMetaData_ValidPngFile_ReturnsExpectedFields)
     EXPECT_EQ(got.value("FileFormat"), QString("png"));
     EXPECT_EQ(got.value("FileSize"), liu::size2HumanT(QFileInfo(path).size()));
     EXPECT_TRUE(got.contains("DateTimeOriginal"));
+    // B1: 日期字段按 METADATA_DATETIME_FORMAT 写入，且可被同一格式解析（与 getCreateDateTime 对齐）
+    const QDateTime lastModified = QFileInfo(path).lastModified();
+    EXPECT_EQ(got.value("DateTimeOriginal"), lastModified.toString(liu::METADATA_DATETIME_FORMAT));
+    EXPECT_EQ(got.value("DateTimeDigitized"), lastModified.toString(liu::METADATA_DATETIME_FORMAT));
+    EXPECT_TRUE(QDateTime::fromString(got.value("DateTimeOriginal"), liu::METADATA_DATETIME_FORMAT).isValid());
 }
 
 TEST_F(FreeImageUtilsTest, GetAllMetaData_MissingFile_ReturnsFallbackFields)
@@ -784,20 +790,19 @@ TEST_F(FreeImageUtilsTest, GetAllMetaData_MissingFile_ReturnsFallbackFields)
 
 // ── getCreateDateTime ─────────────────────────────────────────────────────────
 
-TEST_F(FreeImageUtilsTest, GetCreateDateTime_ExistingFile_ReturnsBirthTimeFallback)
+TEST_F(FreeImageUtilsTest, GetCreateDateTime_ExistingFile_ReturnsMetadataDateTime)
 {
     // Arrange
     const QString path = makeSolidPng(m_workDir.path(), "born.png", 4, 4);
-    const QDateTime birthTime = QFileInfo(path).birthTime();
+    const QDateTime lastModified = QFileInfo(path).lastModified();
 
     // Act
     const QDateTime got = liu::getCreateDateTime(path);
 
-    // Assert（元数据格式不匹配解析失败 → 回退文件 birthTime）
+    // Assert（DateTimeOriginal 写入/解析格式已统一 → 命中元数据，秒精度内等于 lastModified）
     EXPECT_TRUE(got.isValid());
     EXPECT_GT(got.toSecsSinceEpoch(), qint64(1577836800));  // 晚于 2020-01-01
-    if (birthTime.isValid())
-        EXPECT_EQ(got, birthTime);
+    EXPECT_NEAR(got.toSecsSinceEpoch(), lastModified.toSecsSinceEpoch(), 1);
 }
 
 TEST_F(FreeImageUtilsTest, GetCreateDateTime_MissingFile_ReturnsCurrentTimeFallback)
@@ -1088,6 +1093,25 @@ TEST_F(FreeImageUtilsTest, ThumbnailCachePath_XdgCacheHomeSet_ReturnsIsolatedDir
     EXPECT_TRUE(QDir(m_cacheDir.filePath("thumbnails/large")).exists());
     EXPECT_TRUE(QDir(m_cacheDir.filePath("thumbnails/normal")).exists());
     EXPECT_TRUE(QDir(m_cacheDir.filePath("thumbnails/fail")).exists());
+}
+
+TEST_F(FreeImageUtilsTest, ThumbnailCachePath_XdgCacheHomeContainsEqualSign_UsesFullValue)
+{
+    // Arrange（XDG_CACHE_HOME 值内含 '='：section 解析后完整保留）
+    const QString cacheBase = m_workDir.filePath("eq=val");
+    stub_ext::StubExt localStub;
+    localStub.set_lamda(static_cast<QStringList (*)()>(&QProcess::systemEnvironment),
+                        [&cacheBase]() -> QStringList {
+                            return QStringList{ QStringLiteral("XDG_CACHE_HOME=") + cacheBase };
+                        });
+
+    // Act
+    const QString got = liu::thumbnailCachePath();
+
+    // Assert
+    EXPECT_EQ(got, cacheBase + "/thumbnails");
+    EXPECT_TRUE(QDir(cacheBase + "/thumbnails/large").exists());
+    localStub.clear();
 }
 
 TEST_F(FreeImageUtilsTest, ThumbnailCachePath_XdgCacheHomeMissing_FallsBackToHome)

--- a/tests/src/test_free_unionimage.cpp
+++ b/tests/src/test_free_unionimage.cpp
@@ -22,7 +22,6 @@
 // | rotateImageFIleWithImage | high | complexity:8,cognitive:16 | 3 | 5 |
 // | rotateImageFile | high | complexity:9,cognitive:21 | 3 | 6 |
 // | size2Human | mid | complexity:6,cognitive:17 | 2 | 9 |
-// | supportMovieFormat | low | - | 1 | 1 |
 // | supportStaticFormat | low | - | 1 | 1 |
 // | unionImageSupportFormat | low | - | 1 | 1 |
 // | unionImageVersion | low | - | 1 | 1 |
@@ -31,7 +30,7 @@
 // ─── actual 均不低于 min（actual=参数化实例数+独立用例数）───
 //
 // 最小清单完成情况（test-code-gen §最小清单）：
-// 1. 每个公开方法 ≥ 1 用例: [x]（19 自由函数 + UnionImage_Private 2 方法全覆盖；
+// 1. 每个公开方法 ≥ 1 用例: [x]（18 自由函数 + UnionImage_Private 2 方法全覆盖；
 //    convertToSRgbColorSpace 为 static 内部链接函数，经 loadStaticImageFromFile 间接覆盖）
 // 2. 每个输入维度按等价类划分 ≥ 1 用例/类: [x]（角度合法/非法、格式支持/不支持、空/非空输入、
 //    尺寸边界 0/1023/1024/1M/1G、方向 1-8 全枚举）
@@ -129,16 +128,16 @@
 // 分支清单（来源：getPathType(const QString &)）
 // B1: 含 "smb-share:server=" → SMB
 // B2: 含 "mtp:host=" → MTP
-// B3: 含 "gphoto2:host=" → PTP
-// B4: 含 "gphoto2:host=Apple" → APPLE（源码序导致不可达，见缺陷清单）
+// B3: 含 "gphoto2:host=Apple" → APPLE（特判须先于通用 gphoto2:host= 判断方可达）
+// B4: 含 "gphoto2:host=" → PTP
 // B5: isVaultFile → SAFEBOX
 // B6: 含 $HOME/.local/share/Trash → RECYCLEBIN
 // B7: 默认 → LOCAL
 // 用例映射：
 // - GetPathType_SmbUri_ReturnsSmbType → B1
 // - GetPathType_MtpUri_ReturnsMtpType → B2
-// - GetPathType_Gphoto2Uri_ReturnsPtpType → B3
-// - GetPathType_Gphoto2AppleUri_ReturnsPtpInsteadOfApple → B3/B4
+// - GetPathType_Gphoto2AppleUri_ReturnsAppleType → B3
+// - GetPathType_Gphoto2Uri_ReturnsPtpType → B4
 // - GetPathType_VaultFlaggedPath_ReturnsSafeboxType → B5
 // - GetPathType_HomeTrashPath_ReturnsRecyclebinType → B6
 // - GetPathType_PlainLocalPath_ReturnsLocalType → B7
@@ -193,15 +192,15 @@
 // - RotateImageFile_DirectoryTargetPath_ReturnsFalseWithSaveError → B6
 //
 // 分支清单（来源：rotateImageFIleWithImage(int, QImage &, const QString &, QString &)）
-// B1: angel%90!=0 → false + "unsupported angel"
-// B2: img.isNull() → false（无 erroMsg）
+// B1: angel%90!=0 → false + "unsupported angle"
+// B2: img.isNull() → false + "image is null"
 // B3: SVG → QSvgGenerator 写回 → true
 // B4: JPG/JPEG 且 QImage(path,"JPG") 非空 → 旋转保存 → true
 // B5: JPG 加载失败 → false
 // B6: 其它格式 → false
 // 用例映射：
 // - RotateImageFIleWithImage_InvalidAngle_ReturnsFalseWithMessage → B1
-// - RotateImageFIleWithImage_NullImage_ReturnsFalse → B2
+// - RotateImageFIleWithImage_NullImage_ReturnsFalseWithMessage → B2
 // - RotateImageFIleWithImage_SvgFile_RewritesAndReturnsTrue → B3
 // - RotateImageFIleWithImage_JpgFile_SavesRotatedReturnsTrue → B4
 // - RotateImageFIleWithImage_UnsupportedFormat_ReturnsFalse → B6
@@ -246,7 +245,7 @@ bool isNoneQImage(const QImage &qi);
 QString size2Human(const qlonglong bytes);
 
 // unionimage.cpp 文件内隐藏类（无头文件），按源码成员布局逐成员镜像声明
-//（含 m_movie_formats，位置/顺序必须一致，否则构造函数越界写）；
+//（位置/顺序必须一致，否则构造函数越界写）；
 // 构造/析构为类内 inline 定义，链接期与 unionimage.o 弱符号合并
 class UnionImage_Private {
 public:
@@ -254,7 +253,6 @@ public:
     ~UnionImage_Private();
 
     QStringList m_qtSupported;
-    QHash<QString, int> m_movie_formats;
     QStringList m_canSave;
     QStringList m_qtrotate;
 };
@@ -829,10 +827,10 @@ TEST_F(FreeUnionImageTest, GetPathType_Gphoto2Uri_ReturnsPtpType)
     EXPECT_TRUE(captured.isEmpty());
 }
 
-TEST_F(FreeUnionImageTest, GetPathType_Gphoto2AppleUri_ReturnsPtpInsteadOfApple)
+TEST_F(FreeUnionImageTest, GetPathType_Gphoto2AppleUri_ReturnsAppleType)
 {
     // Arrange
-    // 源码缺陷：gphoto2:host= 判断先于 gphoto2:host=Apple，APPLE 分支不可达
+    // Apple 特判先于通用 gphoto2:host= 判断，iPhone 路径应命中 APPLE 分支
     const QString path = QStringLiteral("gphoto2:host=Apple_iPhone/DCIM/IMG.jpg");
     QString captured;
     stub.set_lamda(Libutils::image::isVaultFile,
@@ -845,8 +843,8 @@ TEST_F(FreeUnionImageTest, GetPathType_Gphoto2AppleUri_ReturnsPtpInsteadOfApple)
     const imageViewerSpace::PathType type = getPathType(path);
 
     // Assert
-    EXPECT_EQ(type, imageViewerSpace::PathTypePTP);
-    EXPECT_NE(type, imageViewerSpace::PathTypeAPPLE);
+    EXPECT_EQ(type, imageViewerSpace::PathTypeAPPLE);
+    EXPECT_NE(type, imageViewerSpace::PathTypePTP);
     // else-if 链短路，isVaultFile 不应被调用
     EXPECT_TRUE(captured.isEmpty());
 }
@@ -1374,10 +1372,10 @@ TEST_F(FreeUnionImageTest, RotateImageFIleWithImage_InvalidAngle_ReturnsFalseWit
 
     // Assert
     EXPECT_FALSE(ret);
-    EXPECT_EQ(erroMsg, QString("unsupported angel"));
+    EXPECT_EQ(erroMsg, QString("unsupported angle"));
 }
 
-TEST_F(FreeUnionImageTest, RotateImageFIleWithImage_NullImage_ReturnsFalse)
+TEST_F(FreeUnionImageTest, RotateImageFIleWithImage_NullImage_ReturnsFalseWithMessage)
 {
     // Arrange
     QImage img;
@@ -1389,7 +1387,7 @@ TEST_F(FreeUnionImageTest, RotateImageFIleWithImage_NullImage_ReturnsFalse)
 
     // Assert
     EXPECT_FALSE(ret);
-    EXPECT_EQ(erroMsg, QString());
+    EXPECT_EQ(erroMsg, QString("image is null"));
 }
 
 TEST_F(FreeUnionImageTest, RotateImageFIleWithImage_SvgFile_RewritesAndReturnsTrue)
@@ -1492,16 +1490,13 @@ TEST_F(UnionImage_PrivateTest, UnionImage_Private_Destructor_CleansUpWithoutErro
     EXPECT_EQ(canSaveCount, 9);
 }
 
-// ─── 支持格式查询三函数（补测：lcov FNDA:0，stub.clear() 后直连真实函数）───
-// 实现（unionimage.cpp:238-261）：
+// ─── 支持格式查询两函数（补测：lcov FNDA:0，stub.clear() 后直连真实函数）───
+// 实现（unionimage.cpp）：
 // - supportStaticFormat()    → 返回 union_image_private.m_qtSupported（54 项静态表）
-// - supportMovieFormat()     → 返回 union_image_private.m_movie_formats.keys()
 // - unionImageSupportFormat()→ 首次调用把 m_qtSupported 填入函数内 static res 后返回
+// 注记：supportMovieFormat()/m_movie_formats 因无任何填充点、恒返回空表，已随源码删除。
 // 映射： SupportStaticFormat_QueryTable_ReturnsNonEmptyKnownFormats       → 直连真实函数
-//        SupportMovieFormat_QueryTable_ReturnsEmptyUnpopulatedList       → 直连真实函数
 //        UnionImageSupportFormat_QueryMergedTable_MatchesStaticFormat    → 直连真实函数
-// 缺陷注记（只标红不修改）：m_movie_formats 在源码中无任何填充点，
-// supportMovieFormat() 恒返回空表（见 SupportMovieFormat 用例断言）。
 
 TEST_F(FreeUnionImageTest, SupportStaticFormat_QueryTable_ReturnsNonEmptyKnownFormats)
 {
@@ -1516,20 +1511,6 @@ TEST_F(FreeUnionImageTest, SupportStaticFormat_QueryTable_ReturnsNonEmptyKnownFo
     EXPECT_TRUE(formats.contains(QStringLiteral("BMP")));
     EXPECT_TRUE(formats.contains(QStringLiteral("PNG")));
     EXPECT_TRUE(formats.contains(QStringLiteral("GIF")));
-}
-
-TEST_F(FreeUnionImageTest, SupportMovieFormat_QueryTable_ReturnsEmptyUnpopulatedList)
-{
-    // Arrange：同上，直连真实函数
-    stub.clear();
-
-    // Act
-    const QStringList movieFormats = LibUnionImage_NameSpace::supportMovieFormat();
-
-    // Assert：m_movie_formats 无填充点 → 恒为空表（缺陷注记，真实行为固化）；
-    // 静态格式表非空作对照，证明并非查询机制整体失效
-    EXPECT_EQ(movieFormats.size(), 0);
-    EXPECT_FALSE(LibUnionImage_NameSpace::supportStaticFormat().isEmpty());
 }
 
 TEST_F(FreeUnionImageTest, UnionImageSupportFormat_QueryMergedTable_MatchesStaticFormat)


### PR DESCRIPTION
Fix shared fixed-name temp file in scaleImage; dead branch and mismatched datetime formats in metadata read/write; redundant guard in getCreateDateTime; env value containing = dropped in cache path; search-scheme check in isVaultFile; trash-name probe base and missing separator; duplicate openUrl in showInFileManager; lost bReturn flag in SpliteText recursion; unreachable gphoto2 Apple branch; missing erroMsg on null image; remove never-populated supportMovieFormat.

修复 imageutils/baseutils/unionimage 共 12 项扫描缺陷。

Log: 修复 unionimage 基础库 12 项缺陷
Influence: 移除恒空 supportMovieFormat 导出函数，行为变化已同步单测断言；单测 1131/1131 通过

## Summary by Sourcery

Resolve defects across unionimage base utilities and align the public API and tests with the corrected behavior.

Bug Fixes:
- Fix image scaling temporary-file collisions, preserve cache paths containing equals signs, correctly identify vault and Apple camera paths, and provide missing rotation errors.
- Correct trash filename probing, text-splitting recursion, metadata timestamp handling, and duplicate file-manager launches.

Enhancements:
- Remove the unused movie-format support API and its unpopulated backing state.

Tests:
- Update unit tests and coverage expectations for corrected behavior, including trash collisions, metadata formats, cache paths, URL schemes, path classification, and error reporting.

Chores:
- Refresh SPDX copyright years.