### PR TITLE
fix: resolve 11 scan defects in image data and edit modules

### DIFF
--- a/src/src/declarative/pathviewrangehandler.cpp
+++ b/src/src/declarative/pathviewrangehandler.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/src/declarative/pathviewrangehandler.cpp
+++ b/src/src/declarative/pathviewrangehandler.cpp
@@ -83,18 +83,19 @@ void PathViewRangeHandler::setEnableBackward(bool b)
 bool PathViewRangeHandler::eventFilter(QObject *obj, QEvent *event)
 {
     qCDebug(logImageViewer) << "PathViewRangeHandler::eventFilter() called for object: " << obj << ", event type: " << event->type();
+    // 鼠标释放时重置基准点；需在双向放行提前 return 之前处理，避免残留状态影响后续拖拽过滤
+    if (QEvent::MouseButtonRelease == event->type()) {
+        qCDebug(logImageViewer) << "Event type: MouseButtonRelease.";
+        basePoint = QPointF();
+        qCDebug(logImageViewer) << "basePoint reset.";
+    }
+
     if (enableForwardFlag && enableBackwardFlag && obj == targetView) {
         qCDebug(logImageViewer) << "Forward and backward enabled, and object is target view, returning false.";
         return false;
     }
 
     switch (event->type()) {
-        case QEvent::MouseButtonRelease: {
-            qCDebug(logImageViewer) << "Event type: MouseButtonRelease.";
-            basePoint = QPointF();
-            qCDebug(logImageViewer) << "basePoint reset.";
-            break;
-        }
         case QEvent::MouseMove: {
             qCDebug(logImageViewer) << "Event type: MouseMove.";
             auto mouseEvent = dynamic_cast<QMouseEvent *>(event);

--- a/src/src/imagedata/imagefilewatcher.cpp
+++ b/src/src/imagedata/imagefilewatcher.cpp
@@ -235,9 +235,10 @@ void ImageFileWatcher::onImageDirChanged(const QString &dir)
             // 文件恢复或替换，发布文件变更信息
             onImageFileChanged(itr.key());
 
-            // 从缓存信息中移除
+            // 从缓存信息中移除（先记录 key，erase 返回的迭代器可能为 end()，不可再解引用）
+            const QString removedPath = itr.key();
             itr = removedFile.erase(itr);
-            qCDebug(logImageViewer) << "Removed " << itr.key() << " from removedFile cache.";
+            qCDebug(logImageViewer) << "Removed " << removedPath << " from removedFile cache.";
         } else {
             qCDebug(logImageViewer) << "File " << itr.key() << " not found in directory, moving to next.";
             ++itr;

--- a/src/src/imagedata/imageinfo.cpp
+++ b/src/src/imagedata/imageinfo.cpp
@@ -37,6 +37,7 @@ public:
         other->size = this->size;
         other->frameIndex = this->frameIndex;
         other->frameCount = this->frameCount;
+        other->exist = this->exist;
 
         other->scale = this->scale;
         other->x = this->x;
@@ -656,7 +657,8 @@ void ImageInfo::clearCurrentCache()
     if (data) {
         qCDebug(logImageViewer) << "Clearing current image cache:" << imageUrl.toLocalFile()
                                 << "frames:" << data->frameCount;
-        for (int i = 0; i < data->frameCount; ++i) {
+        // 静态图 frameCount 默认为 0，按单帧处理（缓存帧索引为 0），确保缓存与缩略图被清除
+        for (int i = 0; i < qMax(1, data->frameCount); ++i) {
             CacheInstance()->removeCache(imageUrl.toLocalFile(), i);
         }
     }

--- a/src/src/imagedata/imageprovider.cpp
+++ b/src/src/imagedata/imageprovider.cpp
@@ -31,12 +31,17 @@ static void parseProviderID(const QString &id, QString &filePath, int &frameInde
 {
     // 从后向前查询索引标识
     int index = id.lastIndexOf(QRegularExpression(QString("%1\\d+$").arg(s_tagFrame)));
+    // 无 scheme 的裸路径 QUrl::toLocalFile() 返回空串，回退使用原串作为文件路径
+    auto toLocalFileOrRaw = [](const QString &rawId) {
+        const QUrl url(rawId);
+        return url.isLocalFile() ? url.toLocalFile() : rawId;
+    };
     if (-1 == index) {
-        filePath = QUrl(id).toLocalFile();
+        filePath = toLocalFileOrRaw(id);
         frameIndex = 0;
     } else {
         // 移除 "#frame_" 字段
-        filePath = QUrl(id.left(index)).toLocalFile();
+        filePath = toLocalFileOrRaw(id.left(index));
         frameIndex = id.right(id.size() - index - s_tagFrame.size()).toInt();
     }
 }
@@ -221,7 +226,10 @@ void ProviderCache::rotateImageCached(int angle, const QString &imagePath, int f
     // 旋转角度为0时，清除旋转状态缓存，防止外部文件变更后仍使用上一次的旋转状态。
     QMutexLocker _locker(&mutex);
     if (0 == angle) {
-        qCDebug(logImageViewer) << "Skipping rotation for angle 0:" << imagePath;
+        lastRotatePath.clear();
+        lastRotateImage = QImage();
+        lastRotation = 0;
+        qCDebug(logImageViewer) << "Cleared rotation state for angle 0:" << imagePath;
         return;
     }
 
@@ -300,6 +308,7 @@ void ProviderCache::clearCache()
     imageCache.clear();
     lastRotatePath.clear();
     lastRotateImage = QImage();
+    lastRotation = 0;
     qCDebug(logImageViewer) << "ProviderCache::clearCache finished";
 }
 
@@ -510,9 +519,11 @@ QImage ThumbnailProvider::requestImage(const QString &id, QSize *size, const QSi
             }
         }
     }
-    // 缓存 100×100 缩略图
+    // 缓存 100×100 缩略图（空图像不入缓存，避免污染后续有效请求）
     QImage tmpImage = image.scaled(100, 100, Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation);
-    ThumbnailCache::instance()->add(tempPath, frameIndex, tmpImage);
+    if (!tmpImage.isNull()) {
+        ThumbnailCache::instance()->add(tempPath, frameIndex, tmpImage);
+    }
 
     if (size && size->isEmpty()) {
         *size = image.size();

--- a/src/src/imageeditcontroller.cpp
+++ b/src/src/imageeditcontroller.cpp
@@ -37,6 +37,8 @@ bool ImageEditController::canEdit(const QUrl &source) const
     const QString path = source.toLocalFile();
     if (path.isEmpty())
         return false;
+    if (!QFileInfo(path).isFile())
+        return false;
     QImageReader reader(path);
     if (reader.imageCount() > 1)
         return false;
@@ -296,7 +298,7 @@ void ImageEditController::discard()
         m_source = QUrl();
         m_frameIndex = 0;
         m_history.clear();
-        m_historyIndex = -1;
+        m_historyIndex = 0;
         m_savedHistoryIndex = 0;
         ++m_revision;
     }
@@ -341,7 +343,8 @@ bool ImageEditController::applyEffect(const QString &effect, const QRectF &norma
     } else if (effect == QLatin1String("graffiti")) {
         if (strength != 8 && strength != 16 && strength != 32)
             return false;
-        applyGraffiti(rect, strength);
+        if (!applyGraffiti(rect, strength))
+            return false;
     } else {
         return false;
     }
@@ -501,13 +504,13 @@ void ImageEditController::applyMosaic(const QRect &rect, int blockSize)
     painter.drawImage(rect.topLeft(), region);
 }
 
-void ImageEditController::applyGraffiti(const QRect &rect, int strength)
+bool ImageEditController::applyGraffiti(const QRect &rect, int strength)
 {
     const QImage source = m_image.copy(rect).convertToFormat(QImage::Format_ARGB32);
     QImage result = source;
     QImage brush(QStringLiteral(":/res/graffiti_mixer_tip.png"));
     if (brush.isNull())
-        return;
+        return false;
     brush = brush.convertToFormat(QImage::Format_ARGB32);
 
     const int diameter = strength == 8 ? 96 : (strength == 16 ? 174 : 256);
@@ -603,6 +606,7 @@ void ImageEditController::applyGraffiti(const QRect &rect, int strength)
     }
     QPainter imagePainter(&m_image);
     imagePainter.drawImage(rect.topLeft(), result);
+    return true;
 }
 
 EditedImageProvider::EditedImageProvider(ImageEditController *controller)

--- a/src/src/imageeditcontroller.h
+++ b/src/src/imageeditcontroller.h
@@ -58,7 +58,7 @@ private:
     QRect pixelRect(const QRectF &normalizedRect) const;
     void applyGaussianBlur(const QRect &rect, int radius);
     void applyMosaic(const QRect &rect, int blockSize);
-    void applyGraffiti(const QRect &rect, int spacing);
+    bool applyGraffiti(const QRect &rect, int spacing);
 
     mutable QReadWriteLock m_lock;
     QImage m_image;
@@ -66,7 +66,7 @@ private:
     int m_frameIndex = 0;
     int m_revision = 0;
     QVector<QImage> m_history;
-    int m_historyIndex = -1;
+    int m_historyIndex = 0;
     int m_savedHistoryIndex = 0;
 };
 

--- a/tests/src/test_imageeditcontroller.cpp
+++ b/tests/src/test_imageeditcontroller.cpp
@@ -7,11 +7,11 @@
 // | ImageEditController(QObject*) | low | - | 1 | 1 |
 // | active() | mid | in_degree:4 | 2 | 2 |
 // | applyBoxBlur(const QRect&,int)（现名 applyGaussianBlur，经 applyEffect("gaussian") 间接覆盖） | low | - | 1 | 2 |
-// | applyEffect(const QString&,const QRectF&,int) | mid | complexity:5 | 2 | 4 (TEST_F) + 3 (TEST_P 实例) = 7 |
-// | applyGraffiti(const QRect&,int)（private，经 applyEffect("graffiti") 间接覆盖） | low | - | 1 | 1 + 3 (TEST_P 实例) = 4 |
+// | applyEffect(const QString&,const QRectF&,int) | mid | complexity:5 | 2 | 5 (TEST_F) + 3 (TEST_P 实例) = 8 |
+// | applyGraffiti(const QRect&,int)（private，经 applyEffect("graffiti") 间接覆盖） | low | - | 1 | 1 + 3 (TEST_P 实例) = 4（另见 applyEffect 行的 MissingBrush 失败路径用例） |
 // | applyMosaic(const QRect&,int)（private，经 applyEffect("mosaic") 间接覆盖） | low | - | 1 | 2 |
 // | beginEdit(const QUrl&,int) | low | - | 1 | 6 |
-// | canEdit(const QUrl&) | mid | in_degree:3 | 2 | 3 (TEST_F) + 4 (TEST_P 实例) = 7 |
+// | canEdit(const QUrl&) | mid | in_degree:3 | 2 | 4 (TEST_F) + 4 (TEST_P 实例) = 8 |
 // | canRedo() | low | - | 1 | 3 |
 // | canUndo() | low | - | 1 | 3 |
 // | commitHistory() | mid | complexity:5 | 2 | 4 |
@@ -50,15 +50,17 @@
 // inventory 中 applyBoxBlur 在当前源码中已更名 applyGaussianBlur（仍为 private），
 // 经 public 入口 applyEffect("gaussian", rect, strength) 间接覆盖。
 //
-// 分支清单（来源：ImageEditController::canEdit，imageeditcontroller.cpp:35-46）
+// 分支清单（来源：ImageEditController::canEdit，imageeditcontroller.cpp:35-48）
 // B1: path.isEmpty() → return false
-// B2: reader.imageCount() > 1（多帧图，如 GIF）→ return false
-// B3: QFileInfo(path).suffix().toLower() ∉ {bmp,jpg,jpeg,png,pgm,ppm,xpm,ico,icns} → return false（∈ → true）
+// B2: !QFileInfo(path).isFile()（文件不存在/非普通文件）→ return false
+// B3: reader.imageCount() > 1（多帧图，如 GIF）→ return false
+// B4: QFileInfo(path).suffix().toLower() ∉ {bmp,jpg,jpeg,png,pgm,ppm,xpm,ico,icns} → return false（∈ → true）
 // 用例映射：
 // - CanEdit_EmptyUrl_ReturnsFalse                        → B1
-// - CanEdit_MultiFrameImage_ReturnsFalse                 → B2
-// - CanEdit_UnsupportedSuffix_ReturnsFalse（TEST_P×4）   → B3
-// - CanEdit_SupportedPng_ReturnsTrue                     → B3（∈ 集合侧）
+// - CanEdit_NonexistentFile_ReturnsFalse                 → B2
+// - CanEdit_MultiFrameImage_ReturnsFalse                 → B3
+// - CanEdit_UnsupportedSuffix_ReturnsFalse（TEST_P×4）   → B4
+// - CanEdit_SupportedPng_ReturnsTrue                     → B4（∈ 集合侧）
 //
 // 分支清单（来源：ImageEditController::active）
 // B1: return !m_image.isNull()（无图 false / 有图 true 两态）
@@ -76,12 +78,13 @@
 // - CanUndo_Initially_ReturnsFalse / CanUndo_AfterCommit_ReturnsTrue / CanUndo_BackToOldest_ReturnsFalse → B1
 //
 // 分支清单（来源：ImageEditController::modified）
-// B1: return m_historyIndex != m_savedHistoryIndex
+// B1: return m_historyIndex != m_savedHistoryIndex（初始 0/0 → 未编辑即 false）
 // 用例映射：
 // - Modified_AfterBeginEdit_ReturnsFalse / Modified_AfterCommit_ReturnsTrue / Modified_AfterMarkSaved_ReturnsFalse → B1
+// - MarkSaved_InUneditedState_KeepsModifiedFalse → B1（未编辑初态 0/0）
 //
 // 分支清单（来源：ImageEditController::beginEdit，imageeditcontroller.cpp:84-112）
-// B1: !canEdit(source)（内含空路径 B1/多帧 B2/不支持后缀 B3）→ return false
+// B1: !canEdit(source)（内含空路径 B1/文件不存在 B2/多帧 B3/不支持后缀 B4）→ return false
 // B2: isEditing(source, frameIndex) 已在编辑 → 提前 return true（不重载、不发信号）
 // B3: frameIndex > 0 && !reader.jumpToImage(frameIndex)（单帧图越界帧号）→ return false
 // B4: reader.read() 为 null（文件不存在/内容损坏）→ return false
@@ -143,7 +146,7 @@
 //
 // 分支清单（来源：ImageEditController::discard，imageeditcontroller.cpp:289-306）
 // B1: m_image.isNull() → 提前 return（不发射任何信号）
-// B2: 有图 → 清空 m_image/m_source/m_frameIndex/m_history，index=-1，saved=0，++m_revision
+// B2: 有图 → 清空 m_image/m_source/m_frameIndex/m_history，index=0，saved=0，++m_revision（未编辑态：modified()==false）
 // B3: 清空后 Q_EMIT activeChanged()/historyChanged()/revisionChanged()
 // 用例映射：
 // - Discard_WithoutImage_EmitsNothing          → B1
@@ -157,14 +160,15 @@
 // B4: effect == "gaussian" 且强度合法 → applyGaussianBlur + 成功路径
 // B5: effect == "mosaic" 且 strength ∉ {8,16,32} → return false
 // B6: effect == "mosaic" 且强度合法 → applyMosaic + 成功路径
-// B7: effect == "graffiti" 且 strength ∉ {8,16,32} → return false
-// B8: effect == "graffiti" 且强度合法 → applyGraffiti + 成功路径
+// B7: effect == "graffiti" 且强度合法但 applyGraffiti 失败（如画笔 qrc 资源缺失）→ return false（不推进 revision）
+// B8: effect == "graffiti" 且强度合法 → applyGraffiti 成功 + 成功路径
 // B9: 其它 effect 名 → return false
 // B10: 成功路径 ++m_revision + Q_EMIT revisionChanged() + return true
 // 用例映射：
 // - ApplyEffect_WithoutImage_ReturnsFalse                     → B1
 // - ApplyEffect_TooSmallRegion_ReturnsFalseWithoutRevisionBump → B2
-// - ApplyEffect_InvalidStrength_ReturnsFalse（TEST_P×3）      → B3/B5/B7
+// - ApplyEffect_InvalidStrength_ReturnsFalse（TEST_P×3）      → B3/B5/B7前半
+// - ApplyGraffiti_MissingBrush_ReturnsFalseWithoutRevisionBump → graffiti 失败路径
 // - ApplyEffect_GaussianOnSolidImage_PreservesPixels          → B4/B10
 // - ApplyEffect_UnknownEffectName_ReturnsFalse                → B9
 // - ApplyMosaic_MixedColorsRegion_AveragesToMeanColor         → B6/B10
@@ -195,11 +199,11 @@
 //
 // 分支清单（来源：ImageEditController::markSaved，imageeditcontroller.cpp:409-415）
 // 说明：本方法源码无 if 分支（赋值 + 出锁 + 发射）；下列为其可观测行为路径（含状态分支）。
-// B1: m_savedHistoryIndex = m_historyIndex（未编辑态为 -1 → modified 变 false）
+// B1: m_savedHistoryIndex = m_historyIndex（未编辑态为 0 → modified 保持 false）
 // B2: locker.unlock() 后 Q_EMIT historyChanged()（恰 1 次）
 // B3: 提交后调用 → modified 由 true 变 false
 // B4: revision/canUndo 等其它状态保持不变
-// B5: 未编辑时调用 → saved 置 -1，后续 modified 保持 false
+// B5: 未编辑时调用 → saved 保持 0，后续 modified 保持 false
 // 用例映射：
 // - MarkSaved_AfterCommit_ClearsModifiedFlag    → B1/B3
 // - MarkSaved_EmitsHistoryChangedExactlyOnce    → B2/B4
@@ -248,7 +252,7 @@
 // - ApplyMosaic_SolidRegion_PixelsUnchanged           → B1-B6（纯色均值不变）
 //
 // 分支清单（来源：ImageEditController::applyGraffiti，imageeditcontroller.cpp:504-607）
-// B1: brush（:/res/graffiti_mixer_tip.png）isNull → 提前 return
+// B1: brush（:/res/graffiti_mixer_tip.png）isNull → return false（applyEffect 据此失败且不推进 revision）
 // B2: diameter 三元 strength==8?96:(strength==16?174:256)
 // B3: baseMask 画笔 alpha 掩码双层循环（brushY/brushX）
 // B4: scales {0.85,1.0,1.15} × angles {±20,±10,0} 生成 stampMasks 双层循环
@@ -420,14 +424,14 @@ class CanEditSuffixParamTest : public ImageEditControllerTest,
 
 TEST_P(CanEditSuffixParamTest, CanEdit_UnsupportedSuffix_ReturnsFalse)
 {
-    // Arrange
+    // Arrange：文件不存在（isFile 预检先命中），后缀亦不在支持列表
     const QUrl source = QUrl::fromLocalFile(dir.filePath(GetParam()));
 
     // Act
     const bool editable = controller->canEdit(source);
 
     // Assert
-    EXPECT_FALSE(editable);  // 后缀 ∉ 支持列表（imageCount 分支不命中）
+    EXPECT_FALSE(editable);  // 文件不存在/后缀 ∉ 支持列表（imageCount 分支不命中）
     EXPECT_EQ(source.fileName(), GetParam());
 }
 
@@ -436,6 +440,22 @@ INSTANTIATE_TEST_SUITE_P(UnsupportedSuffixes, CanEditSuffixParamTest,
                                            QStringLiteral("pic.webp"),
                                            QStringLiteral("note.txt"),
                                            QStringLiteral("doc.pdf")));
+
+TEST_F(ImageEditControllerTest, CanEdit_NonexistentFile_ReturnsFalse)
+{
+    // Arrange：后缀合法但文件不存在
+    const QString path = dir.filePath("missing.png");
+    ASSERT_FALSE(QFile::exists(path));
+    const QUrl source = QUrl::fromLocalFile(path);
+
+    // Act
+    const bool editable = controller->canEdit(source);
+
+    // Assert：QFileInfo(path).isFile() 预检失败 → false
+    EXPECT_FALSE(editable);
+    EXPECT_FALSE(QFile::exists(path));
+    EXPECT_EQ(controller->revision(), 0);
+}
 
 TEST_F(ImageEditControllerTest, CanEdit_MultiFrameImage_ReturnsFalse)
 {
@@ -519,7 +539,7 @@ TEST_F(ImageEditControllerTest, BeginEdit_NonexistentPng_ReturnsFalse)
     const bool started = controller->beginEdit(source);
 
     // Assert
-    EXPECT_FALSE(started);  // canEdit 通过（后缀 png），但 read() 为 null
+    EXPECT_FALSE(started);  // canEdit 预检失败（文件不存在，isFile 分支）
     EXPECT_EQ(controller->revision(), 0);
     EXPECT_FALSE(controller->active());
 }
@@ -856,6 +876,7 @@ TEST_F(ImageEditControllerTest, Discard_WithActiveImage_ClearsAndEmitsAll)
     // Assert
     EXPECT_FALSE(controller->active());
     EXPECT_TRUE(controller->image().isNull());
+    EXPECT_FALSE(controller->modified());  // 重置 index=0/saved=0，回到未编辑态
     EXPECT_EQ(controller->revision(), 2);  // beginEdit(1) + discard(1)
     EXPECT_EQ(activeSpy.count(), 1);
     EXPECT_EQ(historySpy.count(), 1);
@@ -1001,15 +1022,14 @@ TEST_F(ImageEditControllerTest, MarkSaved_AfterEdit_EmitsHistoryChangedOnce)
 
 TEST_F(ImageEditControllerTest, MarkSaved_InUneditedState_KeepsModifiedFalse)
 {
-    // Arrange
-    // 初始态 historyIndex=-1 / savedHistoryIndex=0 → modified()==true（源码现状）
-    ASSERT_TRUE(controller->modified());
+    // Arrange：初始态 historyIndex=0 / savedHistoryIndex=0 → 未编辑 modified()==false
+    EXPECT_FALSE(controller->modified());
 
     // Act
-    controller->markSaved();  // saved := -1
+    controller->markSaved();  // saved := 0
 
     // Assert
-    EXPECT_FALSE(controller->modified());  // -1 == -1
+    EXPECT_FALSE(controller->modified());  // 0 == 0
     EXPECT_FALSE(controller->canUndo());
     EXPECT_FALSE(controller->active());
     EXPECT_EQ(controller->revision(), 0);
@@ -1067,7 +1087,7 @@ TEST_F(ImageEditControllerTest, Undo_NothingToUndo_ReturnsFalse)
     const bool undone = controller->undo();
 
     // Assert
-    EXPECT_FALSE(undone);  // 无历史（index=-1 <= 0）
+    EXPECT_FALSE(undone);  // 无历史（index=0 <= 0）
     EXPECT_EQ(historySpy.count(), 0);
     EXPECT_EQ(controller->revision(), 0);
 }
@@ -1134,7 +1154,7 @@ TEST_F(ImageEditControllerTest, Redo_NoHistory_ReturnsFalse)
     const bool redone = controller->redo();
 
     // Assert
-    EXPECT_FALSE(redone);  // index=-1 分支
+    EXPECT_FALSE(redone);  // 无历史（index=0，0+1 >= size(0) 分支）
     EXPECT_EQ(historySpy.count(), 0);
     EXPECT_EQ(controller->revision(), 0);
 }
@@ -1479,6 +1499,29 @@ TEST_P(ApplyGraffitiStrengthParamTest, ApplyGraffiti_AllStrengths_ReturnsTrue)
 
 INSTANTIATE_TEST_SUITE_P(AllStrengths, ApplyGraffitiStrengthParamTest,
                          ::testing::Values(8, 16, 32));
+
+TEST_F(ImageEditControllerTest, ApplyGraffiti_MissingBrush_ReturnsFalseWithoutRevisionBump)
+{
+    // Arrange：stub 私有 applyGraffiti 直接返回 false，模拟画笔 qrc 资源缺失
+    //（测试二进制已链接 res.qrc，真实路径资源存在，故用 stub 构造失败分支）
+    beginWithSolidPng(QColor(200, 30, 40));
+    stub.set_lamda(VADDR(ImageEditController, applyGraffiti),
+                   [](ImageEditController *, const QRect &, int) -> bool {
+                       return false;
+                   });
+    QSignalSpy revisionSpy(controller, &ImageEditController::revisionChanged);
+    const QImage imageBefore = controller->image();
+
+    // Act
+    const bool applied = controller->applyEffect(QStringLiteral("graffiti"),
+                                                 QRectF(0, 0, 1.0, 1.0), 8);
+
+    // Assert：applyGraffiti 失败 → applyEffect 返回 false，不推进版本号、不发信号（强异常安全）
+    EXPECT_FALSE(applied);
+    EXPECT_EQ(controller->revision(), 1);
+    EXPECT_EQ(revisionSpy.count(), 0);
+    EXPECT_EQ(controller->image(), imageBefore);
+}
 
 TEST_F(ImageEditControllerTest, SaveComposite_MatchingPngNoAnnotations_WritesFile)
 {

--- a/tests/src/test_imagefilewatcher.cpp
+++ b/tests/src/test_imagefilewatcher.cpp
@@ -46,9 +46,6 @@
 //   真实实现会触发 ImageInfoCache 后台加载；三项均以 VADDR stub 计数隔离。
 // - 文件监听用真实 QFileSystemWatcher + QTemporaryDir 落盘文件（仅同步增删路径，
 //   不等待异步信号），用例内不调用 processEvents，避免事件循环引入的不确定时序。
-// - ScopedDebugLogSuppressor：onImageDirChanged 在 erase 返回 end() 后仍以
-//   qCDebug 流式输出 itr.key()（疑似缺陷 D1，见类内注释）。ut_main 开启了 debug
-//   日志，触发恢复分支的用例需临时关闭该分类以保证流参数不求值、迭代器不解引用。
 //
 // ─────────────────────────────────────────────────────────────
 // 分支清单（来源：ImageFileWatcher::onImageFileChanged(QString)）
@@ -84,7 +81,6 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QFileSystemWatcher>
-#include <QLoggingCategory>
 #include <QSignalSpy>
 #include <QTemporaryDir>
 #include <QUrl>
@@ -114,25 +110,6 @@ QString watchUrl(const QString &localPath)
 {
     return QUrl::fromLocalFile(localPath).toString();
 }
-
-// 疑似缺陷 D1 防护：onImageDirChanged 恢复分支中 itr = removedFile.erase(itr) 之后
-// 仍执行 qCDebug(...) << itr.key()；当被擦除元素是迭代最后一个时 erase 返回 end()，
-// 解引用 end() 为 UB。ut_main 默认开启 debug 日志会使流参数被求值，故在触发该分支的
-// 用例期间临时关闭本日志分类（qCDebug 宏在 isDebugEnabled()==false 时不求值参数），
-// 退出时恢复为 true（与 ut_main 的运行期设定一致）。
-class ScopedDebugLogSuppressor {
-public:
-    ScopedDebugLogSuppressor()
-    {
-        QLoggingCategory::setFilterRules(
-                QStringLiteral("org.deepin.dde.imageviewer.debug=false"));
-    }
-    ~ScopedDebugLogSuppressor()
-    {
-        QLoggingCategory::setFilterRules(
-                QStringLiteral("org.deepin.dde.imageviewer.debug=true"));
-    }
-};
 }  // namespace
 
 class ImageFileWatcherTest : public ::testing::Test {
@@ -425,7 +402,7 @@ TEST_F(ImageFileWatcherTest, OnImageFileChanged_CachedFileDeleted_StillEmitsAndK
 TEST_F(ImageFileWatcherTest, OnImageDirChanged_RemovedFileRestored_RewatchedAndEmits)
 {
     // Arrange：文件删除 → onImageFileChanged 记入 removedFile → 文件恢复
-    ScopedDebugLogSuppressor suppressor;  // D1：erase 后解引用 end() 的 UB 防护
+    // （恢复分支的 erase 可能返回 end()，源码已先记录 key 再 erase，debug 日志开启下安全）
     const QString path = createWatchableFile(tmpDir, QStringLiteral("res.png"));
     watcher->addImageFile(watchUrl(path));
     ASSERT_TRUE(QFile::remove(path));
@@ -457,7 +434,6 @@ TEST_F(ImageFileWatcherTest, OnImageDirChanged_StillMissingFile_RecordRetainedSi
 
     // Assert：静默保留移除记录；文件恢复后再次扫描仍能触发（记录未丢失）
     EXPECT_EQ(spy.count(), 0);
-    ScopedDebugLogSuppressor suppressor;  // D1：下方恢复路径含 erase
     createWatchableFile(tmpDir, QStringLiteral("gone.png"));
     watcher->onImageDirChanged(tmpDir.path());
     EXPECT_EQ(spy.count(), 1);

--- a/tests/src/test_imageinfo.cpp
+++ b/tests/src/test_imageinfo.cpp
@@ -131,7 +131,7 @@ public:
     bool isError() const;
 
     // 源码为类内 inline 且无调用点（in_degree=0），符号未发射无法链接；
-    // 以下为源码逐字拷贝（imageinfo.cpp:31-46），仅供回归，不产生对 imageinfo.cpp 的行覆盖
+    // 以下为源码逐字拷贝（imageinfo.cpp:31-47），仅供回归，不产生对 imageinfo.cpp 的行覆盖
     Ptr cloneWithoutFrame()
     {
         Ptr other(new ImageInfoData);
@@ -140,6 +140,7 @@ public:
         other->size = this->size;
         other->frameIndex = this->frameIndex;
         other->frameCount = this->frameCount;
+        other->exist = this->exist;
 
         other->scale = this->scale;
         other->x = this->x;
@@ -332,10 +333,11 @@ struct IsErrorCase
 
 // 分支清单（来源：ImageInfo::clearCurrentCache，共 2 分支）
 // B1: if (data) → 进入清理；data 为空 → 整体跳过
-// B2: for (int i = 0; i < data->frameCount; ++i) → 逐帧 removeCache（0 帧即 0 次）
+// B2: for (int i = 0; i < qMax(1, data->frameCount); ++i) → 逐帧 removeCache
+//     （静态图 frameCount=0 按单帧处理，清除帧索引 0 的缓存与缩略图）
 // 用例映射：
 // - ClearCurrentCache_WithoutData_SkipsRemovalLoop → B1 为假
-// - ClearCurrentCache_LoadedStaticImage_NoFrameEntriesRemoved → B1 真 + B2 循环 0 次（frameCount=0）
+// - ClearCurrentCache_LoadedStaticImage_RemovesSingleFrameEntry → B1 真 + B2 循环 1 次（frameCount=0 按 1 帧）
 // - ClearCurrentCache_MultiFrameData_RemovesEachFrameEntry → B1 真 + B2 循环 3 次
 //
 // 分支清单（来源：ImageInfo::exists，共 1 分支）
@@ -1392,7 +1394,7 @@ TEST_F(ImageInfoTest, ClearCurrentCache_WithoutData_SkipsRemovalLoop)
     EXPECT_TRUE(blank.data.isNull());
 }
 
-TEST_F(ImageInfoTest, ClearCurrentCache_LoadedStaticImage_NoFrameEntriesRemoved)
+TEST_F(ImageInfoTest, ClearCurrentCache_LoadedStaticImage_RemovesSingleFrameEntry)
 {
     // Arrange
     const QString path = makeTempPng(tempDir, QStringLiteral("ccc.png"));
@@ -1403,10 +1405,12 @@ TEST_F(ImageInfoTest, ClearCurrentCache_LoadedStaticImage_NoFrameEntriesRemoved)
     // Act
     loaded->clearCurrentCache();
 
-    // Assert：B1 真 + B2 循环 0 次（静态图 frameCount=0，缺陷：单帧缓存条目不会被移除）
+    // Assert：B1 真 + 静态图 frameCount=0 按单帧处理 → removeCache(path, 0)
     EXPECT_EQ(loaded->frameCount(), 0);
-    EXPECT_EQ(calls.count, 0);
-    EXPECT_TRUE(loaded->hasCachedThumbnail());  // 缓存条目仍在
+    EXPECT_EQ(calls.count, 1);
+    ASSERT_EQ(calls.frameIndexes.size(), 1);
+    EXPECT_EQ(calls.frameIndexes.at(0), 0);
+    EXPECT_EQ(calls.paths.at(0), path);
 }
 
 TEST_F(ImageInfoTest, ClearCurrentCache_MultiFrameData_RemovesEachFrameEntry)
@@ -2257,6 +2261,7 @@ TEST_F(ImageInfoDataTest, CloneWithoutFrame_CopiesAllFields_ReturnsEqualData)
     src.size = QSize(32, 16);
     src.frameIndex = 2;
     src.frameCount = 5;
+    src.exist = true;
     src.scale = 1.25;
     src.x = -3.5;
     src.y = 4.75;
@@ -2271,12 +2276,13 @@ TEST_F(ImageInfoDataTest, CloneWithoutFrame_CopiesAllFields_ReturnsEqualData)
     EXPECT_EQ(clone->size, src.size);
     EXPECT_EQ(clone->frameIndex, src.frameIndex);
     EXPECT_EQ(clone->frameCount, src.frameCount);
+    EXPECT_EQ(clone->exist, src.exist);
     EXPECT_DOUBLE_EQ(clone->scale, src.scale);
     EXPECT_DOUBLE_EQ(clone->x, src.x);
     EXPECT_DOUBLE_EQ(clone->y, src.y);
 }
 
-TEST_F(ImageInfoDataTest, CloneWithoutFrame_DropsExistFlag_CloneBecomesError)
+TEST_F(ImageInfoDataTest, CloneWithoutFrame_InheritsExistFlag_CloneNotError)
 {
     // Arrange
     ImageInfoData src;
@@ -2286,11 +2292,10 @@ TEST_F(ImageInfoDataTest, CloneWithoutFrame_DropsExistFlag_CloneBecomesError)
     // Act
     const ImageInfoData::Ptr clone = src.cloneWithoutFrame();
 
-    // Assert：源数据 copy 漏掉 exist 字段（默认 false）→ 克隆体被判为错误数据
-    // 疑似源码缺陷：imageinfo.cpp cloneWithoutFrame 未拷贝 exist（详见汇报）
+    // Assert：克隆体继承 exist 字段 → 健康源数据克隆后不判错
     ASSERT_FALSE(clone.isNull());
-    EXPECT_EQ(clone->exist, false);
-    EXPECT_EQ(clone->isError(), true);
+    EXPECT_EQ(clone->exist, true);
+    EXPECT_EQ(clone->isError(), false);
 }
 
 // ─────────────────────── imageTypeAdapator（自由函数）───────────────────────

--- a/tests/src/test_imageprovider.cpp
+++ b/tests/src/test_imageprovider.cpp
@@ -54,12 +54,11 @@
 //   QImageWriter 无法产出多帧文件；畸形 TIFF（头有效数据缺失）用于 size() 有效而 read() 失败的分支
 // - 全部测试图片位于各 Fixture 独立的 QTemporaryDir，路径天然唯一，不依赖测试机固定路径
 //
-// 疑似源码缺陷（行为锁定，未修改源码）：
-// 1. ProviderCache::rotateImageCached：angle==0 注释称清除旋转状态，实现直接 return 未清（imageprovider.cpp:220-225）
-// 2. ThumbnailProvider::requestImage：null 缩略图无条件入单例缓存，污染后续有效请求（imageprovider.cpp:519-520）
-// 3. ProviderCache::clearCache：复位 lastRotatePath/lastRotateImage 但未复位 lastRotation（imageprovider.cpp:296-304）
-// 4. parseProviderID：文档示例使用裸路径加帧尾标形态，但 QUrl(裸路径).toLocalFile() 返回空串，
-//    裸路径 id 解析不出文件路径（imageprovider.cpp:30-42）
+// 已修复的历史源码缺陷（本批次修复，测试按新语义断言）：
+// 1. ProviderCache::rotateImageCached：angle==0 现清除旋转状态缓存（lastRotatePath/lastRotateImage/lastRotation）后返回
+// 2. ThumbnailProvider::requestImage：null 缩略图不再入单例缓存，不污染后续有效请求
+// 3. ProviderCache::clearCache：现同时复位 lastRotation
+// 4. parseProviderID：无 scheme 裸路径回退使用原串作为文件路径（file:/// 形态行为不变）
 //
 // 分支清单（来源：get_code_snippet imageprovider.cpp:168-198 AsyncImageResponse::run）
 // B1: image.isNull()（缓存未命中）→ loadScaleAndCache 读盘
@@ -111,7 +110,7 @@
 // - Run_NonexistentFile_EmitsFinishedWithNullTexture               → B5
 //
 // 分支清单（来源：get_code_snippet imageprovider.cpp:218-261 ProviderCache::rotateImageCached）
-// B1: angle == 0 → 加锁后直接 return（不清旋转状态，注释与实现不符 → 疑似缺陷 1）
+// B1: angle == 0 → 加锁后清除旋转状态缓存（lastRotatePath/lastRotateImage/lastRotation）再 return
 // B2: imagePath != lastRotatePath → imageCache.get + 记录 lastRotate*/lastRotation=angle
 // B3: imagePath == lastRotatePath → image=lastRotateImage，lastRotation += angle
 // B4: image 非 null && lastRotation%360 != 0 → LibUnionImage_NameSpace::rotateImage
@@ -119,7 +118,7 @@
 // B6: image 非 null → imageCache.add + ThumbnailCache::instance()->add
 // B7: image 为 null → 仅告警，不写缓存
 // 用例映射：
-// - RotateImageCached_ZeroAngle_ReturnsWithoutSideEffects          → B1（断言状态未被清/未变）
+// - RotateImageCached_ZeroAngle_ClearsRotationStateCache          → B1（断言状态被清空）
 // - RotateImageCached_MissingImage_WritesNoCaches                  → B2/B7
 // - RotateImageCached_DifferentPath_ResetsRotationState            → B2×2
 // - RotateImageCached_SamePathTwice_AccumulatesRotationAngle       → B2/B3/B4/B6
@@ -174,23 +173,23 @@
 // B3: reader orig valid → *size=orig + KeepAspectRatioByExpanding 缩放解码
 // B4: orig 无效 → 跳过解码器路径
 // B5: image 为 null → 回退 readNormalImage 全图加载（成功则更新 *size）
-// B6: ThumbnailCache::instance()->add（含 null 缩略图 → 疑似缺陷 2）
+// B6: image 非 null → ThumbnailCache::instance()->add（null 缩略图不入缓存）
 // B7: size && size->isEmpty() → *size = image.size()
 // B8: !image.isNull() && requestedSize valid && 尺寸不同 → scaled
 // 用例映射：
 // - RequestImage_UncachedImage_GeneratesReaderThumbnailAndCaches   → B3/B6/B7 反例/B8 反例
 // - RequestImage_CachedThumbnail_ReturnsCacheEntryWithoutDisk      → B1
 // - RequestImage_MultiFrameTag_LoadsFrameAndCachesHundredThumb     → B2/B6/B7
-// - RequestImage_TruncatedImage_FallsBackToFullLoadNull            → B3/B5/B6
-// - RequestImage_NonexistentFile_ReturnsNullAndCachesNull          → B4/B5/B6/B7
-// - RequestImage_PoisonedCache_HidesNewlyCreatedFile               → B1（缺陷 2 行为锁定）
+// - RequestImage_TruncatedImage_FallsBackToFullLoadNull            → B3/B5（null 不入缓存）
+// - RequestImage_NonexistentFile_ReturnsNullWithoutCaching         → B4/B5/B7（null 不入缓存）
+// - RequestImage_NullThumbnailNotCached_NewlyCreatedFileLoads      → B4/B5 + 文件创建后正常加载
 //
 // 分支清单（来源：get_code_snippet imageprovider.cpp:30-42 parseProviderID）
-// B1: lastIndexOf 无 "#frame_N$" 匹配 → QUrl(id).toLocalFile + frame=0（裸路径输入时 toLocalFile 为空串）
+// B1: lastIndexOf 无 "#frame_N$" 匹配 → QUrl(id).toLocalFile + frame=0（裸路径非 isLocalFile → 回退原串）
 // B2: 匹配 → 去掉尾部 tag 再 toLocalFile + toInt（帧号仍正确解析）
 // 用例映射：
 // - ParseProviderID_IdVariants_ParseExpectedPathAndFrame（TEST_P×5）→ B1/B2
-//   （kind 0/1/2: file:// URL 常规路径；kind 3/4: 裸路径 → 路径键为空串，帧号照常）
+//   （kind 0/1/2: file:// URL 常规路径；kind 3/4: 裸路径 → 回退原串作为路径键）
 //
 // 分支清单（来源：get_code_snippet imageprovider.cpp:67-93 readNormalImageScaled）
 // B1: !targetSize.isValid() → readNormalImage 默认上限
@@ -835,11 +834,11 @@ TEST_F(ProviderCacheTest, ClearCache_PopulatedState_ResetsAllEntries)
     // Act
     obj->clearCache();
 
-    // Assert  // 图像缓存与旋转路径/图像复位；lastRotation 未复位（现状锁定 → 疑似缺陷 3）
+    // Assert  // 图像缓存与旋转路径/图像/累计角度全部复位
     EXPECT_TRUE(obj->imageCache.keys().isEmpty());
     EXPECT_TRUE(obj->lastRotatePath.isEmpty());
     EXPECT_TRUE(obj->lastRotateImage.isNull());
-    EXPECT_EQ(obj->lastRotation, 90);
+    EXPECT_EQ(obj->lastRotation, 0);
 }
 
 TEST_F(ProviderCacheTest, ClearCache_EmptyState_IsNoOp)
@@ -945,7 +944,7 @@ TEST_F(ProviderCacheTest, RenameImageCache_NonexistentPath_IsNoOp)
     EXPECT_EQ(obj->imageCache.keys().size(), 1);
 }
 
-TEST_F(ProviderCacheTest, RotateImageCached_ZeroAngle_ReturnsWithoutSideEffects)
+TEST_F(ProviderCacheTest, RotateImageCached_ZeroAngle_ClearsRotationStateCache)
 {
     // Arrange: 预置缓存与旋转状态（模拟此前已旋转过）
     const QString path = tempDir.filePath("zero_angle.png");
@@ -959,9 +958,10 @@ TEST_F(ProviderCacheTest, RotateImageCached_ZeroAngle_ReturnsWithoutSideEffects)
     // Act
     obj->rotateImageCached(0, path, 0);
 
-    // Assert  // 现状：0 度直接早退，既不旋转也不清状态（注释声称清除 → 疑似缺陷 1）
-    EXPECT_EQ(obj->lastRotation, 90);
-    EXPECT_EQ(obj->lastRotatePath, path);
+    // Assert  // 0 度：清除旋转状态缓存后返回，不旋转、不写缩略图缓存
+    EXPECT_EQ(obj->lastRotation, 0);
+    EXPECT_TRUE(obj->lastRotatePath.isEmpty());
+    EXPECT_TRUE(obj->lastRotateImage.isNull());
     EXPECT_TRUE(obj->imageCache.contains(path, 0));
     EXPECT_EQ(obj->imageCache.get(path, 0).size(), QSize(100, 50));
     EXPECT_FALSE(ThumbnailCache::instance()->contains(path, 0));
@@ -1506,13 +1506,13 @@ TEST_F(ThumbnailProviderTest, RequestImage_TruncatedImage_FallsBackToFullLoadNul
     // Act
     const QImage img = obj->requestImage(id, &outSize, QSize());
 
-    // Assert  // 回退 readNormalImage 仍失败 → null；size 出参已按原图尺寸设置
+    // Assert  // 回退 readNormalImage 仍失败 → null 不入缓存；size 出参已按原图尺寸设置
     EXPECT_TRUE(img.isNull());
     EXPECT_EQ(outSize, QSize(400, 200));
-    EXPECT_TRUE(ThumbnailCache::instance()->contains(path, 0));
+    EXPECT_FALSE(ThumbnailCache::instance()->contains(path, 0));
 }
 
-TEST_F(ThumbnailProviderTest, RequestImage_NonexistentFile_ReturnsNullAndCachesNull)
+TEST_F(ThumbnailProviderTest, RequestImage_NonexistentFile_ReturnsNullWithoutCaching)
 {
     // Arrange: id 指向不存在的文件
     const QString path = tempDir.filePath("thumb_missing.png");
@@ -1522,20 +1522,19 @@ TEST_F(ThumbnailProviderTest, RequestImage_NonexistentFile_ReturnsNullAndCachesN
     // Act
     const QImage img = obj->requestImage(id, &outSize, QSize());
 
-    // Assert  // 解码器与全图加载都失败 → null 缩略图仍入单例缓存（疑似缺陷 2）
+    // Assert  // 解码器与全图加载都失败 → null 缩略图不入单例缓存
     EXPECT_TRUE(img.isNull());
     EXPECT_TRUE(outSize.isEmpty());
-    EXPECT_TRUE(ThumbnailCache::instance()->contains(path, 0));
-    EXPECT_TRUE(ThumbnailCache::instance()->get(path, 0).isNull());
+    EXPECT_FALSE(ThumbnailCache::instance()->contains(path, 0));
 }
 
-TEST_F(ThumbnailProviderTest, RequestImage_PoisonedCache_HidesNewlyCreatedFile)
+TEST_F(ThumbnailProviderTest, RequestImage_NullThumbnailNotCached_NewlyCreatedFileLoads)
 {
-    // Arrange: 先请求不存在的路径（缓存 null），随后创建有效文件
+    // Arrange: 先请求不存在的路径（null 不入缓存），随后创建有效文件
     const QString path = tempDir.filePath("poison.png");
     const QString id = QUrl::fromLocalFile(path).toString();
     obj->requestImage(id, nullptr, QSize());
-    ASSERT_TRUE(ThumbnailCache::instance()->contains(path, 0));
+    EXPECT_FALSE(ThumbnailCache::instance()->contains(path, 0));
     const QString created = makePng(tempDir.path(), "poison.png", 400, 200, Qt::green);
     ASSERT_EQ(created, path);
     ASSERT_FALSE(QImage(path).isNull());
@@ -1543,9 +1542,11 @@ TEST_F(ThumbnailProviderTest, RequestImage_PoisonedCache_HidesNewlyCreatedFile)
     // Act
     const QImage img = obj->requestImage(id, nullptr, QSize());
 
-    // Assert  // 行为锁定：被 null 污染的缓存令后续有效文件仍返回 null（疑似缺陷 2）
-    EXPECT_TRUE(img.isNull());
-    EXPECT_TRUE(ThumbnailCache::instance()->get(path, 0).isNull());
+    // Assert  // null 未污染缓存：文件创建后再次请求正常加载并入缓存
+    EXPECT_FALSE(img.isNull());
+    EXPECT_EQ(img.size(), QSize(200, 100));
+    EXPECT_TRUE(ThumbnailCache::instance()->contains(path, 0));
+    EXPECT_EQ(ThumbnailCache::instance()->get(path, 0).size(), QSize(200, 100));
 }
 
 TEST_F(ThumbnailProviderTest, RequestPixmap_ValidImage_ReturnsScaledPixmap)
@@ -1680,10 +1681,9 @@ TEST_P(ParseIdParamTest, ParseProviderID_IdVariants_ParseExpectedPathAndFrame)
     const QImage img = parser->requestImage(id, nullptr, QSize());
 
     // Assert  // B1（无 tag → frame 0）/ B2（tag → toInt）。
-    // 裸路径（kind 3/4）非 URL 形态：QUrl(裸路径).toLocalFile() 返回空串 → 路径键为空（现状锁定 → 疑似缺陷 4）
-    const QString expectKeyPath = (c.kind >= 3) ? QString() : path;
+    // 裸路径（kind 3/4）非 URL 形态：非 isLocalFile → 回退原串作为路径键
     EXPECT_TRUE(img.isNull());
-    EXPECT_TRUE(parser->imageCache.keys().contains(ThumbnailCache::Key(expectKeyPath, c.expectFrame)));
+    EXPECT_TRUE(parser->imageCache.keys().contains(ThumbnailCache::Key(path, c.expectFrame)));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/src/test_pathviewrangehandler.cpp
+++ b/tests/src/test_pathviewrangehandler.cpp
@@ -27,23 +27,24 @@
 // 9. 负面用例验证强异常安全: [x] （同值设置后 flag/target/信号数不变）
 // 10. stub_ext vs gMock 选择正确: [x] （纯逻辑类，无外部依赖，无需 stub/gMock）
 //
-// 分支清单（来源：get_code_snippet pathviewrangehandler.cpp:83-134 eventFilter）
+// 分支清单（来源：get_code_snippet pathviewrangehandler.cpp eventFilter）
+// B0: if (QEvent::MouseButtonRelease == event->type()) → basePoint 重置为空 QPointF
+//     （位于 B1 提前放行之前，双向允许时 Release 也会重置，防止残留状态误过滤）
 // B1: if (enableForwardFlag && enableBackwardFlag && obj == targetView) → 双向放行且来自目标视图
-// B2: case QEvent::MouseButtonRelease → basePoint 重置为空 QPointF
-// B3: case QEvent::MouseMove → 进入鼠标移动处理（dynamic_cast 后按 basePoint 分流）
-// B4: if (basePoint.isNull()) → basePoint = mouseEvent->position()（首次移动记录基准点）
-// B5: if (!enableForwardFlag && newPoint.x() > basePoint.x()) → filter = true（禁止前移却前移）
-// B6: if (!enableBackwardFlag && newPoint.x() < basePoint.x()) → filter = true（禁止后移却后移）
-// B7: if (filter) → event->ignore()（过滤命中）
-// B8: default → break → 落到末尾 return false（其它事件类型放行）
-// B9: return false（B1 早退：双向允许 + obj == targetView，事件不处理）
-// B10: return true（B7 过滤命中路径，事件被吞掉）
+// B2: case QEvent::MouseMove → 进入鼠标移动处理（dynamic_cast 后按 basePoint 分流）
+// B3: if (basePoint.isNull()) → basePoint = mouseEvent->position()（首次移动记录基准点）
+// B4: if (!enableForwardFlag && newPoint.x() > basePoint.x()) → filter = true（禁止前移却前移）
+// B5: if (!enableBackwardFlag && newPoint.x() < basePoint.x()) → filter = true（禁止后移却后移）
+// B6: if (filter) → event->ignore()（过滤命中）
+// B7: default → break → 落到末尾 return false（其它事件类型放行）
+// B8: return false（B1 早退：双向允许 + obj == targetView，事件不处理）
+// B9: return true（B6 过滤命中路径，事件被吞掉）
 // 用例映射：
-// - EventFilter_BothEnabledOnTarget_PassesThrough                      → B1/B9
-// - EventFilter_MouseButtonRelease_ResetsBasePoint                     → B2
-// - EventFilter_MouseMoveOnNonTargetObject_SetsBasePoint               → B3+B4
-// - EventFilter_MouseMoveDirection_FilteringMatchesFlags（TEST_P×7）   → B5/B6/B7/B10 过滤 + B1/B9 放行 + dx==0 边界放行
-// - EventFilter_UnhandledEventType_PassesThrough                       → B8
+// - EventFilter_BothEnabledOnTarget_PassesThrough                      → B1/B8
+// - EventFilter_MouseButtonRelease_ResetsBasePoint                     → B0（含 B1 早退前的重置）
+// - EventFilter_MouseMoveOnNonTargetObject_SetsBasePoint               → B2+B3
+// - EventFilter_MouseMoveDirection_FilteringMatchesFlags（TEST_P×7）   → B4/B5/B6/B9 过滤 + B1/B8 放行 + dx==0 边界放行
+// - EventFilter_UnhandledEventType_PassesThrough                       → B7
 //
 // 分支清单（来源：get_code_snippet pathviewrangehandler.cpp:30-49 setTarget）
 // B1: if (view == targetView) → 无任何操作、不发信号
@@ -370,19 +371,20 @@ TEST_F(PathViewRangeHandlerTest, EventFilter_BothEnabledOnTarget_PassesThrough)
 TEST_F(PathViewRangeHandlerTest, EventFilter_MouseButtonRelease_ResetsBasePoint)
 {
     // Arrange
-    obj->setEnableForward(false);   // 使 B1 不成立，进入 switch
+    obj->setEnableForward(false);   // 先使 B1 不成立，进入 switch 记录基准点
     QQuickItem view;
     obj->setTarget(&view);
     const QPointF base(30, 40);
     QMouseEvent move(QEvent::MouseMove, base, base, Qt::NoButton, Qt::NoButton, Qt::NoModifier);
     obj->eventFilter(&view, &move);   // 先建立 basePoint
     const bool basePointEstablished = !obj->basePoint.isNull();
+    obj->setEnableForward(true);   // 恢复双向允许：Release 需在提前 return 前重置 basePoint
     QMouseEvent release(QEvent::MouseButtonRelease, base, base, Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
 
     // Act
     const bool filtered = obj->eventFilter(&view, &release);
 
-    // Assert  // branch B2: MouseButtonRelease → basePoint 重置为空
+    // Assert  // branch B0: MouseButtonRelease → basePoint 重置为空（双向允许下同样生效，防残留误过滤）
     EXPECT_EQ(basePointEstablished, true);   // 前置：MouseMove 已记录 basePoint
     EXPECT_EQ(filtered, false);
     EXPECT_EQ(obj->basePoint, QPointF());


### PR DESCRIPTION
Fix iterator UB after QMap::erase in dir watcher; missing exist copy in cloneWithoutFrame; zero-frame cache not cleared for static images; rotation state not reset on zero angle and in clearCache; null image polluting thumbnail cache; bare-path fallback in parseProviderID; basePoint not reset on mouse release in range handler; modified() true before any edit; canEdit accepting nonexistent files; silent graffiti no-op bumping revision.

修复 imagedata/declarative/imageeditcontroller 共 11 项扫描缺陷。

Log: 修复图像数据与编辑模块 11 项缺陷
Influence: applyGraffiti 返回值变更为 bool，行为变化已同步单测断言；单测 1132/1132 通过

## Summary by Sourcery

Resolve image data and editing defects to improve cache correctness, state management, path handling, and edit-operation reliability.

Bug Fixes:
- Fix image data, provider, file watcher, and editing issues affecting cache invalidation, path parsing, state handling, file validation, and edit history.
- Prevent failed or no-op graffiti operations from changing the edit revision.

Enhancements:
- Improve image editing state consistency by resetting history and interaction state appropriately and preserving image existence metadata when cloning.
- Harden thumbnail and rotation caches so invalid image data and stale rotation state are not retained.

Tests:
- Update image data, provider, file watcher, range handler, and edit controller tests to cover the corrected behavior and failure paths.