### PR TITLE
fix: resolve 16 scan defects in ocr print dbus and misc utils

### DIFF
--- a/src/src/commandparser.cpp
+++ b/src/src/commandparser.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -13,6 +13,7 @@
 Q_DECLARE_LOGGING_CATEGORY(logImageViewer)
 
 CommandParser::CommandParser(QObject *parent)
+    : QObject(parent)
 {
     qCDebug(logImageViewer) << "CommandParser constructor called.";
     initialize();

--- a/src/src/cursortool.cpp
+++ b/src/src/cursortool.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -32,7 +32,7 @@ CursorTool::CursorTool(QObject *parent)
     });
     qCDebug(logImageViewer) << "Connected CaptureTimer timeout signal.";
 
-    connect(Dtk::Gui::DGuiApplicationHelper::instance(), &Dtk::Gui::DGuiApplicationHelper::applicationPaletteChanged, [this]() {
+    connect(Dtk::Gui::DGuiApplicationHelper::instance(), &Dtk::Gui::DGuiApplicationHelper::applicationPaletteChanged, this, [this]() {
         auto newColor = Dtk::Gui::DGuiApplicationHelper::instance()->applicationPalette().highlight().color();
         emit activeColorChanged(newColor);
         qCDebug(logImageViewer) << "Application palette changed, emitting activeColorChanged with new color.";

--- a/src/src/dbus/applicationadpator.cpp
+++ b/src/src/dbus/applicationadpator.cpp
@@ -21,8 +21,10 @@ bool ApplicationAdaptor::openImageFile(const QString &fileName)
 {
     if (fileControl) {
         const QUrl inputUrl(fileName);
-        const QString localPath = inputUrl.isLocalFile() ? inputUrl.toLocalFile() : fileName;
-        const QString urlPath = QUrl::fromLocalFile(localPath).toString();
+        const QUrl normalizedUrl = inputUrl.isLocalFile()
+                ? QUrl::fromLocalFile(inputUrl.toLocalFile())
+                : inputUrl;
+        const QString urlPath = normalizedUrl.toString();
         if (fileControl->isCanReadable(urlPath) && fileControl->isImage(urlPath)) {
             Q_EMIT fileControl->openImageFile(urlPath);
             return true;

--- a/src/src/ocr/livetextanalyzer.cpp
+++ b/src/src/ocr/livetextanalyzer.cpp
@@ -7,6 +7,7 @@
 #include <QVariant>
 #include <QApplication>
 #include <QScreen>
+#include <QThread>
 
 #include <deepin-ocr-plugin-manager/deepinocrplugindef.h>
 #include <deepin-ocr-plugin-manager/deepinocrplugin.h>
@@ -16,7 +17,7 @@
 
 Q_DECLARE_LOGGING_CATEGORY(logImageViewer)
 
-LiveTextAnalyzer::LiveTextAnalyzer(QObject *parent)
+LiveTextAnalyzer::LiveTextAnalyzer()
     : QQuickImageProvider(Image),
       ocrDriver(new DeepinOCRPlugin::DeepinOCRDriver)
 {
@@ -73,7 +74,8 @@ void LiveTextAnalyzer::analyze(const QString &token)
     // 外部调用的时候也凭借收到的token判断是否采用此次的识别结果
     // 以此来解决QML的信号延迟问题，但仅降低此问题的复现概率，没有完全解决
     QtConcurrent::run([this, token]() {
-        while (ocrDriver->isRunning()) { };   // 等待之前的分析结束
+        while (ocrDriver->isRunning())
+            QThread::msleep(1);   // 等待之前的分析结束
         bool result = ocrDriver->analyze();
         qCDebug(logImageViewer) << "OCR analysis completed with token:" << token << "result:" << result;
         emit analyzeFinished(result, token);
@@ -116,6 +118,10 @@ QVariant LiveTextAnalyzer::charBox(int blockIndex) const
 
     auto boxes = ocrDriver->getCharBoxes(static_cast<size_t>(blockIndex));
     qCDebug(logImageViewer) << "Getting character boxes for block:" << blockIndex << "count:" << boxes.size();
+    if (boxes.empty()) {
+        qCWarning(logImageViewer) << "No character boxes for block:" << blockIndex;
+        return QVariant();
+    }
 
     QList<QVariant> result;
 
@@ -148,7 +154,12 @@ QString LiveTextAnalyzer::textResult(int blockIndex, int startIndex, int len) co
 QImage LiveTextAnalyzer::requestImage(const QString &id, QSize *size, const QSize &requestedSize)
 {
     auto startIndex = id.indexOf("_") + 1;
-    size_t index = id.mid(startIndex).toUInt();
+    bool ok = false;
+    size_t index = id.mid(startIndex).toUInt(&ok);
+    if (!ok) {
+        qCWarning(logImageViewer) << "Invalid text box id:" << id;
+        return QImage();
+    }
 
     if (index >= ocrDriver->getTextBoxes().size()) {
         qCWarning(logImageViewer) << "Invalid text box index:" << index;

--- a/src/src/ocr/livetextanalyzer.h
+++ b/src/src/ocr/livetextanalyzer.h
@@ -16,7 +16,7 @@ class LiveTextAnalyzer : public QQuickImageProvider
 {
     Q_OBJECT
 public:
-    explicit LiveTextAnalyzer(QObject *parent = nullptr);
+    explicit LiveTextAnalyzer();
     ~LiveTextAnalyzer();
     Q_INVOKABLE void setImage(const QImage &image);
 

--- a/src/src/ocr/ocrinterface.h
+++ b/src/src/ocr/ocrinterface.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -33,7 +33,6 @@ public:
     */
     OcrInterface(const QString &serviceName, const QString &ObjectPath,
                  const QDBusConnection &connection, QObject *parent = nullptr);
-    QDBusConnection dbus = QDBusConnection::sessionBus();
     ~OcrInterface();
 
 public Q_SLOTS: // METHODS
@@ -61,6 +60,8 @@ public Q_SLOTS: // METHODS
         if (image.save(&buf, "PNG")) {
             data = qCompress(data, 9);
             data = data.toBase64();
+        } else {
+            qWarning() << __FUNCTION__ << "failed to save image to buffer, size:" << image.size();
         }
         return call(QStringLiteral("openImage"), QVariant::fromValue(data));
     }
@@ -80,6 +81,8 @@ public Q_SLOTS: // METHODS
         if (image.save(&buf, "PNG")) {
             data = qCompress(data, 9);
             data = data.toBase64();
+        } else {
+            qWarning() << __FUNCTION__ << "failed to save image:" << imageName;
         }
         return call(QStringLiteral("openImageAndName"), QVariant::fromValue(data), imageName);
     }

--- a/src/src/printdialog/printhelper.cpp
+++ b/src/src/printdialog/printhelper.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -23,13 +23,18 @@ Q_DECLARE_LOGGING_CATEGORY(logImageViewer)
 
 PrintHelper *PrintHelper::m_Printer = nullptr;
 
-PrintHelper *PrintHelper::getIntance()
+PrintHelper *PrintHelper::getInstance()
 {
     if (!m_Printer) {
         qCDebug(logImageViewer) << "Creating new PrintHelper instance";
         m_Printer = new PrintHelper();
     }
     return m_Printer;
+}
+
+PrintHelper *PrintHelper::getIntance()
+{
+    return getInstance();
 }
 
 PrintHelper::PrintHelper(QObject *parent)
@@ -116,6 +121,7 @@ void PrintHelper::showPrintDialog(const QStringList &paths, QWidget *parent)
                 imgReadreder.jumpToImage(imgindex);
                 m_re->m_imgs << imgReadreder.read();
             }
+            tempExsitPaths << path;
         } else {
             qCDebug(logImageViewer) << "Loading single image:" << path;
             // QImage不应该多次赋值，所以换到这里来，修复style问题
@@ -124,11 +130,11 @@ void PrintHelper::showPrintDialog(const QStringList &paths, QWidget *parent)
             if (!img.isNull()) {
                 qCDebug(logImageViewer) << "Loaded single image:" << path << "size:" << img.size();
                 m_re->m_imgs << img;
+                tempExsitPaths << path;
             } else {
                 qCWarning(logImageViewer) << "Failed to load image:" << path << "error:" << errMsg;
             }
         }
-        tempExsitPaths << paths;
     }
 
     // 看图采用同步,因为只有一张图片
@@ -162,8 +168,8 @@ void PrintHelper::showPrintDialog(const QStringList &paths, QWidget *parent)
 }
 
 RequestedSlot::RequestedSlot(QObject *parent)
+    : QObject(parent)
 {
-    Q_UNUSED(parent)
     qCDebug(logImageViewer) << "RequestedSlot instance created";
 }
 
@@ -190,7 +196,7 @@ void RequestedSlot::paintRequestSync(DPrinter *_printer)
             ratio = wRect.width() * 1.0 / img.width();
             if (qreal(wRect.height() - img.height() * ratio) > 0) {
                 qCDebug(logImageViewer) << "Fitting image to width, ratio:" << ratio;
-                painter.drawImage(QRectF(0, abs(qreal(wRect.height() - img.height() * ratio)) / 2,
+                painter.drawImage(QRectF(0, qAbs(qreal(wRect.height() - img.height() * ratio)) / 2,
                                          wRect.width(), img.height() * ratio),
                                   img);
             } else {

--- a/src/src/printdialog/printhelper.h
+++ b/src/src/printdialog/printhelper.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -30,6 +30,7 @@ class PrintHelper : public QObject
     Q_OBJECT
 
 public:
+    static PrintHelper *getInstance();
     static PrintHelper *getIntance();
     ~PrintHelper();
 

--- a/src/src/utils/filetrashhelper.cpp
+++ b/src/src/utils/filetrashhelper.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -212,8 +212,10 @@ bool FileTrashHelper::isExternalDevice(const QString &path)
 {
     qCDebug(logImageViewer) << "Checking if path is on external device:" << path;
     for (auto itr = mountDevices.begin(); itr != mountDevices.end(); ++itr) {
-        if (path.startsWith(itr.value())) {
-            qCDebug(logImageViewer) << "Path is on external device:" << itr.value();
+        const QString &mount = itr.value();
+        // 严格匹配挂载点路径边界，避免 /x/usb_backup 被误判为挂载于 /x/usb
+        if (mount == path || path.startsWith(mount + "/")) {
+            qCDebug(logImageViewer) << "Path is on external device:" << mount;
             return true;
         }
     }

--- a/src/src/utils/rotateimagehelper.cpp
+++ b/src/src/utils/rotateimagehelper.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -95,6 +95,16 @@ void RotateImageHelper::rotateImageFile(const QString &path, int angle)
     totalAngle += angle;
     totalAngle %= 360;
     qCDebug(logImageViewer) << "Updated total rotation angle for" << path << "to" << totalAngle << "degrees";
+
+    // 累计角度归零时无实际旋转需求，不再入队执行无效旋转，
+    // 按成功补发与 rotateImageImpl 正常路径相同的信号序列，保证接收方状态一致
+    if (0 == totalAngle) {
+        qCDebug(logImageViewer) << "Skipping rotation for accumulated 0 degrees:" << path;
+        Q_EMIT recordRotateImage(path);
+        Q_EMIT clearRotateStatus(path);
+        Q_EMIT rotateImageFinished(path, true);
+        return;
+    }
 
     if (data->watcher.isRunning()) {
         qCDebug(logImageViewer) << "Watcher is running, adding or updating task in queue.";

--- a/tests/src/test_applicationadpator.cpp
+++ b/tests/src/test_applicationadpator.cpp
@@ -32,8 +32,8 @@
 // ─────────────────────────────────────────────────────────────
 // ApplicationAdaptor::openImageFile(const QString &fileName)
 // B1: fileControl == nullptr                          → 跳过全部检查 return false
-// B2: inputUrl.isLocalFile() ? toLocalFile() : fileName（三元）→ file:// URL 走 toLocalFile，
-//     裸路径/相对路径/空串/远程 URL 原样作为 localPath，再经 fromLocalFile 归一化为 file: 形态
+// B2: inputUrl.isLocalFile() ? fromLocalFile(toLocalFile()) : inputUrl（三元）→ file:// URL
+//     解包再封包归一化；其余输入（裸路径/相对路径/空串/远程 URL）原样保留，不折叠为 file: 形态
 // B3: !fileControl->isCanReadable(urlPath)（&& 短路）  → return false，isImage 不被调用
 // B4: isCanReadable && !isImage                       → return false，不发射信号
 // B5: isCanReadable && isImage                        → Q_EMIT openImageFile(urlPath) return true
@@ -41,8 +41,9 @@
 //        ApplicationAdaptor_ConstructWithNullController_NoParentAttached          → ctor(空)
 //        OpenImageFile_NullController_ReturnsFalseWithoutControllerChecks         → B1
 //        OpenImageFile_VariousInputs_ReturnsExpected (TEST_P)                     → B2/B3/B4/B5
-//   其中参数组：file-url+ok→B5；裸绝对路径→B2(假)+B5；相对路径→B2(假)+B5；
-//              空串→B2(假)+B5(退化归一化)；远程 URL→B2(假)+B5；
+//   其中参数组：file-url+ok→B2(真)+B5；裸绝对路径→B2(假)+B5（原样透传）；
+//              相对路径→B2(假)+B5（原样透传）；空串→B2(假)+B5（空串往返）；
+//              远程 URL→B2(假)+B5（不折叠，生产 isCanReadable 会拒绝远程）；
 //              不可读→B3(短路)；可读非图像→B4
 
 #include <gtest/gtest.h>
@@ -239,14 +240,15 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(
         // B2(真) + B5：file:// URL 解包再封包，url 原样往返
         OpenFileCase{"file:///virtual/pic.png", true, true, true, "file:///virtual/pic.png", 1, 1},
-        // B2(假) + B5：裸绝对路径归一化为 file:// 形态（Qt6 实测 QUrl(裸路径).isLocalFile()==false）
-        OpenFileCase{"/virtual/pic.png", true, true, true, "file:///virtual/pic.png", 1, 1},
-        // B2(假) + B5：相对路径归一化为 "file:pic.png"（无斜杠，Qt6 实测）
-        OpenFileCase{"pic.png", true, true, true, "file:pic.png", 1, 1},
-        // B2(假) + B5：空串边界——fromLocalFile("") 退化为空串
+        // B2(假) + B5：裸绝对路径原样透传（QUrl(裸路径).isLocalFile()==false，Qt6 实测）
+        OpenFileCase{"/virtual/pic.png", true, true, true, "/virtual/pic.png", 1, 1},
+        // B2(假) + B5：相对路径原样透传
+        OpenFileCase{"pic.png", true, true, true, "pic.png", 1, 1},
+        // B2(假) + B5：空串边界——QUrl("") 往返仍为空串
         OpenFileCase{"", true, true, true, "", 1, 1},
-        // B2(假) + B5：远程 URL 被折叠为 file: 前缀形态（现状行为锚定）
-        OpenFileCase{"http://media.host/pic.png", true, true, true, "file:http://media.host/pic.png", 1, 1},
+        // B2(假) + B5：远程 URL 不再折叠为 file: 伪 URL，原样透传
+        //（生产 isCanReadable 对非本地 URL 的 toLocalFile 为空，会拒绝远程）
+        OpenFileCase{"http://media.host/pic.png", true, true, true, "http://media.host/pic.png", 1, 1},
         // B3：isCanReadable 短路失败，isImage 不被调用、不发信号
         OpenFileCase{"file:///virtual/pic.png", false, false, false, "file:///virtual/pic.png", 0, 0},
         // B4：可读但非图像，不发信号

--- a/tests/src/test_commandparser.cpp
+++ b/tests/src/test_commandparser.cpp
@@ -4,7 +4,7 @@
 // 用例计数声明（self-check-structural 验证此块）：
 // | method | level | factors | min | actual |
 // |--------|-------|---------|-----|--------|
-// | CommandParserCtor | low | - | 1 | 1 |
+// | CommandParserCtor | low | - | 1 | 2 |
 // | instance | low | - | 1 | 1 |
 // | initialize | low | - | 1 | 1 |
 // | initOptions | low | - | 1 | 1 |
@@ -105,6 +105,22 @@ protected:
 // ═══════════════════════════════════════════════════════════════
 
 // ─── 构造 / instance / initialize / initOptions ───
+
+TEST_F(CommandParserTest, CommandParser_WithParent_LinksToParentObject)
+{
+    // Arrange：栈上父对象（SetUp 的 obj 以 nullptr 构造，不参与本用例）
+    QObject parent;
+
+    // Act
+    CommandParser *child = new CommandParser(&parent);
+
+    // Assert：parent 形参经初始化列表传入基类 QObject，父子关系建立；
+    // 构造路径 initialize/initOptions 仍正常执行
+    EXPECT_EQ(child->parent(), &parent);
+    EXPECT_FALSE(child->isSet("print"));
+    EXPECT_TRUE(child->positionalArguments().isEmpty());
+    // parent 析构自动回收 child，无泄漏
+}
 
 TEST_F(CommandParserTest, CommandParser_FreshInstance_NoFlagSetAndNoPositionalArguments)
 {

--- a/tests/src/test_cursortool.cpp
+++ b/tests/src/test_cursortool.cpp
@@ -8,19 +8,16 @@
 //   （setCaptureCursor(true) + QTest::qWait 派发）；lambda2 由 setApplicationPalette
 //   真实发射 applicationPaletteChanged（DTK 为队列发射，需事件派发后送达））。
 //
-// ⚠️ 源码缺陷（只标红不修，见 ctor）：
-// palette lambda 的 connect 未传 this 作为 context（cursortool.cpp:33），
-// 连接生命周期挂在 DGuiApplicationHelper 单例上，CursorTool 析构后不会自动断开，
-// 之后任何 applicationPaletteChanged 发射都会以悬垂 this 调用 lambda（ASAN: heap-use-after-free）。
-// 因此本文件做两点约束规避崩溃（不掩盖缺陷本身）：
-//   1) 唯一会触发 palette 信号的用例（CursorTool_ApplicationPaletteChanged_*）置于文件首位，
-//      保证发射窗口内不存在已析构的 CursorTool；恢复原 palette 也在该用例体内、析构前完成并派发。
-//   2) 其余用例不再触碰 DTK 全局 palette（activeColor 改为 stub applicationPalette 重载）。
+// 历史缺陷已修复：palette lambda 的 connect 已传入 this 作为 context，
+// 连接生命周期随 CursorTool 析构自动断开，不再产生悬垂 this 调用
+// （回归用例 CursorTool_DestroyedInstance_IgnoresLaterPaletteChanges 覆盖；
+//   原“palette 用例必须置于文件首位”的排序规避约束已不再必要）。
+// 其余用例仍不触碰 DTK 全局 palette（activeColor 用 stub applicationPalette 重载）。
 //
 // 用例计数声明（min 按 level/factors 推导：low=1, mid=2, high=3）
 // | method            | level | factors | min | actual |
 // |-------------------|-------|---------|-----|--------|
-// | CursorTool        | low   | -       | 1   | 3      |
+// | CursorTool        | low   | -       | 1   | 4      |
 // | activeColor       | low   | -       | 1   | 1      |
 // | currentCursorPos  | low   | -       | 1   | 1      |
 // | setCaptureCursor  | mid   | -       | 2   | 2      |
@@ -46,10 +43,12 @@
 // B3: b == true  → m_CaptureTimer->start()
 // B4: b == false → m_CaptureTimer->stop()
 // ctor 内 applicationPaletteChanged lambda（cursortool.cpp:33-37）：无分支，全 body 覆盖
+//   （connect 以 this 为 context，实例析构后连接自动断开）
 // activeColor / currentCursorPos：无分支
 //
 // 用例映射：
 // - CursorTool_ApplicationPaletteChanged_EmitsActiveColorChangedWithNewHighlight → palette lambda（真实信号）
+// - CursorTool_DestroyedInstance_IgnoresLaterPaletteChanges → palette lambda（context 连接回归：析构自动断开）
 // - CursorTool_ConstructWithParent_CreatesIdleSampleTimerOwnedByTool             → ctor 方法体
 // - CursorTool_SampleTimeoutWithMovingCursor_EmitsCursorPosChangedForMovesOnly   → B1+B2（真实 QTimer 超时）
 // - ActiveColor_WithStubbedApplicationPalette_ReturnsExactHighlightColor         → activeColor 方法体
@@ -98,8 +97,6 @@ protected:
 // ═══════════════════════════════════════════════════════════════════
 
 // ── CursorTool::CursorTool 内 applicationPaletteChanged lambda（真实信号触发）──
-// ⚠️ 必须保持为本文件第一个用例：palette 信号发射窗口内不能存在已析构的
-// CursorTool（源码 connect 缺 context，析构后连接悬垂，见文件头缺陷说明）。
 
 TEST_F(CursorToolTest, CursorTool_ApplicationPaletteChanged_EmitsActiveColorChangedWithNewHighlight)
 {
@@ -121,6 +118,49 @@ TEST_F(CursorToolTest, CursorTool_ApplicationPaletteChanged_EmitsActiveColorChan
     EXPECT_EQ(tool->activeColor(), QColor(10, 200, 60));                     // 新色已生效（状态一致）
 
     // Cleanup：在 tool 析构前恢复全局 palette 并派发队列信号，避免污染单例状态
+    helper->setApplicationPalette(originalPalette);
+    QTest::qWait(200);
+}
+
+// ── ctor palette lambda 的 context 连接回归（实例析构后连接自动断开，不悬垂）──
+
+TEST_F(CursorToolTest, CursorTool_DestroyedInstance_IgnoresLaterPaletteChanges)
+{
+    // Arrange：短生命周期实例的作用域短于 DGuiApplicationHelper 单例；
+    // 存活的 SetUp tool 挂 spy 观测 palette 变化的实际到达情况
+    auto *helper = Dtk::Gui::DGuiApplicationHelper::instance();
+    const Dtk::Gui::DPalette originalPalette = helper->applicationPalette();
+    QSignalSpy spy(tool, &CursorTool::activeColorChanged);
+    ASSERT_TRUE(spy.isValid());
+
+    {
+        CursorTool shortLived;
+        QSignalSpy shortSpy(&shortLived, &CursorTool::activeColorChanged);
+        ASSERT_TRUE(shortSpy.isValid());
+
+        // Act（第一段）：短生命周期实例存活期间变更 palette，两实例连接均应送达
+        Dtk::Gui::DPalette pal = originalPalette;
+        pal.setColor(QPalette::Highlight, QColor(11, 22, 33));
+        helper->setApplicationPalette(pal);
+        QTest::qWait(300);
+
+        // Assert（第一段）：两实例各收到一次（连接正常建立）
+        ASSERT_EQ(shortSpy.count(), 1);
+        ASSERT_EQ(spy.count(), 1);
+    }   // shortLived 析构：connect 以其为 context，连接应随之自动断开
+
+    // Act（第二段）：析构后再变更 palette（修复前此处以悬垂 this 调用 lambda）
+    Dtk::Gui::DPalette pal2 = originalPalette;
+    pal2.setColor(QPalette::Highlight, QColor(44, 55, 66));
+    helper->setApplicationPalette(pal2);
+    QTest::qWait(300);
+
+    // Assert（第二段）：存活实例恰好再收一次（共 2），已析构实例不再被激活
+    //（无崩溃即回归通过，ASAN 下悬垂调用表现为 heap-use-after-free）
+    EXPECT_EQ(spy.count(), 2);
+    EXPECT_EQ(tool->activeColor(), QColor(44, 55, 66));
+
+    // Cleanup：恢复全局 palette 并派发，避免污染单例状态
     helper->setApplicationPalette(originalPalette);
     QTest::qWait(200);
 }

--- a/tests/src/test_filetrashhelper.cpp
+++ b/tests/src/test_filetrashhelper.cpp
@@ -18,7 +18,7 @@
 // 最小清单完成情况（test-code-gen §最小清单）：
 // 1. 每个公开方法 ≥ 1 用例: [x]（9/9 方法，含构造函数）
 // 2. 每个输入维度按等价类划分 ≥ 1 用例/类: [x]（路径：有效/无效/空/边界前缀；DBus 返回：成功/错误/超时/无效 URL）
-// 3. 每个等价类的边界值显式覆盖: [x]（startsWith 等值边界、gvfs 近似路径、空挂载表、空挂载点、空设备列表）
+// 3. 每个等价类的边界值显式覆盖: [x]（挂载点等值/子路径/兄弟目录前缀边界、gvfs 近似路径、空挂载表、空挂载点、空设备列表）
 // 4. 同质 ≥ 3 组用 TEST_P: [x]（isGvfsFile×6、isExternalDevice×5、removeFile×3）
 // 5. 分支清单 → 用例映射已列出: [x]（见下方分支清单，来源 MCP get_code_snippet filetrashhelper.cpp:53-303）
 // 6. 每条 if/switch/throw/early-return 有触发用例: [x]
@@ -75,9 +75,9 @@
 //
 // 分支清单（来源：FileTrashHelper::isExternalDevice，filetrashhelper.cpp:211-223）
 // B1: for 遍历 mountDevices（0 次边界 / N 次）
-// B2: path.startsWith(itr.value()) → return true
+// B2: mount == path || path.startsWith(mount + "/") → return true（挂载点路径边界严格匹配）
 // B3: 遍历结束未命中 → return false
-// → IsExternalDevice_MountTablePaths_ReturnsExpected（TEST_P：等值/子路径/不相关/前缀过匹配/空表）
+// → IsExternalDevice_MountTablePaths_ReturnsExpected（TEST_P：等值/子路径/不相关/兄弟目录前缀边界/空表）
 //
 // 分支清单（来源：FileTrashHelper::isGvfsFile，filetrashhelper.cpp:228-242）
 // B1: !url.isValid() → return false
@@ -461,8 +461,8 @@ INSTANTIATE_TEST_SUITE_P(
         FileTrashExternalCase{ QStringLiteral("usb"), QStringLiteral("usb"), true },           // 等值边界
         FileTrashExternalCase{ QStringLiteral("usb"), QStringLiteral("usb/sub/a.jpg"), true }, // 子路径命中
         FileTrashExternalCase{ QStringLiteral("usb"), QStringLiteral("other/a.jpg"), false },  // 不相关路径
-        // 前缀过匹配：源码仅用 startsBy 前缀比较，无路径边界检查，usb_backup 被误判（按实际行为断言并上报缺陷）
-        FileTrashExternalCase{ QStringLiteral("usb"), QStringLiteral("usb_backup/a.jpg"), true },
+        // 路径边界：usb_backup 为 usb 的兄弟目录而非子路径，不得误判为外部设备（已修复边界检查）
+        FileTrashExternalCase{ QStringLiteral("usb"), QStringLiteral("usb_backup/a.jpg"), false },
         FileTrashExternalCase{ QString(), QStringLiteral("other/a.jpg"), false }));   // 空挂载表（B1 0 次）
 
 // ── FileTrashHelper::moveFileToTrash ──────────────────────────────

--- a/tests/src/test_livetextanalyzer.cpp
+++ b/tests/src/test_livetextanalyzer.cpp
@@ -4,13 +4,13 @@
 // 用例计数声明（self-check-structural 验证此块）：
 // | method | level | factors | min | actual |
 // |--------|-------|---------|-----|--------|
-// | LiveTextAnalyzer(parent) | low | - | 1 | 3 |
+// | LiveTextAnalyzer() | low | - | 1 | 2 |
 // | ~LiveTextAnalyzer | low | - | 1 | 1 |
 // | setImage(image) | low | - | 1 | 3 |
 // | analyze(token) | low | - | 1 | 2 |
 // | breakAnalyze() | low | - | 1 | 2 |
 // | liveBlock() | mid | - | 2 | 2 |
-// | charBox(blockIndex) | mid | - | 2 | 5 |（2 TEST_F + TEST_P×2 实例 + 空块 1）
+// | charBox(blockIndex) | mid | - | 2 | 6 |（2 TEST_F + TEST_P×2 实例 + 空块 1 + 空字符框 1）
 // | textResult(blockIndex,startIndex,len) | low | - | 1 | 6 |（2 TEST_F + TEST_P×4 实例）
 // | requestImage(id,size,requestedSize) | low | - | 1 | 13 |（7 TEST_F + TEST_P×3×2 实例）
 // ─── actual 均不低于 min ───
@@ -35,12 +35,12 @@
 // - analyze 的 QtConcurrent 后台任务在 TearDown 先 waitForDone 再 stub.clear()，杜绝补丁窗口竞态
 // - QGuiApplication::primaryScreen 仅在"无屏构造"用例内临时 stub，TearDown 统一恢复
 //
-// 疑似源码缺陷（行为锁定，未修改源码）：
-// 1. charBox：getCharBoxes 返回空时 boxes[0].points[0] 无空检查直接访问 → UB（livetextanalyzer.cpp:117-118），
-//    无法安全编写触发用例，仅以清单标注
-// 2. 构造函数 parent 形参未转发给 QQuickImageProvider 基类，QObject 父子关系丢失（livetextanalyzer.cpp:19-24）
-// 3. analyze：`while (ocrDriver->isRunning()) { }` 忙等无睡眠，占用 CPU 且与 breakAnalyze 存在竞态窗口（livetextanalyzer.cpp:77）
-// 4. requestImage：畸形 id 经 toUInt 解析失败静默归 0，误取第 0 块而非报错（livetextanalyzer.cpp:151-152）
+// 源码缺陷修复同步（原"行为锁定"缺陷已按修复后语义改写）：
+// 1. charBox：getCharBoxes 返回空时原直接 boxes[0] 越界，现空表早退返回无效 QVariant
+//    （CharBox_EmptyCharBoxes_ReturnsInvalidVariant 覆盖）
+// 2. 构造函数 parent 形参已移除（基类 QQuickImageProvider 无 parent 槽位，原形参被丢弃）
+// 3. analyze：忙等循环体现以 QThread::msleep(1) 退让，不再空转占核
+// 4. requestImage：畸形 id 经 toUInt(&ok) 校验失败现返回空 QImage，不再静默归 0 误取第 0 块
 //
 // 分支清单（来源：get_code_snippet livetextanalyzer.cpp:19-42 LiveTextAnalyzer 构造函数）
 // B1: qApp->primaryScreen() 非空 → pixelRatio = devicePixelRatio()
@@ -49,7 +49,6 @@
 // 用例映射：
 // - LiveTextAnalyzer_FreshInstance_LoadsPluginAndHardware   → B1（offscreen 屏存在路径 + 插件/硬件调用计数）
 // - LiveTextAnalyzer_NoPrimaryScreen_KeepsUnitPixelRatio    → B2（stub primaryScreen 返回空）
-// - LiveTextAnalyzer_ParentArgument_DroppedByBase           → B1 + 缺陷 2 行为锁定
 //
 // 分支清单（来源：get_code_snippet livetextanalyzer.cpp:44-47 ~LiveTextAnalyzer）
 // 析构仅 delete ocrDriver，无分支
@@ -65,7 +64,7 @@
 // - SetImage_NullImage_ForwardsEmptyMatrix                  → B2 负面（空图 setMatrix(0,0)）
 //
 // 分支清单（来源：get_code_snippet livetextanalyzer.cpp:69-81 analyze）
-// B1: while (ocrDriver->isRunning()) 为真 → 自旋等待（0 次与 2 次迭代均覆盖）
+// B1: while (ocrDriver->isRunning()) 为真 → QThread::msleep(1) 退让等待（0 次与 2 次迭代均覆盖）
 // B2: analyze() 结果 true/false → emit analyzeFinished(result, token)
 // 用例映射：
 // - Analyze_IdleDriver_EmitsFinishedWithTrueAndToken        → B1(0 次)/B2(true)
@@ -88,13 +87,14 @@
 // 分支清单（来源：get_code_snippet livetextanalyzer.cpp:110-129 charBox）
 // B1: blockIndex >= getTextBoxes().size() → if 越界判定
 // B2: 越界早退 return QVariant()（无效值返回路径）
-// B3: 有效 → for 遍历字符框，以 boxes[0].points[0].first 为基址压入 [0, 各框 points[1].first - base]
-// 注：getCharBoxes 为空时 B3 中 boxes[0] 无检查（疑似缺陷 1）
+// B3: getCharBoxes 返回空 → 早退 return QVariant()（修复后新增分支）
+// B4: 有效 → for 遍历字符框，以 boxes[0].points[0].first 为基址压入 [0, 各框 points[1].first - base]
 // 用例映射：
-// - CharBox_ValidBlock_ReturnsOffsetsRelativeToFirstChar    → B3
-// - CharBox_LastBoundaryBlock_ReturnsOffsets                → B3（index==size-1 边界）
+// - CharBox_ValidBlock_ReturnsOffsetsRelativeToFirstChar    → B4
+// - CharBox_LastBoundaryBlock_ReturnsOffsets                → B4（index==size-1 边界）
 // - CharBox_InvalidBlockIndex_ReturnsInvalidVariant（TEST_P）→ B1/B2（负数与 ==size）
 // - CharBox_NoTextBoxes_ReturnsInvalidVariant               → B1/B2（空列表 + index 0）
+// - CharBox_EmptyCharBoxes_ReturnsInvalidVariant            → B3
 //
 // 分支清单（来源：get_code_snippet livetextanalyzer.cpp:131-145 textResult）
 // B1: blockIndex>=size || startIndex<0 || len<=0（短路或，三条件独立触发）→ 返回 ""
@@ -105,7 +105,7 @@
 // - TextResult_InvalidParams_ReturnsEmpty（TEST_P）          → B1（块越界/start 负/len 0/len 负）
 //
 // 分支清单（来源：get_code_snippet livetextanalyzer.cpp:148-174 requestImage）
-// B1: id 无 "_" → indexOf 为 -1，+1 后 mid(0) 解析整串（垃圾串 toUInt 归 0 → 疑似缺陷 4）
+// B1: id 无 "_" / 尾随垃圾 / 负数 → toUInt(&ok) 失败 → 返回空 QImage（修复后不再归 0 误取）
 // B2: index >= getTextBoxes().size() → 返回空 QImage（size 出参不写）
 // B3: 有效 → rect 坐标 × pixelRatio 后 imageCache.copy 裁剪
 // B4: size != nullptr → *size = image.size()
@@ -116,7 +116,7 @@
 // - RequestImage_WithRequestedSize_ReturnsScaled            → B3/B4/B5（3x2 缩放，*size 保持裁剪尺寸）
 // - RequestImage_NonPositiveRequestedSize_ReturnsUnscaled（TEST_P）→ B5 短路两侧/B6
 // - RequestImage_IndexOutOfRange_ReturnsNullImage           → B2
-// - RequestImage_MalformedId_FallsBackToIndexZero（TEST_P）→ B1（缺陷 4 行为锁定）
+// - RequestImage_MalformedId_ReturnsNullImage（TEST_P）      → B1（修复后语义）
 // - RequestImage_HighPixelRatio_DoublesCropRegion           → B3（ratio=2 坐标放大）
 // - RequestImage_NullSizePointer_NoCrash                    → B4 反例（size 为空不写）
 
@@ -282,20 +282,6 @@ TEST_F(LiveTextAnalyzerTest, LiveTextAnalyzer_NoPrimaryScreen_KeepsUnitPixelRati
     // Assert  // ctor B2: 无主屏时 pixelRatio 保持默认 1.0，对象仍可用
     EXPECT_EQ(noScreenObj.pixelRatio, 1.0);
     EXPECT_TRUE(noScreenObj.liveBlock().toList().isEmpty());
-}
-
-TEST_F(LiveTextAnalyzerTest, LiveTextAnalyzer_ParentArgument_DroppedByBase)
-{
-    // Arrange: 栈上父对象 + 传入 parent 构造
-    QObject parentObj;
-
-    // Act
-    LiveTextAnalyzer child(&parentObj);
-
-    // Assert  // 现状：parent 形参未转发基类，QObject 父子关系丢失（疑似缺陷 2，行为锁定）
-    EXPECT_EQ(child.parent(), nullptr);
-    EXPECT_EQ(loadDefaultPluginCount, 2);
-    ASSERT_NE(child.ocrDriver, nullptr);
 }
 
 TEST_F(LiveTextAnalyzerTest, Destructor_AfterAnalyze_DeletesDriverWithoutDamage)
@@ -555,6 +541,20 @@ TEST_F(LiveTextAnalyzerTest, CharBox_NoTextBoxes_ReturnsInvalidVariant)
     EXPECT_EQ(getCharBoxesCount, 0);
 }
 
+TEST_F(LiveTextAnalyzerTest, CharBox_EmptyCharBoxes_ReturnsInvalidVariant)
+{
+    // Arrange: 1 个文本框但字符框为空（修复前 boxes[0] 直接越界）
+    textBoxes = { makeTextBox(0.f, 0.f, 1.f, 0.f, 1.f, 1.f, 0.f, 1.f, 0.f) };
+    charBoxes.clear();
+
+    // Act
+    const QVariant result = obj->charBox(0);
+
+    // Assert  // charBox B3: 空字符框早退 → 无效 QVariant，不越界访问
+    EXPECT_FALSE(result.isValid());
+    EXPECT_EQ(getCharBoxesCount, 1);
+}
+
 // ══════════════════════════ textResult ══════════════════════════
 
 TEST_F(LiveTextAnalyzerTest, TextResult_ValidRange_ReturnsSubstring)
@@ -728,23 +728,23 @@ struct MalformedIdCase {
 struct MalformedIdParamTest : public LiveTextAnalyzerTest, public ::testing::WithParamInterface<MalformedIdCase> {
 };
 
-TEST_P(MalformedIdParamTest, RequestImage_MalformedId_FallsBackToIndexZero)
+TEST_P(MalformedIdParamTest, RequestImage_MalformedId_ReturnsNullImage)
 {
     const MalformedIdCase c = GetParam();
 
-    // Arrange: 1 框 (1,1)-(5,5)，喂畸形 id（无下划线/负数/尾随垃圾）
+    // Arrange: 1 框 (1,1)-(5,5)，喂畸形 id（无下划线/负数/尾随垃圾），size 出参预置哨兵值
     QImage source(10, 10, QImage::Format_ARGB32);
     source.fill(Qt::red);
     obj->setImage(source);
     textBoxes = { makeTextBox(1.f, 1.f, 2.f, 1.f, 5.f, 5.f, 2.f, 5.f, 0.f) };
-    QSize reported;
+    QSize reported(7, 7);
 
     // Act
     const QImage image = obj->requestImage(c.id, &reported, QSize());
 
-    // Assert  // requestImage B1: toUInt 解析失败归 0 → 等价取第 0 块（疑似缺陷 4 行为锁定）
-    EXPECT_EQ(image.size(), QSize(5, 5));
-    EXPECT_EQ(reported, QSize(5, 5));
+    // Assert  // requestImage B1: toUInt(&ok) 解析失败 → 空图早退，size 出参不被写（修复后语义）
+    EXPECT_TRUE(image.isNull());
+    EXPECT_EQ(reported, QSize(7, 7));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/src/test_ocrinterface.cpp
+++ b/tests/src/test_ocrinterface.cpp
@@ -32,17 +32,18 @@
 // - 会话总线不存在时 sessionBus() 返回断连对象，构造与断言均安全（不依赖本机 DBus 守护进程）
 // - 全部对象在 TearDown 中 stub.clear() 后释放
 //
-// 疑似源码缺陷（行为锁定，未修改源码）：
-// 1. 公有成员 `QDBusConnection dbus` 恒以 sessionBus 默认初始化，与构造参数 connection 无关且全工程未使用
-//    （ocrinterface.h:38，用 ConstructionWithNonSessionConnection 锁定）
-// 2. openImage/openImageAndName：image.save 失败时静默发送空 payload，无错误上报/早退（ocrinterface.h:60-63 / 79-82）
+// 源码缺陷修复同步（原"行为锁定"缺陷已按修复后语义改写）：
+// 1. 公有成员 `QDBusConnection dbus`（恒 sessionBus 且全工程未使用）已删除
+//    （原 ConstructionWithNonSessionConnection_KeepsSessionBusMember 行为锁定用例改写为构造绑定校验）
+// 2. openImage/openImageAndName：image.save 失败分支已补 qWarning 日志（openImageAndName 含 imageName），
+//    调用结构不变，仍发送空 payload（行为锁定用例保持有效）
 // 3. 头文件结尾注释 `#endif // DRAWINTERFACE_H` 与 `#ifndef OCRINTERFACE_H` 不匹配，为复制残留（ocrinterface.h:96，仅标注）
 //
 // 分支清单（来源：get_code_snippet ocrinterface.cpp:10-15 OcrInterface 构造函数）
 // 构造仅转发基类（serviceName/ObjectPath/staticInterfaceName()/connection/parent），无分支
 // 用例映射：
-// - OcrInterface_Construction_BindsServicePathAndInterface         → service/path/interface/connection 四元组绑定
-// - OcrInterface_ConstructionWithNonSessionConnection_KeepsSessionBusMember → 缺陷 1 行为锁定
+// - OcrInterface_Construction_BindsServicePathAndInterface              → service/path/interface/connection 四元组绑定
+// - OcrInterface_ConstructionWithNonSessionConnection_BindsGivenConnection → 非 session 连接完整转发基类
 //
 // 分支清单（来源：get_code_snippet ocrinterface.cpp:17-20 ~OcrInterface）
 // 析构仅日志，无分支
@@ -61,17 +62,17 @@
 //
 // 分支清单（来源：get_code_snippet ocrinterface.h:56-66 openImage）
 // B1: image.save(&buf,"PNG") 成功 → qCompress(9)+toBase64 后发送
-// B2: save 失败（空图等）→ data 保持空 QByteArray 直接发送
+// B2: save 失败（空图等）→ data 保持空 QByteArray 直接发送（qWarning 记录，payload 行为不变）
 // 用例映射：
 // - OpenImage_ValidImage_SendsCompressedBase64Png                  → B1（base64 解码→解压→PNG 还原逐像素对账）
-// - OpenImage_NullImage_SendsEmptyPayload                          → B2（缺陷 2 行为锁定）
+// - OpenImage_NullImage_SendsEmptyPayload                          → B2（修复后仍发送空 payload）
 //
 // 分支清单（来源：get_code_snippet ocrinterface.h:75-85 openImageAndName）
 // B1: image.save 成功 → 压缩 base64 + imageName 双参发送
-// B2: save 失败 → 空 payload + imageName 双参发送
+// B2: save 失败 → 空 payload + imageName 双参发送（qWarning 含 imageName，payload 行为不变）
 // 用例映射：
 // - OpenImageAndName_ValidImageAndName_SendsPayloadAndName         → B1
-// - OpenImageAndName_NullImage_SendsEmptyPayloadAndName            → B2（缺陷 2 行为锁定）
+// - OpenImageAndName_NullImage_SendsEmptyPayloadAndName            → B2（修复后仍发送空 payload）
 
 #include "ocrinterface.h"
 
@@ -163,18 +164,17 @@ TEST_F(OcrInterfaceTest, OcrInterface_Construction_BindsServicePathAndInterface)
     EXPECT_EQ(boundConnection, QDBusConnection::sessionBus().name());
 }
 
-TEST_F(OcrInterfaceTest, OcrInterface_ConstructionWithNonSessionConnection_KeepsSessionBusMember)
+TEST_F(OcrInterfaceTest, OcrInterface_ConstructionWithNonSessionConnection_BindsGivenConnection)
 {
     // Arrange: 用 systemBus 作为构造连接（栈上第二实例，不产生 DBus 调用）
     OcrInterface sysBound(kTestService, kTestPath, QDBusConnection::systemBus());
 
     // Act
     const QString ctorConnection = sysBound.connection().name();
-    const QString memberConnection = sysBound.dbus.name();
 
-    // Assert  // 现状：dbus 成员恒 sessionBus，与构造参数无关且未被使用（疑似缺陷 1，行为锁定）
+    // Assert  // 非 session 连接完整转发基类（恒 sessionBus 的 dbus 成员已随源码删除）
     EXPECT_EQ(ctorConnection, QDBusConnection::systemBus().name());
-    EXPECT_EQ(memberConnection, QDBusConnection::sessionBus().name());
+    EXPECT_NE(ctorConnection, QDBusConnection::sessionBus().name());
 }
 
 TEST_F(OcrInterfaceTest, Destructor_ExistingInstance_DeletesWithoutSideEffect)
@@ -253,7 +253,7 @@ TEST_F(OcrInterfaceTest, OpenImage_NullImage_SendsEmptyPayload)
     // Act
     QDBusPendingReply<> reply = obj->openImage(nullImage);
 
-    // Assert  // openImage B2: save 失败 → 空 payload 仍照常发起调用（疑似缺陷 2，行为锁定）
+    // Assert  // openImage B2: save 失败 → qWarning 记录后空 payload 仍照常发起调用
     EXPECT_EQ(doCallCount, 1);
     EXPECT_EQ(lastMethod, QStringLiteral("openImage"));
     ASSERT_EQ(lastArgs.size(), 1);
@@ -293,7 +293,7 @@ TEST_F(OcrInterfaceTest, OpenImageAndName_NullImage_SendsEmptyPayloadAndName)
     // Act
     QDBusPendingReply<> reply = obj->openImageAndName(nullImage, imageName);
 
-    // Assert  // openImageAndName B2: 空 payload + 名称仍双参发送（疑似缺陷 2，行为锁定）
+    // Assert  // openImageAndName B2: qWarning 记录 imageName 后空 payload + 名称仍双参发送
     EXPECT_EQ(doCallCount, 1);
     ASSERT_EQ(lastArgs.size(), 2);
     EXPECT_TRUE(lastArgs.at(0).toByteArray().isEmpty());

--- a/tests/src/test_printhelper.cpp
+++ b/tests/src/test_printhelper.cpp
@@ -5,8 +5,9 @@
 // | method | level | factors | min | actual |
 // |--------|-------|---------|-----|--------|
 // | PrintHelper | low | - | 1 | 1 |
+// | getInstance | low | - | 1 | 1 |
 // | getIntance | mid | - | 2 | 2 |
-// | showPrintDialog | mid | - | 2 | 4 |
+// | showPrintDialog | mid | - | 2 | 5 |
 // | ~PrintHelper | low | - | 1 | 1 |
 // | RequestedSlot | low | - | 1 | 1 |
 // | paintRequestSync | low | - | 1 | 7 |
@@ -14,7 +15,7 @@
 // ─── actual 均不低于 min ───
 //
 // 最小清单完成情况（test-code-gen §最小清单）：
-// 1. 每个公开方法 ≥ 1 用例: [x]（7/7 方法，含构造/析构）
+// 1. 每个公开方法 ≥ 1 用例: [x]（8/8 方法，含构造/析构）
 // 2. 每个输入维度按等价类划分 ≥ 1 用例/类: [x]（路径：存在/缺失/空列表/多页；图像：宽扁/方/高瘦/空图）
 // 3. 每个等价类的边界值显式覆盖: [x]（0 张/1 张/2 张边界；单页与多页分界 imageCount 1/>1）
 // 4. 同质 ≥ 3 组用 TEST_P: [x]（paintRequestSync 宽高缩放 3 组）
@@ -73,18 +74,19 @@ DWIDGET_USE_NAMESPACE
 // 分支清单与用例映射（来源：MCP get_code_snippet）
 //
 // 分支清单（来源：PrintHelper::showPrintDialog，printhelper.cpp:100-162）
-// B1: imgReadreder.imageCount() > 1 → 多页分支：jumpToImage + read 逐页装入 m_imgs
+// B1: imgReadreder.imageCount() > 1 → 多页分支：jumpToImage + read 逐页装入 m_imgs，路径计入 tempExsitPaths
 // B2: imageCount() <= 1             → 单图分支：loadStaticImageFromFile 加载
-// B3: !img.isNull()                 → m_imgs 追加该图
-// B4: img.isNull()                  → 仅告警，不追加
+// B3: !img.isNull()                 → m_imgs 追加该图，路径计入 tempExsitPaths
+// B4: img.isNull()                  → 仅告警，不追加图与路径
 // B5: runtimeDtkVersion >= 5.4.10 且 tempExsitPaths.count() > 0 → setDocName(首路径 completeBaseName + ".pdf")
-// B6: tempExsitPaths.count() == 0（空 paths）→ 不调 setDocName
+// B6: tempExsitPaths.count() == 0（空 paths / 全部加载失败）→ 不调 setDocName
 // B7: exec()（本构建未定义 USE_TEST）→ 定时器在 exec 事件循环内 reject 对话框，断言 dialogSeen
 // 用例映射：
 // - ShowPrintDialog_SingleImageFile_SetsDocNameAndClearsCache → B2+B3+B5+B7
 // - ShowPrintDialog_MultiPageImage_ReadsEveryPage             → B1+B5+B7
 // - ShowPrintDialog_EmptyPaths_DoesNotSetDocName              → B6+B7
-// - ShowPrintDialog_MissingFile_LoadFailsImageSkipped         → B2+B4+B7
+// - ShowPrintDialog_MissingFile_LoadFailsImageSkipped         → B2+B4+B6+B7
+// - ShowPrintDialog_LoadFailedFirst_OnlyLoadedPathsCounted    → B2+B3+B4+B5+B7（失败在前，文档名取首个成功路径）
 //
 // 分支清单（来源：RequestedSlot::paintRequestSync，printhelper.cpp:175-215）
 // B1: !img.isNull()                       → 计算缩放比例并 drawImage
@@ -174,7 +176,7 @@ QRectF expectedPaintRect(const QRectF &wRect, int imgW, int imgH)
 
 void expectRectNear(const QRectF &actual, const QRectF &expected)
 {
-    // 坐标含源码 abs() 运算，容忍整型截断差异；宽高由同式推导，精确比较
+    // 坐标含源码 qAbs() 运算，容忍整型截断差异；宽高由同式推导，精确比较
     EXPECT_NEAR(actual.x(), expected.x(), 1.5);
     EXPECT_NEAR(actual.y(), expected.y(), 1.5);
     EXPECT_DOUBLE_EQ(actual.width(), expected.width());
@@ -281,7 +283,24 @@ TEST_F(PrintHelperTest, PrintHelper_Destructor_DefersRequestedSlotDeletion) {
     EXPECT_TRUE(guard.isNull());
 }
 
-// ───────────────────────── PrintHelper::getIntance ─────────────────────────
+// ───────────────────────── PrintHelper::getInstance/getIntance ─────────────────────────
+
+TEST_F(PrintHelperTest, GetInstance_SameSingletonAsLegacyGetIntance) {
+    // Arrange：清空静态单例，保证用例自足
+    if (PrintHelper::m_Printer != nullptr) {
+        delete PrintHelper::m_Printer;
+        PrintHelper::m_Printer = nullptr;
+    }
+
+    // Act：先经旧拼写入口创建，再经新拼写入口获取
+    PrintHelper *legacy = PrintHelper::getIntance();
+    PrintHelper *modern = PrintHelper::getInstance();
+
+    // Assert：两个入口指向同一单例
+    EXPECT_NE(modern, nullptr);
+    EXPECT_EQ(modern, legacy);
+    EXPECT_EQ(PrintHelper::m_Printer, modern);
+}
 
 TEST_F(PrintHelperTest, GetIntance_NoExistingInstance_CreatesSingletonAndReusesIt) {
     // Arrange：清空静态单例，保证用例自足
@@ -418,12 +437,51 @@ TEST_F(PrintHelperTest, ShowPrintDialog_MissingFile_LoadFailsImageSkipped) {
     helper->showPrintDialog(QStringList{ missingPath }, nullptr);
     flushDialogEvents(cap);
 
-    // Assert：加载失败 → 不追加图像；结束后缓存清空
+    // Assert：加载失败 → 不追加图像，失败路径不计入 tempExsitPaths → 不调 setDocName（B6）
     EXPECT_EQ(loadCalls, 1);
     EXPECT_EQ(loadedPath, missingPath);
+    EXPECT_EQ(cap->docNameCount, 0);
     EXPECT_TRUE(cap->dialogSeen);
     EXPECT_TRUE(helper->m_re->m_imgs.isEmpty());
     EXPECT_TRUE(helper->m_re->m_paths.isEmpty());
+}
+
+TEST_F(PrintHelperTest, ShowPrintDialog_LoadFailedFirst_OnlyLoadedPathsCounted) {
+    // Arrange：[缺失, 可加载] 顺序驱动——修复前整表追加使失败路径占 tempExsitPaths[0]，
+    // 修复后仅成功路径计入，文档名取首个成功路径
+    const QString badPath = tmpDir.filePath("bad.png");
+    ASSERT_FALSE(QFileInfo::exists(badPath));
+    QImage img(16, 16, QImage::Format_RGB32);
+    img.fill(Qt::blue);
+    const QString goodPath = tmpDir.filePath("good.png");
+    ASSERT_TRUE(img.save(goodPath, "PNG"));
+
+    int loadCalls = 0;
+    stub.set_lamda(
+        static_cast<bool (*)(const QString &, QImage &, QString &, const QString &, int)>(
+            &LibUnionImage_NameSpace::loadStaticImageFromFile),
+        [&loadCalls, &badPath](const QString &path, QImage &out, QString &, const QString &, int) -> bool {
+            ++loadCalls;
+            if (path == badPath)
+                return false;
+            out = QImage(16, 16, QImage::Format_RGB32);
+            return true;
+        });
+
+    auto cap = std::make_shared<DialogCaptures>();
+    stubPreviewDialog(cap);
+    armDialogReject(cap);
+    helper = new PrintHelper();
+
+    // Act
+    helper->showPrintDialog(QStringList{ badPath, goodPath }, nullptr);
+    flushDialogEvents(cap);
+
+    // Assert：两个路径都尝试加载，但文档名只取成功路径（good.pdf 而非 bad.pdf）
+    EXPECT_EQ(loadCalls, 2);
+    EXPECT_EQ(cap->docNameCount, 1);
+    EXPECT_EQ(cap->docName, QStringLiteral("good.pdf"));
+    EXPECT_TRUE(helper->m_re->m_imgs.isEmpty());
 }
 
 // ═════════════════════════════ RequestedSlot ═════════════════════════════
@@ -477,19 +535,18 @@ protected:
     }
 };
 
-TEST_F(RequestedSlotTest, RequestedSlot_Constructor_IgnoresParentAndStartsEmpty) {
+TEST_F(RequestedSlotTest, RequestedSlot_Constructor_SetsParentAndStartsEmpty) {
     // Arrange
     QObject owner;
 
     // Act
     RequestedSlot *withParent = new RequestedSlot(&owner);
 
-    // Assert：源码 Q_UNUSED(parent)（printhelper.cpp:165），父子关系未建立；
-    // 初始路径与图像缓存为空
-    EXPECT_EQ(withParent->parent(), nullptr);
+    // Assert：parent 经初始化列表传入基类 QObject（printhelper.cpp），父子关系建立；
+    // 初始路径与图像缓存为空；owner 析构时自动回收子对象，无需手动释放
+    EXPECT_EQ(withParent->parent(), &owner);
     EXPECT_TRUE(withParent->m_paths.isEmpty());
     EXPECT_TRUE(withParent->m_imgs.isEmpty());
-    delete withParent;  // 无父对象，手动释放防泄漏
 }
 
 TEST_F(RequestedSlotTest, RequestedSlot_Destructor_DeletesChildObjects) {

--- a/tests/src/test_rotateimagehelper.cpp
+++ b/tests/src/test_rotateimagehelper.cpp
@@ -48,7 +48,8 @@
 // - 状态机用例全部使用栈上独立 RotateImageHelper 实例（私有构造经
 //   -fno-access-control 可达），不污染单例；TearDown 统一 waitForDone + 单例复位。
 // - 旋转状态转移断言 = 前后状态对比（rotationCache / processQueue 镜像直读）+
-//   QSignalSpy（rotateImageImpl 三信号发射于 instance() 单例上，spy 挂单例）。
+//   QSignalSpy（rotateImageImpl 三信号发射于 instance() 单例上，spy 挂单例；
+//   rotateImageFile 累计归零短路（B8）的三信号发射于操作实例上，spy 挂该实例）。
 // - enqueueRotateTask 的 QtConcurrent 工作线程真实启动，rotateImageImpl 以函数地址
 //   stub 隔离文件写入；ImplRecorder 内置 QMutex 保证工作线程并发记录安全。
 // - QThread::msleep(10)（rotateImageImpl 内同步短睡眠）保持真实，仅 10ms。
@@ -64,10 +65,12 @@
 // B5: if (proc.first == path) → 原地更新该任务角度并 return
 // B6: for 未命中 → 追加队列（不启动新线程）
 // B7: else（watcher 未运行）→ enqueueRotateTask（入队并启动 QtConcurrent 线程）
+// B8: totalAngle %= 360 后为 0 → 不更新/不入队任务，在操作实例上按成功补发
+//     record/clear/finished(path,true) 三信号（与 rotateImageImpl 正常路径序列一致）后 return
 // 映射： RotateImageFile_ZeroOrFullTurnAngle_ReturnsBeforePathCheck → B1
 //        RotateImageFile_UnsupportedPathType_SkipsRotationWithoutCaching（TEST_P）→ B2
 //        RotateImageFile_LocalPath_EnqueuesAsyncRotationTask → B3+B7
-//        RotateImageFile_SamePathTwiceWhileRunning_UpdatesQueuedAngle → B3+B4+B5
+//        RotateImageFile_AccumulatedFullTurnWhileRunning_CompletesWithoutEnqueue → B3+B6+B8（累计归零短路）
 //        RotateImageFile_DifferentPathsWhileRunning_AppendsToQueue → B3+B4+B6
 //        RotateImageFile_AngleBeyondFullTurn_ReducesModulo360 → B3+B6（>360° 边界）
 //
@@ -415,7 +418,7 @@ TEST_F(RotateImageHelperTest, RotateImageFile_LocalPath_EnqueuesAsyncRotationTas
     EXPECT_FALSE(scoped.data->watcher.isRunning());
 }
 
-TEST_F(RotateImageHelperTest, RotateImageFile_SamePathTwiceWhileRunning_UpdatesQueuedAngle)
+TEST_F(RotateImageHelperTest, RotateImageFile_AccumulatedFullTurnWhileRunning_CompletesWithoutEnqueue)
 {
     // Arrange
     RotateImageHelper scoped;
@@ -428,16 +431,25 @@ TEST_F(RotateImageHelperTest, RotateImageFile_SamePathTwiceWhileRunning_UpdatesQ
         static_cast<bool (QFutureWatcher<void>::*)() const>(&QFutureWatcher<void>::isRunning),
         []() -> bool { return true; });
     const QString path = QStringLiteral("album/pic-a.png");
+    QSignalSpy spyRecord(&scoped, &RotateImageHelper::recordRotateImage);
+    QSignalSpy spyClear(&scoped, &RotateImageHelper::clearRotateStatus);
+    QSignalSpy spyFinished(&scoped, &RotateImageHelper::rotateImageFinished);
 
-    // Act：90° + 270° 累计取模归零；同一任务在队列中被原地更新
+    // Act：90° 入队后再追加 270°，累计取模归零 → 短路按成功完成，不再入队 0° 无效旋转
     scoped.rotateImageFile(path, 90);
     scoped.rotateImageFile(path, 270);
 
-    // Assert：B3+B4 —— 累计角度 0，队列仍单任务且角度已更新，未重复入队/启动线程
+    // Assert：B3+B6+B8 —— 累计角度 0；首个任务保持 90° 未被改写为 0、未重复入队/启动线程；
+    // 短路路径在操作实例上按成功补发与正常路径相同的三信号序列
     EXPECT_EQ(scoped.data->rotationCache.value(path), 0);
     ASSERT_EQ(scoped.data->processQueue.size(), 1);
-    EXPECT_EQ(scoped.data->processQueue.head().second, 0);
+    EXPECT_EQ(scoped.data->processQueue.head().second, 90);
     EXPECT_EQ(scoped.data->processQueue.head().first, path);
+    EXPECT_EQ(spyRecord.count(), 1);
+    EXPECT_EQ(spyClear.count(), 1);
+    ASSERT_EQ(spyFinished.count(), 1);
+    EXPECT_EQ(spyFinished.at(0).at(0).toString(), path);
+    EXPECT_EQ(spyFinished.at(0).at(1).toBool(), true);
 }
 
 TEST_F(RotateImageHelperTest, RotateImageFile_DifferentPathsWhileRunning_AppendsToQueue)


### PR DESCRIPTION
Fix out-of-range boxes[0] and busy-wait loop in live text analyzer; drop unused ctor param; validate toUInt in requestImage. Remove dead dbus member in OcrInterface; log save failures before sending payload. Fix whole-list append and failed paths in showPrintDialog; add getInstance keeping getIntance alias; forward parent in RequestedSlot and CommandParser; qAbs for qreal; keep remote URL semantics in openImageFile. Fix mount-point prefix boundary in isExternalDevice; skip no-op full-turn rotation; add context object to palette connect.

修复 ocr/printdialog/dbus/utils 共 16 项扫描缺陷。

Log: 修复 OCR/打印/DBus/辅助工具 16 项缺陷
Influence: LiveTextAnalyzer 构造签名变更（移除未用形参），行为变化已同步单测断言；单测 1134/1134 通过

## Summary by Sourcery

Resolve scan defects across OCR, printing, DBus integration, and utility components while preserving compatibility and updating regression coverage.

Bug Fixes:
- Prevent out-of-range OCR character-box access and reject malformed image-provider identifiers.
- Reduce CPU usage while waiting for OCR operations and improve OCR image-save failure diagnostics.
- Correct print-dialog path tracking, mount-point boundary checks, remote URL handling, and full-turn rotation behavior.
- Ensure QObject parent ownership is preserved and palette signal connections are safely scoped to object lifetimes.

Enhancements:
- Add the correctly spelled PrintHelper singleton accessor while retaining the legacy alias.
- Remove an unused DBus connection member and use type-safe absolute-value handling for print layout calculations.

Tests:
- Update and extend unit tests to cover the corrected OCR, DBus, print-dialog, palette-lifecycle, mount-path, rotation, and URL-handling behavior.