### PR TITLE
fix(viewer): migrate scale notice to dtk message

### DIFF
--- a/src/qml/FullImageView.qml
+++ b/src/qml/FullImageView.qml
@@ -305,7 +305,7 @@ Item {
             if (IV.GStatus.editMode) {
                 IV.ImageEditor.beginEdit(IV.GControl.currentSource, IV.GControl.currentFrameIndex);
                 editToolbar.currentTool = "";
-                floatLabel.visible = false;
+                floatLabel.close();
                 editCanvas.clear();
                 editCanvas.initializeHistory();
             } else {
@@ -750,26 +750,10 @@ Item {
     }
 
     //浮动提示框
+    //uos-design: 瞬态提示由 D.FloatingMessage/MessageManager 承载（见 Utils/FloatingNotice.qml），
+    //本组件退化为非可视接口；定位由 main.qml 中窗口级 D.MessageManager.layout 统一控制
+    //（缩略图栏高度 + floatMargin，与旧锚定位置等价）。
     FloatingNotice {
         id: floatLabel
-
-        anchors.bottom: parent.bottom
-        anchors.bottomMargin: thumbnailViewBackGround.height + IV.GStatus.floatMargin
-        anchors.left: parent.left
-        anchors.leftMargin: parent.width / 2 - 50
-        opacity: 0.7
-        visible: false
-
-        Timer {
-            interval: 1500
-            repeat: false
-            running: parent.visible
-
-            onTriggered: {
-                parent.visible = false;
-            }
-        }
-        Accessible.name: "FloatLabel"
-        Accessible.role: Accessible.Pane
     }
 }

--- a/src/qml/ImageViewer.qml
+++ b/src/qml/ImageViewer.qml
@@ -115,7 +115,7 @@ Item {
 
     function showScaleFloatLabel() {
         if (IV.GStatus.editMode) {
-            floatLabel.visible = false;
+            floatLabel.close();
             return;
         }
         // 不存在的图片不弹出缩放提示框
@@ -126,13 +126,12 @@ Item {
         // 图片实际缩放比值 绘制像素宽度 / 图片原始像素宽度
         var readableScale = targetImage.paintedWidth * targetImage.scale / targetImageInfo.width * 100;
         if (readableScale.toFixed(0) > 2000 && readableScale.toFixed(0) <= 3000) {
-            floatLabel.displayStr = "2000%";
+            floatLabel.show("2000%");
         } else if (readableScale.toFixed(0) < 2 && readableScale.toFixed(0) >= 0) {
-            floatLabel.displayStr = "2%";
+            floatLabel.show("2%");
         } else if (readableScale.toFixed(0) >= 2 && readableScale.toFixed(0) <= 2000) {
-            floatLabel.displayStr = readableScale.toFixed(0) + "%";
+            floatLabel.show(readableScale.toFixed(0) + "%");
         }
-        floatLabel.visible = true;
     }
 
     Component.onCompleted: {

--- a/src/qml/ImageViewer.qml
+++ b/src/qml/ImageViewer.qml
@@ -125,12 +125,13 @@ Item {
 
         // 图片实际缩放比值 绘制像素宽度 / 图片原始像素宽度
         var readableScale = targetImage.paintedWidth * targetImage.scale / targetImageInfo.width * 100;
-        if (readableScale.toFixed(0) > 2000 && readableScale.toFixed(0) <= 3000) {
+        var scaleInt = parseInt(readableScale.toFixed(0)); // 缓存取整结果，避免重复 toFixed 调用
+        if (scaleInt > 2000 && scaleInt <= 3000) {
             floatLabel.show("2000%");
-        } else if (readableScale.toFixed(0) < 2 && readableScale.toFixed(0) >= 0) {
+        } else if (scaleInt < 2 && scaleInt >= 0) {
             floatLabel.show("2%");
-        } else if (readableScale.toFixed(0) >= 2 && readableScale.toFixed(0) <= 2000) {
-            floatLabel.show(readableScale.toFixed(0) + "%");
+        } else if (scaleInt >= 2 && scaleInt <= 2000) {
+            floatLabel.show(scaleInt + "%");
         }
     }
 

--- a/src/qml/Utils/FloatingNotice.qml
+++ b/src/qml/Utils/FloatingNotice.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/qml/Utils/FloatingNotice.qml
+++ b/src/qml/Utils/FloatingNotice.qml
@@ -3,26 +3,26 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import QtQuick
-import QtQuick.Controls
-import QtQml
+import org.deepin.dtk 1.0
 
 //浮动提示框定义
+//uos-design: 瞬态应用内提示必须交由 D.FloatingMessage / MessageManager 承载（勿自绘外壳）。
+//实际显示、主题配色、出入场动画与自动关闭均由 D.FloatingMessage 标准面板完成。
 Item {
     id: root
 
-    property string displayStr: ""
+    // 提示存续时长（毫秒），与旧实现 Timer.interval=1500 保持一致
+    readonly property int duration: 1500
+    // 消息标识：相同 msgId 的消息会被 MessageManager 去重并就地更新内容
+    readonly property string msgId: "FloatLabel"
 
-    visible: false
+    // content: 要展示的文本，如 "200%"
+    function show(content) {
+        DTK.sendMessage(root, content, "", duration, msgId);
+    }
 
-    Rectangle {
-        color: "#EEEEEE"
-        height: 45
-        radius: 20
-        width: 90
-
-        Text {
-            anchors.centerIn: parent
-            text: displayStr
-        }
+    // 立即关闭当前消息（无出场动画，对应旧实现 visible=false 的即时消失）
+    function close() {
+        DTK.closeMessage(root, msgId);
     }
 }

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -33,6 +33,17 @@ ApplicationWindow {
     palette: DTK.palette
     // 调整暗色主题下的窗口背景色
     color: DS.Style.control.selectColor(palette.window, palette.window, Qt.rgba(24 / 255, 24 / 255, 24 / 255, 1))
+
+    //uos-design: 应用内瞬态提示统一由 D.FloatingMessage / MessageManager 承载。
+    //此布局决定浮动消息出现的位置：工具栏悬浮于窗口底上方 10px (showBottomY=80, 高 70)，
+    //其顶边距窗口底 80px；提示框再上方留 10px 间距。
+    MessageManager.layout: Column {
+        anchors {
+            horizontalCenter: parent.horizontalCenter
+            bottom: parent.bottom
+            bottomMargin: 80 + 10
+        }
+    }
     // uos-design: allow-overlay-titlebar 应用采用沉浸式浮动标题栏 (ViewTopTitle) 而非窗口级 D.TitleBar header，
     // 标题栏随图片缩放/全屏滑入滑出，窗口按钮 (菜单/最小化/最大化/关闭) 由浮动 TitleBar 内的
     // D.WindowButtonGroup 提供，符合 DTK 窗口按钮 hover/press 标准实现。

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -35,13 +35,13 @@ ApplicationWindow {
     color: DS.Style.control.selectColor(palette.window, palette.window, Qt.rgba(24 / 255, 24 / 255, 24 / 255, 1))
 
     //uos-design: 应用内瞬态提示统一由 D.FloatingMessage / MessageManager 承载。
-    //此布局决定浮动消息出现的位置：工具栏悬浮于窗口底上方 10px (showBottomY=80, 高 70)，
-    //其顶边距窗口底 80px；提示框再上方留 10px 间距。
+    //此布局决定浮动消息出现的位置：工具栏顶边距窗口底为 GStatus.showBottomY（工具栏高 70 + 底边距 10），
+    //提示框与工具栏保持 10px 间距，与工具栏共用同一设计常量。
     MessageManager.layout: Column {
         anchors {
             horizontalCenter: parent.horizontalCenter
             bottom: parent.bottom
-            bottomMargin: 80 + 10
+            bottomMargin: IV.GStatus.showBottomY + 10
         }
     }
     // uos-design: allow-overlay-titlebar 应用采用沉浸式浮动标题栏 (ViewTopTitle) 而非窗口级 D.TitleBar header，


### PR DESCRIPTION
## 变更说明 / Changes

fix(viewer): migrate scale notice to dtk message

1. Replace the self-drawn FloatingNotice shell (Rectangle + Text) with D.FloatingMessage rendered through DTK.sendMessage/closeMessage
2. Add MessageManager.layout so the notice sits 10px above the floating bottom toolbar (toolbar top edge is 80px above window bottom)
3. Keep the 1500ms duration and dedupe by msgId; call sites switch from visible binding to explicit show/close method calls

Log: scale zoom notice now renders through the standard DTK FloatingMessage panel
Influence: notice style, theme and position follow DTK; no API change

fix(viewer): 缩放提示框迁移至 DTK 消息组件

1. 用 DTK sendMessage/closeMessage 承载的 D.FloatingMessage 替换自绘 FloatingNotice 外壳(矩形 + 文本)
2. 新增 MessageManager.layout,使提示框位于悬浮底部工具栏上方 10px (工具栏顶边距窗口底部 80px)
3. 保留 1500ms 时长与 msgId 去重;调用点由 visible 绑定改为显式 show/close 方法调用

Log: 缩放提示框改由 DTK 标准 FloatingMessage 面板渲染
PMS: [BUG-376419](https://pms.uniontech.com/bug-view-376419.html)
Influence: 提示框样式、主题与位置交由 DTK 管理,无接口变更

## 验证 / Verification

- Build passes (cmake --build, EXIT=0)
- Runtime verified on real xcb session: notice position measured 10px above the floating toolbar, horizontally centered; show/close/dedupe behavior confirmed; no runtime errors

## Summary by Sourcery

Use DTK floating messages for viewer scale notifications and align them consistently above the bottom toolbar.

Bug Fixes:
- Migrate the viewer's scale notifications to the standard DTK floating message system while preserving their duration, deduplication, and explicit close behavior.

Enhancements:
- Position floating scale notifications consistently above the bottom toolbar through centralized window-level message layout management.